### PR TITLE
feat: add tts playback support

### DIFF
--- a/website/glancy-website/src/api/__tests__/client.test.js
+++ b/website/glancy-website/src/api/__tests__/client.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { jest } from "@jest/globals"
-import { createApiClient } from '@/api/client.js'
+import { createApiClient, ApiError } from '@/api/client.js'
 
 describe('apiRequest error handling', () => {
   afterEach(() => {
@@ -28,6 +28,18 @@ describe('apiRequest error handling', () => {
     global.fetch = jest.fn().mockResolvedValue(resp)
     const apiRequest = createApiClient()
     await expect(apiRequest('/api')).rejects.toThrow('Server error')
+  })
+
+  test('includes status code in thrown error', async () => {
+    const resp = {
+      ok: false,
+      status: 403,
+      text: jest.fn().mockResolvedValue('Forbidden'),
+      headers: { get: () => 'text/plain' }
+    }
+    global.fetch = jest.fn().mockResolvedValue(resp)
+    const apiRequest = createApiClient()
+    await expect(apiRequest('/api')).rejects.toMatchObject({ status: 403 })
   })
 
   test('throws unified message on network failure', async () => {

--- a/website/glancy-website/src/api/client.js
+++ b/website/glancy-website/src/api/client.js
@@ -1,6 +1,19 @@
 import { extractMessage } from '@/utils/json.js'
 
 /**
+ * Error thrown by the API client for non-ok HTTP responses.
+ * Exposes the HTTP status code and response headers so callers can make
+ * decisions based on them.
+ */
+export class ApiError extends Error {
+  constructor(status, message, headers) {
+    super(message)
+    this.status = status
+    this.headers = headers
+  }
+}
+
+/**
  * Create a new API client instance with optional default headers and token.
  *
  * @param {Object} [config]
@@ -31,7 +44,8 @@ export function createApiClient({ token, headers: defaultHeaders = {}, onUnautho
         console.error(err)
         return ''
       })
-      throw new Error(extractMessage(text) || 'Request failed')
+      const message = extractMessage(text) || 'Request failed'
+      throw new ApiError(resp.status, message, resp.headers)
     }
     const contentType = resp.headers.get('content-type') || ''
     if (contentType.includes('application/json')) {

--- a/website/glancy-website/src/api/index.js
+++ b/website/glancy-website/src/api/index.js
@@ -6,6 +6,7 @@ import { createSearchRecordsApi } from './searchRecords.js'
 import { createUsersApi } from './users.js'
 import { createProfilesApi } from './profiles.js'
 import { createLlmApi } from './llm.js'
+import { createTtsApi } from './tts.js'
 
 export function createApi(config) {
   const request = createApiClient(config)
@@ -19,7 +20,8 @@ export function createApi(config) {
     searchRecords: createSearchRecordsApi(request),
     users: createUsersApi(request),
     profiles: createProfilesApi(request),
-    llm: createLlmApi(request)
+    llm: createLlmApi(request),
+    tts: createTtsApi(request)
   }
 }
 

--- a/website/glancy-website/src/api/tts.js
+++ b/website/glancy-website/src/api/tts.js
@@ -1,0 +1,25 @@
+import { API_PATHS } from '@/config/api.js'
+import { apiRequest } from './client.js'
+
+/**
+ * Create TTS API helpers.
+ * Each method returns the raw fetch response or parsed JSON depending on
+ * content type, allowing callers to handle 204 responses gracefully.
+ */
+export function createTtsApi(request = apiRequest) {
+  const post = (path, body) =>
+    request(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+
+  const speakWord = (body) => post(API_PATHS.ttsWord, body)
+  const speakSentence = (body) => post(API_PATHS.ttsSentence, body)
+  const fetchVoices = ({ lang }) => request(`${API_PATHS.ttsVoices}?lang=${encodeURIComponent(lang)}`)
+
+  return { speakWord, speakSentence, fetchVoices }
+}
+
+export const { speakWord, speakSentence, fetchVoices } = createTtsApi(
+)

--- a/website/glancy-website/src/components/index.js
+++ b/website/glancy-website/src/components/index.js
@@ -9,6 +9,7 @@ export { default as HistoryDisplay } from './ui/HistoryDisplay'
 export { default as ICP } from './ui/ICP'
 export { default as Loader } from './ui/Loader'
 export { default as MessagePopup } from './ui/MessagePopup'
+export { default as VoiceSelector } from './tts/VoiceSelector.jsx'
 
 export { default as AuthForm } from './form/AuthForm.jsx'
 export { default as AgeStepper } from './form/AgeStepper/AgeStepper.jsx'

--- a/website/glancy-website/src/components/tts/VoiceSelector.jsx
+++ b/website/glancy-website/src/components/tts/VoiceSelector.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { useApi } from '@/hooks'
+import { useUserStore } from '@/store/userStore.ts'
+import styles from './VoiceSelector.module.css'
+
+/**
+ * Dropdown for selecting available voices for a given language.
+ * Voices requiring Pro plan are disabled for non-pro users.
+ */
+export default function VoiceSelector({ lang, value, onChange }) {
+  const api = useApi()
+  const user = useUserStore((s) => s.user)
+  const [voices, setVoices] = useState([])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!lang) return
+    api.tts
+      .fetchVoices({ lang })
+      .then((list) => {
+        if (!cancelled) setVoices(list)
+      })
+      .catch((err) => console.error(err))
+    return () => {
+      cancelled = true
+    }
+  }, [lang, api])
+
+  const isPro = !!(user?.member || user?.isPro || (user?.plan && user.plan !== 'free'))
+
+  return (
+    <select className={styles.select} value={value} onChange={(e) => onChange?.(e.target.value)}>
+      {voices.map((v) => (
+        <option
+          key={v.id}
+          value={v.id}
+          disabled={v.plan === 'pro' && !isPro}
+          className={!isPro && v.plan === 'pro' ? styles.disabled : undefined}
+        >
+          {v.label}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/website/glancy-website/src/components/tts/VoiceSelector.module.css
+++ b/website/glancy-website/src/components/tts/VoiceSelector.module.css
@@ -1,0 +1,11 @@
+.select {
+  padding: 4px 8px;
+  border: 1px solid var(--color-border, #ccc);
+  border-radius: 6px;
+  background: var(--color-bg, #fff);
+  color: var(--color-text, #333);
+}
+
+.disabled {
+  color: #aaa;
+}

--- a/website/glancy-website/src/config/api.js
+++ b/website/glancy-website/src/config/api.js
@@ -14,5 +14,8 @@ export const API_PATHS = {
   contact: `${API_BASE}/contact`,
   faqs: `${API_BASE}/faqs`,
   searchRecords: `${API_BASE}/search-records`,
-  llmModels: `${API_BASE}/llm/models`
+  llmModels: `${API_BASE}/llm/models`,
+  ttsWord: `${API_BASE}/tts/word`,
+  ttsSentence: `${API_BASE}/tts/sentence`,
+  ttsVoices: `${API_BASE}/tts/voices`
 }

--- a/website/glancy-website/src/hooks/index.js
+++ b/website/glancy-website/src/hooks/index.js
@@ -1,6 +1,7 @@
 export { useApi } from './useApi.js'
 export { useAppShortcuts } from './useAppShortcuts.js'
 export { useFetchWord } from './useFetchWord.js'
+export { useTtsPlayer } from './useTtsPlayer.js'
 export { default as useEscapeKey } from './useEscapeKey.js'
 export { default as useMediaQuery } from './useMediaQuery.js'
 export { default as useOutsideToggle } from './useOutsideToggle.js'

--- a/website/glancy-website/src/hooks/useTtsPlayer.js
+++ b/website/glancy-website/src/hooks/useTtsPlayer.js
@@ -1,0 +1,74 @@
+import { useRef, useState, useEffect, useCallback } from 'react'
+import { useApi } from '@/hooks/useApi.js'
+import { ApiError } from '@/api/client.js'
+
+/**
+ * Hook that encapsulates TTS playback logic with cache-first strategy.
+ * It first tries a shortcut request which may return 204 when cache misses.
+ * In that case it retries without shortcut and plays the resulting audio.
+ */
+export function useTtsPlayer({ scope = 'word' } = {}) {
+  const api = useApi()
+  const tts = api.tts
+  const audioRef = useRef(typeof Audio !== 'undefined' ? new Audio() : null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [playing, setPlaying] = useState(false)
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+    const handleEnd = () => setPlaying(false)
+    audio.addEventListener('ended', handleEnd)
+    return () => audio.removeEventListener('ended', handleEnd)
+  }, [])
+
+  const play = useCallback(
+    async ({ text, lang, voice, speed = 1.0, format = 'mp3' }) => {
+      if (!text || !lang) return
+      setLoading(true)
+      setError(null)
+      try {
+        const body = { text, lang, voice, speed, format, shortcut: true }
+        const fn = scope === 'sentence' ? tts.speakSentence : tts.speakWord
+        let resp = await fn(body)
+        if (resp instanceof Response && resp.status === 204) {
+          resp = await fn({ ...body, shortcut: false })
+        }
+        const data = resp.url ? resp : await resp.json()
+        const audio = audioRef.current
+        if (audio) {
+          audio.src = data.url
+          await audio.play()
+          setPlaying(true)
+        }
+      } catch (err) {
+        if (err instanceof ApiError) {
+          switch (err.status) {
+            case 403:
+              setError('升级以继续使用或切换可用音色')
+              break
+            case 429: {
+              const retry = err.headers?.get('Retry-After')
+              setError(`请求过于频繁，请在${retry || '稍后'}秒后重试`)
+              break
+            }
+            case 424:
+            case 503:
+              setError('服务繁忙，请稍后再试')
+              break
+            default:
+              setError(err.message)
+          }
+        } else {
+          setError('网络错误')
+        }
+      } finally {
+        setLoading(false)
+      }
+    },
+    [tts, scope],
+  )
+
+  return { play, audio: audioRef.current, loading, error, playing }
+}


### PR DESCRIPTION
## Summary
- add client-side TTS API helpers and playback hook with cache-aware retry
- expose voice selector honoring Pro-plan restrictions
- enrich API client with detailed error handling

## Testing
- `NODE_OPTIONS='--experimental-vm-modules' npx jest src/api/__tests__/client.test.js`
- `npm run lint`
- `npm run lint:css`
- `npm test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689aced68ea08332b2f8da195ec2ea1b