### PR TITLE
[Fix] Use ClassPathResource for prompt loading

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/prompt/PromptManagerImpl.java
+++ b/backend/src/main/java/com/glancy/backend/llm/prompt/PromptManagerImpl.java
@@ -1,9 +1,10 @@
 package com.glancy.backend.llm.prompt;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
 
 @Component
 public class PromptManagerImpl implements PromptManager {
@@ -11,7 +12,8 @@ public class PromptManagerImpl implements PromptManager {
     @Override
     public String loadPrompt(String path) {
         try {
-            return Files.readString(Path.of("src/main/resources/" + path));
+            ClassPathResource resource = new ClassPathResource(path);
+            return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException("Prompt load failed: " + path, e);
         }

--- a/backend/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -11,8 +11,10 @@ import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import io.github.cdimascio.dotenv.Dotenv;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -147,9 +149,8 @@ class DeepSeekClientTest {
         }
 
         // 读取 PROMPT_CN.md 文件内容
-        String prompt = java.nio.file.Files.readString(
-            java.nio.file.Paths.get("src/main/resources/prompts/english_to_chinese.txt")
-        );
+        String prompt = new ClassPathResource("prompts/english_to_chinese.txt")
+            .getContentAsString(StandardCharsets.UTF_8);
 
         String body = String.format(
             """

--- a/backend/src/test/java/com/glancy/backend/llm/prompt/PromptManagerImplJarTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/prompt/PromptManagerImplJarTest.java
@@ -1,0 +1,43 @@
+package com.glancy.backend.llm.prompt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+
+class PromptManagerImplJarTest {
+
+    @Test
+    void loadPromptFromJar() throws Exception {
+        ClassPathResource original = new ClassPathResource("prompts/english_to_chinese.txt");
+        byte[] data = StreamUtils.copyToByteArray(original.getInputStream());
+
+        Path jar = Files.createTempFile("prompt", ".jar");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
+            JarEntry entry = new JarEntry("prompts/english_to_chinese.txt");
+            jos.putNextEntry(entry);
+            jos.write(data);
+            jos.closeEntry();
+        }
+
+        URLClassLoader loader = new URLClassLoader(new URL[] { jar.toUri().toURL() }, null);
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(loader);
+        try {
+            PromptManagerImpl manager = new PromptManagerImpl();
+            String prompt = manager.loadPrompt("prompts/english_to_chinese.txt");
+            assertEquals(new String(data, StandardCharsets.UTF_8), prompt);
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+            loader.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace file-based prompt loading with ClassPathResource and explicit UTF-8 decoding (`backend/src/main/java/com/glancy/backend/llm/prompt/PromptManagerImpl.java`)
- update DeepSeekClientTest to read prompts via classpath resource (`backend/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java`)
- add jar-based test ensuring prompts load correctly from packaged artifacts (`backend/src/test/java/com/glancy/backend/llm/prompt/PromptManagerImplJarTest.java`)

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894f4bd99688332bb9f9a071b7dfe5a