### PR TITLE
feat(tts): add hot-reloadable TTS configuration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -51,10 +51,16 @@
                           <groupId>org.springframework.boot</groupId>
                           <artifactId>spring-boot-starter-mail</artifactId>
                   </dependency>
-                  <dependency>
-                          <groupId>org.springframework.boot</groupId>
-                          <artifactId>spring-boot-starter-aop</artifactId>
-                  </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-aop</artifactId>
+                </dependency>
+
+                <!-- YAML support for hot-reloadable TTS configuration -->
+                <dependency>
+                        <groupId>com.fasterxml.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-yaml</artifactId>
+                </dependency>
 
                   <dependency>
                           <groupId>com.mysql</groupId>

--- a/backend/src/main/java/com/glancy/backend/service/tts/config/TtsConfig.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/config/TtsConfig.java
@@ -1,0 +1,83 @@
+package com.glancy.backend.service.tts.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+/**
+ * In-memory representation of TTS runtime configuration. The structure mirrors
+ * the YAML file and is intentionally simple so that it can be serialised and
+ * validated easily.
+ */
+@Data
+public class TtsConfig {
+
+    private Map<String, VoiceGroup> voices = Map.of();
+    private Quota quota = new Quota();
+    private Cache cache = new Cache();
+    private RateLimit ratelimit = new RateLimit();
+    private Features features = new Features();
+
+    /**
+     * Voice options organised by language. Each language exposes a default voice
+     * and an arbitrary number of selectable options.
+     */
+    @Data
+    public static class VoiceGroup {
+        @JsonProperty("default")
+        private String defaultVoice;
+        private List<VoiceOption> options = List.of();
+    }
+
+    /** Describes a single voice option. */
+    @Data
+    public static class VoiceOption {
+        private String id;
+        private String label;
+        private String plan;
+    }
+
+    /** Configuration for synthesis quota. */
+    @Data
+    public static class Quota {
+        private Daily daily = new Daily();
+
+        @Data
+        public static class Daily {
+            private int pro;
+            private int free;
+        }
+    }
+
+    /** Cache related settings. */
+    @Data
+    public static class Cache {
+        private TtlDays ttlDays = new TtlDays();
+        private int audioSampleRate;
+
+        @Data
+        public static class TtlDays {
+            private int pro;
+            private int free;
+        }
+    }
+
+    /** Parameters for rate limiting. */
+    @Data
+    public static class RateLimit {
+        private int userPerMinute;
+        private int ipPerMinute;
+        private int burst;
+        private int cooldownSeconds;
+    }
+
+    /** Feature toggles. */
+    @Data
+    public static class Features {
+        private boolean hotReload;
+        private boolean useCdn;
+        private boolean returnUrl;
+        private boolean countCachedAsUsage;
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/tts/config/TtsConfigManager.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/config/TtsConfigManager.java
@@ -1,0 +1,155 @@
+package com.glancy.backend.service.tts.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Loads and watches the TTS configuration file. The latest valid snapshot is
+ * kept in memory and swaps atomically on every successful reload. Any parsing or
+ * validation errors result in retaining the previous snapshot to ensure
+ * availability.
+ */
+@Slf4j
+@Component
+public class TtsConfigManager implements Closeable {
+
+    private final String configPath;
+    private final ObjectMapper mapper;
+    private final AtomicReference<TtsConfig> snapshot = new AtomicReference<>(new TtsConfig());
+
+    private WatchService watchService;
+    private ExecutorService watchExecutor;
+
+    public TtsConfigManager(@Value("${tts.config-path:}") String configPath) {
+        this.configPath = configPath;
+        this.mapper = new ObjectMapper(new YAMLFactory());
+        this.mapper.findAndRegisterModules();
+        this.mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        init();
+    }
+
+    /** Returns the currently active configuration snapshot. */
+    public TtsConfig current() {
+        return snapshot.get();
+    }
+
+    /** Reloads configuration from disk if a path is configured. */
+    public synchronized void reload() {
+        if (!StringUtils.hasText(configPath)) {
+            return;
+        }
+        Path path = Path.of(configPath);
+        loadFromFile(path);
+    }
+
+    private void init() {
+        if (StringUtils.hasText(configPath)) {
+            Path path = Path.of(configPath);
+            loadFromFile(path);
+            if (snapshot.get().getFeatures().isHotReload()) {
+                startWatcher(path);
+            }
+        } else {
+            loadFromClasspath();
+        }
+    }
+
+    private void loadFromClasspath() {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("tts-config.yml")) {
+            if (in == null) {
+                log.warn("Default TTS config resource not found");
+                return;
+            }
+            TtsConfig cfg = mapper.readValue(in, TtsConfig.class);
+            validate(cfg);
+            snapshot.set(cfg);
+            log.info("Loaded TTS config from classpath");
+        } catch (Exception ex) {
+            log.error("Failed to load classpath TTS config", ex);
+        }
+    }
+
+    private void loadFromFile(Path path) {
+        try (InputStream in = Files.newInputStream(path)) {
+            TtsConfig cfg = mapper.readValue(in, TtsConfig.class);
+            validate(cfg);
+            snapshot.set(cfg);
+            log.info("Loaded TTS config from {}", path.toAbsolutePath());
+        } catch (Exception ex) {
+            log.warn("Failed to reload TTS config from {}", path.toAbsolutePath(), ex);
+        }
+    }
+
+    private void validate(TtsConfig cfg) {
+        cfg.getVoices()
+            .forEach(
+                (lang, group) -> {
+                    boolean exists =
+                        group.getOptions().stream().anyMatch(v -> v.getId().equals(group.getDefaultVoice()));
+                    if (!exists) {
+                        throw new IllegalArgumentException(
+                            "Default voice for " + lang + " not present in options");
+                    }
+                }
+            );
+    }
+
+    private void startWatcher(Path path) {
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+            Path dir = path.getParent();
+            dir.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+            watchExecutor =
+                Executors.newSingleThreadExecutor(
+                    r -> {
+                        Thread t = new Thread(r, "tts-config-watcher");
+                        t.setDaemon(true);
+                        return t;
+                    }
+                );
+            watchExecutor.submit(
+                () -> {
+                    while (!Thread.currentThread().isInterrupted()) {
+                        WatchKey key = watchService.take();
+                        for (WatchEvent<?> event : key.pollEvents()) {
+                            Path changed = dir.resolve((Path) event.context());
+                            if (Files.isRegularFile(changed) && changed.getFileName().equals(path.getFileName())) {
+                                log.info("Detected TTS config change");
+                                reload();
+                            }
+                        }
+                        key.reset();
+                    }
+                }
+            );
+            log.info("Watching {} for TTS config changes", path.toAbsolutePath());
+        } catch (IOException | RuntimeException ex) {
+            log.warn("Failed to watch TTS config file", ex);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (watchExecutor != null) {
+            watchExecutor.shutdownNow();
+        }
+        if (watchService != null) {
+            try {
+                watchService.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+}

--- a/backend/src/main/resources/tts-config.yml
+++ b/backend/src/main/resources/tts-config.yml
@@ -1,0 +1,26 @@
+voices:
+  zh-CN:
+    default: zh_female_cancan_mars_bigtts
+    options:
+      - id: zh_female_cancan_mars_bigtts
+        label: "CanCan·女声"
+        plan: all
+quota:
+  daily:
+    pro: 100
+    free: 5
+cache:
+  ttlDays:
+    pro: 90
+    free: 30
+  audioSampleRate: 48000
+ratelimit:
+  userPerMinute: 30
+  ipPerMinute: 120
+  burst: 20
+  cooldownSeconds: 60
+features:
+  hotReload: true
+  useCdn: true
+  returnUrl: true
+  countCachedAsUsage: false

--- a/backend/src/test/java/com/glancy/backend/service/tts/config/TtsConfigManagerTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/config/TtsConfigManagerTest.java
@@ -1,0 +1,166 @@
+package com.glancy.backend.service.tts.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link TtsConfigManager} focused on reload behaviour and validation
+ * mechanics.
+ */
+class TtsConfigManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * A valid YAML file should replace the in-memory snapshot when reloaded.
+     * Flow: write initial config -> load -> modify -> reload -> verify update.
+     */
+    @Test
+    void reloadReplacesSnapshotOnValidConfig() throws IOException {
+        Path file = tempDir.resolve("tts.yml");
+        Files.writeString(
+            file,
+            """
+                voices:
+                  zh-CN:
+                    default: zh_female_cancan_mars_bigtts
+                    options:
+                      - id: zh_female_cancan_mars_bigtts
+                        label: A
+                        plan: all
+                quota:
+                  daily: { pro: 100, free: 5 }
+                cache:
+                  ttlDays: { pro: 90, free: 30 }
+                  audioSampleRate: 48000
+                ratelimit:
+                  userPerMinute: 30
+                  ipPerMinute: 120
+                  burst: 20
+                  cooldownSeconds: 60
+                features:
+                  hotReload: false
+                  useCdn: true
+                  returnUrl: true
+                  countCachedAsUsage: false
+                """
+        );
+        TtsConfigManager mgr = new TtsConfigManager(file.toString());
+        mgr.reload();
+        assertEquals(
+            "zh_female_cancan_mars_bigtts",
+            mgr.current().getVoices().get("zh-CN").getDefaultVoice()
+        );
+
+        Files.writeString(
+            file,
+            """
+                voices:
+                  zh-CN:
+                    default: zh_male_new_voice
+                    options:
+                      - id: zh_male_new_voice
+                        label: B
+                        plan: all
+                quota:
+                  daily: { pro: 100, free: 5 }
+                cache:
+                  ttlDays: { pro: 90, free: 30 }
+                  audioSampleRate: 48000
+                ratelimit:
+                  userPerMinute: 30
+                  ipPerMinute: 120
+                  burst: 20
+                  cooldownSeconds: 60
+                features:
+                  hotReload: false
+                  useCdn: true
+                  returnUrl: true
+                  countCachedAsUsage: false
+                """
+        );
+        mgr.reload();
+        assertEquals("zh_male_new_voice", mgr.current().getVoices().get("zh-CN").getDefaultVoice());
+        mgr.close();
+    }
+
+    /**
+     * When the configuration is invalid the previous snapshot should remain
+     * active. Flow: load valid config -> write invalid -> reload -> unchanged.
+     */
+    @Test
+    void reloadRejectsInvalidConfig() throws IOException {
+        Path file = tempDir.resolve("tts.yml");
+        Files.writeString(
+            file,
+            """
+                voices:
+                  zh-CN:
+                    default: voice1
+                    options:
+                      - id: voice1
+                        label: A
+                        plan: all
+                quota:
+                  daily: { pro: 100, free: 5 }
+                cache:
+                  ttlDays: { pro: 90, free: 30 }
+                  audioSampleRate: 48000
+                ratelimit:
+                  userPerMinute: 30
+                  ipPerMinute: 120
+                  burst: 20
+                  cooldownSeconds: 60
+                features:
+                  hotReload: false
+                  useCdn: true
+                  returnUrl: true
+                  countCachedAsUsage: false
+                """
+        );
+        TtsConfigManager mgr = new TtsConfigManager(file.toString());
+        mgr.reload();
+        assertEquals("voice1", mgr.current().getVoices().get("zh-CN").getDefaultVoice());
+
+        Files.writeString(
+            file,
+            """
+                voices:
+                  zh-CN:
+                    default: missing
+                    options:
+                      - id: voice1
+                        label: A
+                        plan: all
+                quota:
+                  daily: { pro: 100, free: 5 }
+                cache:
+                  ttlDays: { pro: 90, free: 30 }
+                  audioSampleRate: 48000
+                ratelimit:
+                  userPerMinute: 30
+                  ipPerMinute: 120
+                  burst: 20
+                  cooldownSeconds: 60
+                features:
+                  hotReload: false
+                  useCdn: true
+                  returnUrl: true
+                  countCachedAsUsage: false
+                """
+        );
+        mgr.reload();
+        assertEquals(
+            "voice1",
+            mgr.current().getVoices().get("zh-CN").getDefaultVoice(),
+            "Invalid config should not replace snapshot"
+        );
+        mgr.close();
+    }
+}


### PR DESCRIPTION
## Summary
- add YAML-driven TTS configuration with voices, quota, cache and rate limit settings
- implement TtsConfigManager with validation and hot reload via file watcher
- cover config reload and validation rules with unit tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at wrong local POM)*

------
https://chatgpt.com/codex/tasks/task_e_689a3df0b4bc833298706716a59aaf5e