### PR TITLE
feat: add tts api contract

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/TtsController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/TtsController.java
@@ -1,0 +1,71 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.config.auth.AuthenticatedUser;
+import com.glancy.backend.dto.TtsRequest;
+import com.glancy.backend.dto.TtsResponse;
+import com.glancy.backend.dto.VoiceResponse;
+import com.glancy.backend.service.tts.TtsService;
+import jakarta.validation.Valid;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Endpoints for text to speech synthesis. The controller exposes
+ * separate routes for word and sentence pronunciations and a query
+ * interface for available voices.
+ */
+@RestController
+@RequestMapping("/api/tts")
+@Slf4j
+public class TtsController {
+
+    private final TtsService ttsService;
+
+    public TtsController(TtsService ttsService) {
+        this.ttsService = ttsService;
+    }
+
+    /**
+     * Synthesize pronunciation for a word.
+     */
+    @PostMapping("/word")
+    public ResponseEntity<TtsResponse> synthesizeWord(
+        @AuthenticatedUser Long userId,
+        @Valid @RequestBody TtsRequest request
+    ) {
+        Optional<TtsResponse> resp = ttsService.synthesizeWord(userId, request);
+        return resp.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    /**
+     * Synthesize pronunciation for a sentence or example phrase.
+     */
+    @PostMapping("/sentence")
+    public ResponseEntity<TtsResponse> synthesizeSentence(
+        @AuthenticatedUser Long userId,
+        @Valid @RequestBody TtsRequest request
+    ) {
+        Optional<TtsResponse> resp = ttsService.synthesizeSentence(userId, request);
+        return resp.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    /**
+     * List voices available for the given language. The result may
+     * vary depending on the user's subscription plan.
+     */
+    @GetMapping("/voices")
+    public ResponseEntity<VoiceResponse> listVoices(
+        @AuthenticatedUser Long userId,
+        @RequestParam String lang
+    ) {
+        VoiceResponse resp = ttsService.listVoices(userId, lang);
+        return ResponseEntity.ok(resp);
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/dto/TtsRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/TtsRequest.java
@@ -1,0 +1,44 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+/**
+ * Request payload for text to speech synthesis. Shared by both
+ * word and sentence endpoints.
+ */
+@Data
+public class TtsRequest {
+
+    /** Text content to synthesize. */
+    @NotBlank
+    private String text;
+
+    /** Language code, e.g. "en-US". */
+    @NotBlank
+    private String lang;
+
+    /** Voice identifier within the language. */
+    private String voice;
+
+    /**
+     * Audio format. Currently only mp3 is supported but expressed
+     * as a field to keep the contract extensible.
+     */
+    @Pattern(regexp = "mp3", message = "Only mp3 format is supported")
+    private String format = "mp3";
+
+    /** Playback speed multiplier. */
+    @DecimalMin("0.5")
+    @DecimalMax("2.0")
+    private double speed = 1.0;
+
+    /**
+     * When true, the backend returns 204 if cache is missed allowing
+     * the client to decide whether to trigger synthesis.
+     */
+    private boolean shortcut = true;
+}

--- a/backend/src/main/java/com/glancy/backend/dto/TtsResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/TtsResponse.java
@@ -1,0 +1,33 @@
+package com.glancy.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response payload containing synthesized audio metadata.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TtsResponse {
+
+    /** Temporary URL for the audio file. */
+    private String url;
+
+    /** Audio duration in milliseconds. */
+    @JsonProperty("duration_ms")
+    private long durationMs;
+
+    /** Audio format such as mp3. */
+    private String format;
+
+    /** Indicates whether the result was served from cache. */
+    @JsonProperty("from_cache")
+    private boolean fromCache;
+
+    /** Object storage key for the audio file. */
+    @JsonProperty("object_key")
+    private String objectKey;
+}

--- a/backend/src/main/java/com/glancy/backend/dto/VoiceOption.java
+++ b/backend/src/main/java/com/glancy/backend/dto/VoiceOption.java
@@ -1,0 +1,23 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a single voice choice available under a language.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VoiceOption {
+
+    /** Unique voice identifier. */
+    private String id;
+
+    /** Human readable voice label. */
+    private String label;
+
+    /** Subscription plan that can access this voice. */
+    private String plan;
+}

--- a/backend/src/main/java/com/glancy/backend/dto/VoiceResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/VoiceResponse.java
@@ -1,0 +1,23 @@
+package com.glancy.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response payload describing available voices for a language.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VoiceResponse {
+
+    /** Default voice identifier for the language. */
+    @JsonProperty("default")
+    private String defaultVoice;
+
+    /** All voice options available. */
+    private List<VoiceOption> options;
+}

--- a/backend/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -51,6 +51,30 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(QuotaExceededException.class)
+    public ResponseEntity<ErrorResponse> handleQuota(QuotaExceededException ex) {
+        log.error("Quota exceeded: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleRateLimit(RateLimitExceededException ex) {
+        log.warn("Rate limit exceeded: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    @ExceptionHandler(TtsFailedException.class)
+    public ResponseEntity<ErrorResponse> handleTtsFailure(TtsFailedException ex) {
+        log.error("TTS failed: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.FAILED_DEPENDENCY);
+    }
+
+    @ExceptionHandler(ServiceDegradedException.class)
+    public ResponseEntity<ErrorResponse> handleServiceDegraded(ServiceDegradedException ex) {
+        log.error("Service degraded: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException ex) {
         log.error("Missing request parameter: {}", ex.getParameterName());

--- a/backend/src/main/java/com/glancy/backend/exception/QuotaExceededException.java
+++ b/backend/src/main/java/com/glancy/backend/exception/QuotaExceededException.java
@@ -1,0 +1,12 @@
+package com.glancy.backend.exception;
+
+/**
+ * Thrown when a user has exceeded their allotted synthesis quota
+ * or attempts to use a voice beyond their subscription plan.
+ */
+public class QuotaExceededException extends RuntimeException {
+
+    public QuotaExceededException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/exception/RateLimitExceededException.java
+++ b/backend/src/main/java/com/glancy/backend/exception/RateLimitExceededException.java
@@ -1,0 +1,11 @@
+package com.glancy.backend.exception;
+
+/**
+ * Raised when a request violates configured rate limits.
+ */
+public class RateLimitExceededException extends RuntimeException {
+
+    public RateLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/exception/ServiceDegradedException.java
+++ b/backend/src/main/java/com/glancy/backend/exception/ServiceDegradedException.java
@@ -1,0 +1,12 @@
+package com.glancy.backend.exception;
+
+/**
+ * Used when the service is intentionally degraded and cannot
+ * fulfill synthesis requests at the moment.
+ */
+public class ServiceDegradedException extends RuntimeException {
+
+    public ServiceDegradedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/exception/TtsFailedException.java
+++ b/backend/src/main/java/com/glancy/backend/exception/TtsFailedException.java
@@ -1,0 +1,12 @@
+package com.glancy.backend.exception;
+
+/**
+ * Indicates that the downstream TTS provider failed to synthesize
+ * the requested audio.
+ */
+public class TtsFailedException extends RuntimeException {
+
+    public TtsFailedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/tts/TtsService.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/TtsService.java
@@ -1,0 +1,39 @@
+package com.glancy.backend.service.tts;
+
+import com.glancy.backend.dto.TtsRequest;
+import com.glancy.backend.dto.TtsResponse;
+import com.glancy.backend.dto.VoiceResponse;
+import java.util.Optional;
+
+/**
+ * Contracts for text to speech synthesis operations.
+ */
+public interface TtsService {
+
+    /**
+     * Synthesize audio for a single word.
+     *
+     * @param userId authenticated user performing the request
+     * @param request synthesis parameters
+     * @return optional response; empty when cache miss and shortcut is true
+     */
+    Optional<TtsResponse> synthesizeWord(Long userId, TtsRequest request);
+
+    /**
+     * Synthesize audio for a sentence or arbitrary text.
+     *
+     * @param userId authenticated user performing the request
+     * @param request synthesis parameters
+     * @return optional response; empty when cache miss and shortcut is true
+     */
+    Optional<TtsResponse> synthesizeSentence(Long userId, TtsRequest request);
+
+    /**
+     * Retrieve voice options available for the given language.
+     *
+     * @param userId authenticated user performing the request
+     * @param lang language code
+     * @return voice information
+     */
+    VoiceResponse listVoices(Long userId, String lang);
+}

--- a/backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java
@@ -1,0 +1,110 @@
+package com.glancy.backend.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.glancy.backend.dto.TtsRequest;
+import com.glancy.backend.dto.TtsResponse;
+import com.glancy.backend.dto.VoiceOption;
+import com.glancy.backend.dto.VoiceResponse;
+import com.glancy.backend.service.UserService;
+import com.glancy.backend.service.tts.TtsService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Tests for {@link TtsController}. The focus is on verifying the
+ * HTTP contract and parameter handling rather than synthesis logic.
+ */
+@WebMvcTest(TtsController.class)
+@Import(
+    {
+        com.glancy.backend.config.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
+    }
+)
+class TtsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TtsService ttsService;
+
+    @MockitoBean
+    private UserService userService;
+
+    /**
+     * Verify that a successful word synthesis returns the payload
+     * from the service layer.
+     */
+    @Test
+    void synthesizeWordReturnsAudio() throws Exception {
+        TtsResponse resp = new TtsResponse("url", 1000L, "mp3", true, "obj");
+        when(ttsService.synthesizeWord(eq(1L), any(TtsRequest.class))).thenReturn(Optional.of(resp));
+        doNothing().when(userService).validateToken(1L, "tkn");
+
+        mockMvc
+            .perform(
+                post("/api/tts/word")
+                    .param("userId", "1")
+                    .header("X-USER-TOKEN", "tkn")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"text\":\"hello\",\"lang\":\"en\"}")
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.url").value("url"))
+            .andExpect(jsonPath("$.from_cache").value(true));
+    }
+
+    /**
+     * When the service indicates a cache miss, the controller should
+     * respond with 204 to signal the client to retry without shortcut.
+     */
+    @Test
+    void synthesizeWordCacheMissReturns204() throws Exception {
+        when(ttsService.synthesizeWord(eq(1L), any(TtsRequest.class))).thenReturn(Optional.empty());
+        doNothing().when(userService).validateToken(1L, "tkn");
+
+        mockMvc
+            .perform(
+                post("/api/tts/word")
+                    .param("userId", "1")
+                    .header("X-USER-TOKEN", "tkn")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"text\":\"hello\",\"lang\":\"en\"}")
+            )
+            .andExpect(status().isNoContent());
+    }
+
+    /**
+     * Ensure the voices endpoint returns voice data as provided by
+     * the service.
+     */
+    @Test
+    void listVoicesReturnsOptions() throws Exception {
+        VoiceResponse resp = new VoiceResponse("v1", List.of(new VoiceOption("v1", "label", "all")));
+        when(ttsService.listVoices(eq(1L), eq("en"))).thenReturn(resp);
+        doNothing().when(userService).validateToken(1L, "tkn");
+
+        mockMvc
+            .perform(get("/api/tts/voices").param("userId", "1").header("X-USER-TOKEN", "tkn").param("lang", "en"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.default").value("v1"))
+            .andExpect(jsonPath("$.options[0].id").value("v1"));
+    }
+}


### PR DESCRIPTION
## Summary
- add TTS request/response DTOs and voice listing structures
- expose `/api/tts/word`, `/api/tts/sentence`, and `/api/tts/voices` endpoints
- extend global exception handling for quota, rate limiting, TTS failure, and service degradation

## Testing
- `mvn -q test` *(failed: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 (absent): Could not transfer artifact... Network is unreachable and 'parent.relativePath' points at wrong local POM)*

------
https://chatgpt.com/codex/tasks/task_e_689a3ba573648332beb788646b97ccc9