### PR TITLE
fix: ensure website workflow uses correct working dir

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: website/glancy-website
     env:
       WEBSITE_DIR: website/glancy-website
     steps:
@@ -29,16 +26,19 @@ jobs:
       # 3. 安装前端依赖
       - name: Install dependencies
         run: npm ci
+        working-directory: ${{ env.WEBSITE_DIR }}
 
       # 4. 代码规范校验
       - name: Lint code
         run: |
           npm run lint
           npm run lint:css
+        working-directory: ${{ env.WEBSITE_DIR }}
 
       # 5. 构建项目
       - name: Build project
         run: npm run build
+        working-directory: ${{ env.WEBSITE_DIR }}
 
       # 6. 清空服务器上旧的 dist 目录
       - name: Clean server directory


### PR DESCRIPTION
## Summary
- remove job-level default working dir from website deployment workflow
- explicitly run website build steps in `website/glancy-website`

## Testing
- `npm test` *(fails: The requested module '@/context' does not provide an export named 'useLocale')*
- `yamllint .github/workflows/deploy-website.yml`

------
https://chatgpt.com/codex/tasks/task_e_68958b17f3c083328c5d80f34f33404c