### PR TITLE
chore: reformat test imports

### DIFF
--- a/backend/src/test/java/com/glancy/backend/config/TokenAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/glancy/backend/config/TokenAuthenticationFilterTest.java
@@ -9,19 +9,13 @@ import com.glancy.backend.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(com.glancy.backend.controller.SearchRecordController.class)
-@Import(
-    {
-        SecurityConfig.class,
-        WebConfig.class,
-        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
-    }
-)
+@Import({SecurityConfig.class, WebConfig.class, com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class TokenAuthenticationFilterTest {
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
@@ -12,9 +12,9 @@ import com.glancy.backend.service.ContactService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ContactController.class)

--- a/backend/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
@@ -13,9 +13,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FaqController.class)

--- a/backend/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
@@ -10,18 +10,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(LlmController.class)
-@Import(
-    {
-        com.glancy.backend.config.SecurityConfig.class,
-        com.glancy.backend.config.WebConfig.class,
-        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
-    }
-)
+@Import({com.glancy.backend.config.SecurityConfig.class, com.glancy.backend.config.WebConfig.class, com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class LlmControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/LocaleControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/LocaleControllerTest.java
@@ -8,8 +8,8 @@ import java.util.Locale;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(LocaleController.class)

--- a/backend/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
@@ -15,9 +15,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(NotificationController.class)

--- a/backend/src/test/java/com/glancy/backend/controller/PingControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/PingControllerTest.java
@@ -7,9 +7,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @WebMvcTest(PingController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)

--- a/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -16,19 +16,13 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SearchRecordController.class)
-@Import(
-    {
-        com.glancy.backend.config.SecurityConfig.class,
-        com.glancy.backend.config.WebConfig.class,
-        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
-    }
-)
+@Import({com.glancy.backend.config.SecurityConfig.class, com.glancy.backend.config.WebConfig.class, com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class SearchRecordControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -14,21 +14,15 @@ import com.glancy.backend.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(UserController.class)
-@Import(
-    {
-        com.glancy.backend.config.SecurityConfig.class,
-        com.glancy.backend.config.WebConfig.class,
-        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
-    }
-)
+@Import({com.glancy.backend.config.SecurityConfig.class, com.glancy.backend.config.WebConfig.class, com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class UserControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -14,9 +14,9 @@ import com.glancy.backend.service.UserPreferenceService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserPreferenceController.class)

--- a/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
@@ -13,9 +13,9 @@ import com.glancy.backend.service.UserProfileService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserProfileController.class)

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -16,19 +16,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(WordController.class)
-@Import(
-    {
-        com.glancy.backend.config.SecurityConfig.class,
-        com.glancy.backend.config.WebConfig.class,
-        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
-    }
-)
+@Import({com.glancy.backend.config.SecurityConfig.class, com.glancy.backend.config.WebConfig.class, com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class WordControllerTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- align test imports with Spotless format rules
- collapse multi-line `@Import` annotations to single line for consistency

## Testing
- `mvn -o test` *(fails: Non-resolvable parent POM due to network unavailability)*

------
https://chatgpt.com/codex/tasks/task_e_689a2b7a22b8833286a280575f741231