### PR TITLE
feat: add quota and rate limit services

### DIFF
--- a/backend/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/backend/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -1,6 +1,7 @@
 package com.glancy.backend;
 
 import com.glancy.backend.util.EnvLoader;
+import java.time.Clock;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -31,5 +32,15 @@ public class GlancyBackendApplication {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    /**
+     * Provide a system UTC clock for time-based services. Keeping this
+     * as a bean allows tests to supply a deterministic clock while the
+     * application defaults to the system clock.
+     */
+    @Bean
+    public Clock systemClock() {
+        return Clock.systemUTC();
     }
 }

--- a/backend/src/main/java/com/glancy/backend/controller/TtsController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/TtsController.java
@@ -5,6 +5,7 @@ import com.glancy.backend.dto.TtsRequest;
 import com.glancy.backend.dto.TtsResponse;
 import com.glancy.backend.dto.VoiceResponse;
 import com.glancy.backend.service.tts.TtsService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -38,9 +39,11 @@ public class TtsController {
     @PostMapping("/word")
     public ResponseEntity<TtsResponse> synthesizeWord(
         @AuthenticatedUser Long userId,
+        HttpServletRequest httpRequest,
         @Valid @RequestBody TtsRequest request
     ) {
-        Optional<TtsResponse> resp = ttsService.synthesizeWord(userId, request);
+        String ip = httpRequest.getRemoteAddr();
+        Optional<TtsResponse> resp = ttsService.synthesizeWord(userId, ip, request);
         return resp.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
     }
 
@@ -50,9 +53,11 @@ public class TtsController {
     @PostMapping("/sentence")
     public ResponseEntity<TtsResponse> synthesizeSentence(
         @AuthenticatedUser Long userId,
+        HttpServletRequest httpRequest,
         @Valid @RequestBody TtsRequest request
     ) {
-        Optional<TtsResponse> resp = ttsService.synthesizeSentence(userId, request);
+        String ip = httpRequest.getRemoteAddr();
+        Optional<TtsResponse> resp = ttsService.synthesizeSentence(userId, ip, request);
         return resp.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
     }
 

--- a/backend/src/main/java/com/glancy/backend/entity/TtsUsage.java
+++ b/backend/src/main/java/com/glancy/backend/entity/TtsUsage.java
@@ -1,0 +1,30 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Daily synthesis usage for a user. This entity tracks how many
+ * successful syntheses a user has performed on a given date so
+ * that daily quotas can be enforced efficiently.
+ */
+@Entity
+@Table(name = "tts_usage", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "date"}))
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class TtsUsage extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private int count;
+}

--- a/backend/src/main/java/com/glancy/backend/repository/TtsUsageRepository.java
+++ b/backend/src/main/java/com/glancy/backend/repository/TtsUsageRepository.java
@@ -1,0 +1,15 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.TtsUsage;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository for tracking per-user daily TTS usage counts.
+ */
+@Repository
+public interface TtsUsageRepository extends JpaRepository<TtsUsage, Long> {
+    Optional<TtsUsage> findByUserIdAndDate(Long userId, LocalDate date);
+}

