### PR TITLE
[Fix] Replace MockitoBean with MockBean in tests

### DIFF
--- a/backend/src/test/java/com/glancy/backend/config/TokenAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/glancy/backend/config/TokenAuthenticationFilterTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(com.glancy.backend.controller.SearchRecordController.class)
@@ -19,19 +19,18 @@ import org.springframework.test.web.servlet.MockMvc;
     {
         SecurityConfig.class,
         WebConfig.class,
-        TokenAuthenticationInterceptor.class,
         com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
     }
 )
-class TokenAuthenticationInterceptorTest {
+class TokenAuthenticationFilterTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private SearchRecordService searchRecordService;
 
-    @MockitoBean
+    @MockBean
     private UserService userService;
 
     /**

--- a/backend/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ContactController.class)
@@ -24,10 +24,10 @@ class ContactControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private ContactService contactService;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FaqController.class)
@@ -25,10 +25,10 @@ class FaqControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private FaqService faqService;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(LlmController.class)
@@ -27,10 +27,10 @@ class LlmControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private LlmModelService modelService;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     @Test

--- a/backend/src/test/java/com/glancy/backend/controller/LocaleControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/LocaleControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(LocaleController.class)
@@ -18,7 +19,7 @@ class LocaleControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     /**

--- a/backend/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(NotificationController.class)
@@ -27,10 +27,10 @@ class NotificationControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private NotificationService notificationService;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/PingControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/PingControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @WebMvcTest(PingController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
@@ -17,7 +18,7 @@ class PingControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     /**

--- a/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SearchRecordController.class)
@@ -34,10 +34,10 @@ class SearchRecordControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private SearchRecordService searchRecordService;
 
-    @MockitoBean
+    @MockBean
     private UserService userService;
 
     /**

--- a/backend/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -34,7 +34,7 @@ class UserControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private UserService userService;
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserPreferenceController.class)
@@ -26,10 +26,10 @@ class UserPreferenceControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private UserPreferenceService userPreferenceService;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserProfileController.class)
@@ -25,10 +25,10 @@ class UserProfileControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private UserProfileService userProfileService;
 
-    @MockitoBean
+    @MockBean
     private com.glancy.backend.service.UserService userService;
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(WordController.class)
@@ -34,13 +34,13 @@ class WordControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private WordService wordService;
 
-    @MockitoBean
+    @MockBean
     private SearchRecordService searchRecordService;
 
-    @MockitoBean
+    @MockBean
     private UserService userService;
 
     /**

--- a/backend/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -40,7 +40,7 @@ class UserServiceTest {
     @Autowired
     private UserProfileRepository userProfileRepository;
 
-    @MockitoBean
+    @MockBean
     private AvatarStorage avatarStorage;
 
     @BeforeAll


### PR DESCRIPTION
## Summary
- replace deprecated `@MockitoBean` with Spring Boot's `@MockBean` across test classes
- rename `TokenAuthenticationInterceptorTest` to `TokenAuthenticationFilterTest` to match current security setup

## Testing
- `./mvnw test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689a28bc7e30833281ed42ca0ef973dc