### PR TITLE
[feature] add reusable tooltip component

### DIFF
--- a/website/glancy-website/src/components/ui/Tooltip/Tooltip.module.css
+++ b/website/glancy-website/src/components/ui/Tooltip/Tooltip.module.css
@@ -1,0 +1,33 @@
+.tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: help;
+}
+
+.icon {
+  width: 16px;
+  height: 16px;
+}
+
+.content {
+  visibility: hidden;
+  background: rgb(0 0 0 / 75%);
+  color: #fff;
+  text-align: center;
+  padding: 4px 8px;
+  border-radius: 4px;
+  position: absolute;
+  z-index: 10;
+  bottom: 150%;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  white-space: nowrap;
+  transition: opacity 0.3s;
+}
+
+.tooltip:hover .content {
+  visibility: visible;
+  opacity: 1;
+}

--- a/website/glancy-website/src/components/ui/Tooltip/index.jsx
+++ b/website/glancy-website/src/components/ui/Tooltip/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import ThemeIcon from '@/components/ui/Icon'
+import styles from './Tooltip.module.css'
+
+function Tooltip({ icon, text, children }) {
+  return (
+    <span className={styles.tooltip}>
+      {icon ? <ThemeIcon name={icon} className={styles.icon} width={16} height={16} /> : children}
+      <span className={styles.content}>{text}</span>
+    </span>
+  )
+}
+
+export default Tooltip

--- a/website/glancy-website/src/pages/profile/Profile.module.css
+++ b/website/glancy-website/src/pages/profile/Profile.module.css
@@ -125,30 +125,3 @@
   text-align: left;
 }
 
-.tooltip {
-  position: relative;
-  display: inline-block;
-  cursor: help;
-}
-
-.tooltip .tooltip-text {
-  visibility: hidden;
-  background: rgb(0 0 0 / 75%);
-  color: #fff;
-  text-align: center;
-  padding: 4px 8px;
-  border-radius: 4px;
-  position: absolute;
-  z-index: 10;
-  bottom: 150%;
-  left: 50%;
-  transform: translateX(-50%);
-  opacity: 0;
-  white-space: nowrap;
-  transition: opacity 0.3s;
-}
-
-.tooltip:hover .tooltip-text {
-  visibility: visible;
-  opacity: 1;
-}

--- a/website/glancy-website/src/pages/profile/index.jsx
+++ b/website/glancy-website/src/pages/profile/index.jsx
@@ -11,6 +11,7 @@ import { useApi } from '@/hooks'
 import { useUser } from '@/context'
 import { cacheBust } from '@/utils/url.js'
 import ThemeIcon from '@/components/ui/Icon'
+import Tooltip from '@/components/ui/Tooltip'
 
 function Profile({ onCancel }) {
   const { t } = useLanguage()
@@ -133,17 +134,13 @@ function Profile({ onCancel }) {
             <ThemeIcon name="cake" className={styles.icon} width={20} height={20} />
             <span>{t.ageLabel}</span>
             <AgeStepper value={age} onChange={setAge} />
-            <span className={styles.tooltip}>
-              ?<span className={styles['tooltip-text']}>{t.ageHelp}</span>
-            </span>
+            <Tooltip text={t.ageHelp}>?</Tooltip>
           </div>
           <div className={styles.item}>
             <ThemeIcon name="user" className={styles.icon} width={20} height={20} />
             <span>{t.genderLabel}</span>
             <GenderSelect value={gender} onChange={setGender} />
-            <span className={styles.tooltip}>
-              ?<span className={styles['tooltip-text']}>{t.genderHelp}</span>
-            </span>
+            <Tooltip text={t.genderHelp}>?</Tooltip>
           </div>
           <div className={styles.item}>
             <ThemeIcon name="star-outline" className={styles.icon} width={20} height={20} />
@@ -153,9 +150,7 @@ function Profile({ onCancel }) {
               onChange={(e) => setInterests(e.target.value)}
               placeholder={t.interestsPlaceholder}
             />
-            <span className={styles.tooltip}>
-              ?<span className={styles['tooltip-text']}>{t.interestsHelp}</span>
-            </span>
+            <Tooltip text={t.interestsHelp}>?</Tooltip>
           </div>
           <div className={styles.item}>
             <ThemeIcon name="target" className={styles.icon} width={20} height={20} />
@@ -165,9 +160,7 @@ function Profile({ onCancel }) {
               onChange={(e) => setGoal(e.target.value)}
               placeholder={t.goalPlaceholder}
             />
-            <span className={styles.tooltip}>
-              ?<span className={styles['tooltip-text']}>{t.goalHelp}</span>
-            </span>
+            <Tooltip text={t.goalHelp}>?</Tooltip>
           </div>
         </div>
         <div className={styles.actions}>


### PR DESCRIPTION
### Summary
- add reusable Tooltip UI component with CSS module
- refactor profile page to use Tooltip and remove inline styles

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894f15963648332b8c93e171c656f1d