--- a/backend/src/main/java/com/glancy/backend/service/tts/TtsService.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/TtsService.java
@@ -16,7 +16,7 @@ public interface TtsService {
      * @param request synthesis parameters
      * @return optional response; empty when cache miss and shortcut is true
      */
-    Optional<TtsResponse> synthesizeWord(Long userId, TtsRequest request);
+    Optional<TtsResponse> synthesizeWord(Long userId, String ip, TtsRequest request);
 
     /**
      * Synthesize audio for a sentence or arbitrary text.
@@ -25,7 +25,7 @@ public interface TtsService {
      * @param request synthesis parameters
      * @return optional response; empty when cache miss and shortcut is true
      */
-    Optional<TtsResponse> synthesizeSentence(Long userId, TtsRequest request);
+    Optional<TtsResponse> synthesizeSentence(Long userId, String ip, TtsRequest request);
 
     /**
      * Retrieve voice options available for the given language.

--- a/backend/src/main/java/com/glancy/backend/service/tts/quota/TtsQuotaService.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/quota/TtsQuotaService.java
@@ -1,0 +1,76 @@
+package com.glancy.backend.service.tts.quota;
+
+import com.glancy.backend.entity.TtsUsage;
+import com.glancy.backend.entity.User;
+import com.glancy.backend.exception.QuotaExceededException;
+import com.glancy.backend.repository.TtsUsageRepository;
+import com.glancy.backend.service.tts.config.TtsConfig;
+import com.glancy.backend.service.tts.config.TtsConfigManager;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Enforces and records per-user synthesis quotas.
+ */
+@Service
+@Slf4j
+public class TtsQuotaService {
+
+    private final TtsUsageRepository usageRepository;
+    private final TtsConfigManager configManager;
+    private final Clock clock;
+
+    public TtsQuotaService(TtsUsageRepository usageRepository, TtsConfigManager configManager, Clock clock) {
+        this.usageRepository = usageRepository;
+        this.configManager = configManager;
+        this.clock = clock;
+    }
+
+    /**
+     * Validate that the user still has remaining quota for today.
+     */
+    public void verifyQuota(User user) {
+        int limit = quotaLimit(user);
+        LocalDate today = LocalDate.now(clock);
+        Optional<TtsUsage> usageOpt = usageRepository.findByUserIdAndDate(user.getId(), today);
+        if (usageOpt.map(TtsUsage::getCount).orElse(0) >= limit) {
+            log.warn("User {} exceeded daily TTS quota", user.getId());
+            throw new QuotaExceededException("今日配额已用完");
+        }
+    }
+
+    /**
+     * Record a successful synthesis for the user. This should be invoked
+     * only after the synthesis completes to align with billing semantics.
+     */
+    @Transactional
+    public void recordUsage(User user) {
+        int limit = quotaLimit(user);
+        LocalDate today = LocalDate.now(clock);
+        TtsUsage usage = usageRepository.findByUserIdAndDate(user.getId(), today).orElse(null);
+        if (usage == null) {
+            usage = new TtsUsage();
+            usage.setUser(user);
+            usage.setDate(today);
+            usage.setCount(1);
+        } else {
+            if (usage.getCount() >= limit) {
+                log.warn("User {} exceeded daily TTS quota during record", user.getId());
+                throw new QuotaExceededException("今日配额已用完");
+            }
+            usage.setCount(usage.getCount() + 1);
+        }
+        usageRepository.save(usage);
+    }
+
+    private int quotaLimit(User user) {
+        TtsConfig cfg = configManager.current();
+        return Boolean.TRUE.equals(user.getMember())
+            ? cfg.getQuota().getDaily().getPro()
+            : cfg.getQuota().getDaily().getFree();
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/tts/ratelimit/TtsRateLimiter.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/ratelimit/TtsRateLimiter.java
@@ -1,0 +1,104 @@
+package com.glancy.backend.service.tts.ratelimit;
+
+import com.glancy.backend.exception.RateLimitExceededException;
+import com.glancy.backend.service.tts.config.TtsConfig;
+import com.glancy.backend.service.tts.config.TtsConfigManager;
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * In-memory token bucket rate limiter for TTS requests.
+ * Suitable for single-node deployments; external implementations
+ * should be provided for distributed environments.
+ */
+@Component
+@Slf4j
+public class TtsRateLimiter {
+
+    private static class Bucket {
+        int tokens;
+        long windowStart;
+        long cooldownUntil;
+    }
+
+    private final Map<String, Bucket> userBuckets = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> ipBuckets = new ConcurrentHashMap<>();
+    private final TtsConfigManager configManager;
+    private final Clock clock;
+
+    public TtsRateLimiter(TtsConfigManager configManager, Clock clock) {
+        this.configManager = configManager;
+        this.clock = clock;
+    }
+
+    /**
+     * Validate request against user and IP limits.
+     */
+    public void validate(Long userId, String ip) {
+        TtsConfig.RateLimit cfg = configManager.current().getRatelimit();
+        long retryUser = checkBucket(
+            userBuckets,
+            userId.toString(),
+            cfg.getUserPerMinute(),
+            cfg.getBurst(),
+            cfg.getCooldownSeconds()
+        );
+        if (retryUser > 0) {
+            log.warn("User {} hit rate limit, retry after {}s", userId, retryUser);
+            throw new RateLimitExceededException("请" + retryUser + "秒后重试");
+        }
+        long retryIp = checkBucket(
+            ipBuckets,
+            ip,
+            cfg.getIpPerMinute(),
+            cfg.getBurst(),
+            cfg.getCooldownSeconds()
+        );
+        if (retryIp > 0) {
+            log.warn("IP {} hit rate limit, retry after {}s", maskIp(ip), retryIp);
+            throw new RateLimitExceededException("请" + retryIp + "秒后重试");
+        }
+    }
+
+    private long checkBucket(
+        Map<String, Bucket> buckets,
+        String key,
+        int perMinute,
+        int burst,
+        int cooldownSeconds
+    ) {
+        long now = clock.millis();
+        Bucket bucket = buckets.computeIfAbsent(
+            key,
+            k -> {
+                Bucket b = new Bucket();
+                b.tokens = perMinute + burst;
+                b.windowStart = now;
+                return b;
+            }
+        );
+        synchronized (bucket) {
+            if (now < bucket.cooldownUntil) {
+                return (bucket.cooldownUntil - now + 999) / 1000;
+            }
+            if (now - bucket.windowStart >= 60_000) {
+                bucket.tokens = perMinute + burst;
+                bucket.windowStart = now;
+            }
+            if (bucket.tokens > 0) {
+                bucket.tokens--;
+                return 0;
+            }
+            bucket.cooldownUntil = now + cooldownSeconds * 1000L;
+            return (bucket.cooldownUntil - now + 999) / 1000;
+        }
+    }
+
+    private String maskIp(String ip) {
+        int idx = ip.lastIndexOf('.');
+        return idx > 0 ? ip.substring(0, idx) + ".xxx" : ip;
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -55,7 +56,7 @@ class TtsControllerTest {
     @Test
     void synthesizeWordReturnsAudio() throws Exception {
         TtsResponse resp = new TtsResponse("url", 1000L, "mp3", true, "obj");
-        when(ttsService.synthesizeWord(eq(1L), any(TtsRequest.class))).thenReturn(Optional.of(resp));
+        when(ttsService.synthesizeWord(eq(1L), anyString(), any(TtsRequest.class))).thenReturn(Optional.of(resp));
         doNothing().when(userService).validateToken(1L, "tkn");
 
         mockMvc
@@ -77,7 +78,7 @@ class TtsControllerTest {
      */
     @Test
     void synthesizeWordCacheMissReturns204() throws Exception {
-        when(ttsService.synthesizeWord(eq(1L), any(TtsRequest.class))).thenReturn(Optional.empty());
+        when(ttsService.synthesizeWord(eq(1L), anyString(), any(TtsRequest.class))).thenReturn(Optional.empty());
         doNothing().when(userService).validateToken(1L, "tkn");
 
         mockMvc

--- a/backend/src/test/java/com/glancy/backend/service/tts/quota/TtsQuotaServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/quota/TtsQuotaServiceTest.java
@@ -1,0 +1,95 @@
+package com.glancy.backend.service.tts.quota;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+import com.glancy.backend.entity.TtsUsage;
+import com.glancy.backend.entity.User;
+import com.glancy.backend.exception.QuotaExceededException;
+import com.glancy.backend.repository.TtsUsageRepository;
+import com.glancy.backend.service.tts.config.TtsConfig;
+import com.glancy.backend.service.tts.config.TtsConfigManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link TtsQuotaService}. These ensure that daily usage
+ * limits are enforced and persisted correctly.
+ */
+class TtsQuotaServiceTest {
+
+    @Mock
+    private TtsUsageRepository usageRepository;
+
+    @Mock
+    private TtsConfigManager configManager;
+
+    private Clock clock;
+
+    private TtsQuotaService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        clock = Clock.fixed(Instant.parse("2024-01-02T00:00:00Z"), ZoneOffset.UTC);
+        service = new TtsQuotaService(usageRepository, configManager, clock);
+
+        TtsConfig cfg = new TtsConfig();
+        TtsConfig.Quota quota = new TtsConfig.Quota();
+        TtsConfig.Quota.Daily daily = new TtsConfig.Quota.Daily();
+        daily.setPro(100);
+        daily.setFree(5);
+        quota.setDaily(daily);
+        cfg.setQuota(quota);
+        when(configManager.current()).thenReturn(cfg);
+    }
+
+    /**
+     * verifyQuota should reject requests once the user reaches their limit.
+     */
+    @Test
+    void verifyQuotaRejectsWhenLimitReached() {
+        User user = new User();
+        user.setId(1L);
+        user.setMember(false);
+        TtsUsage usage = new TtsUsage();
+        usage.setCount(5);
+        when(usageRepository.findByUserIdAndDate(eq(1L), any(LocalDate.class))).thenReturn(Optional.of(usage));
+
+        assertThrows(QuotaExceededException.class, () -> service.verifyQuota(user));
+    }
+
+    /**
+     * recordUsage should increment the existing counter.
+     */
+    @Test
+    void recordUsageIncrementsCount() {
+        User user = new User();
+        user.setId(1L);
+        user.setMember(true);
+        TtsUsage usage = new TtsUsage();
+        usage.setUser(user);
+        usage.setDate(LocalDate.of(2024, 1, 2));
+        usage.setCount(1);
+        when(usageRepository.findByUserIdAndDate(eq(1L), any(LocalDate.class))).thenReturn(Optional.of(usage));
+        when(usageRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.recordUsage(user);
+
+        ArgumentCaptor<TtsUsage> captor = ArgumentCaptor.forClass(TtsUsage.class);
+        verify(usageRepository).save(captor.capture());
+        assertEquals(2, captor.getValue().getCount());
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/service/tts/ratelimit/TtsRateLimiterTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/ratelimit/TtsRateLimiterTest.java
@@ -1,0 +1,53 @@
+package com.glancy.backend.service.tts.ratelimit;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.glancy.backend.exception.RateLimitExceededException;
+import com.glancy.backend.service.tts.config.TtsConfig;
+import com.glancy.backend.service.tts.config.TtsConfigManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link TtsRateLimiter} ensuring user and IP limits are enforced.
+ */
+class TtsRateLimiterTest {
+
+    @Mock
+    private TtsConfigManager configManager;
+
+    private Clock clock;
+    private TtsRateLimiter limiter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        clock = Clock.fixed(Instant.parse("2024-01-02T00:00:00Z"), ZoneOffset.UTC);
+        TtsConfig cfg = new TtsConfig();
+        TtsConfig.RateLimit rl = new TtsConfig.RateLimit();
+        rl.setUserPerMinute(2);
+        rl.setIpPerMinute(100);
+        rl.setBurst(0);
+        rl.setCooldownSeconds(60);
+        cfg.setRatelimit(rl);
+        when(configManager.current()).thenReturn(cfg);
+        limiter = new TtsRateLimiter(configManager, clock);
+    }
+
+    /**
+     * Once the user exceeds the allowed requests per minute, subsequent
+     * calls should trigger a {@link RateLimitExceededException}.
+     */
+    @Test
+    void validateEnforcesUserLimit() {
+        limiter.validate(1L, "1.1.1.1");
+        limiter.validate(1L, "1.1.1.1");
+        assertThrows(RateLimitExceededException.class, () -> limiter.validate(1L, "1.1.1.1"));
+    }
+}


### PR DESCRIPTION
## Summary
- track daily TTS usage per user and enforce quotas
- enforce per-user and per-IP request limits via token bucket
- expose client IP to TTS service through controller
- provide system clock bean for time-based components

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a438946208332861eccbe73193379