### PR TITLE
feat: add TTS play button for words and sentences

### DIFF
--- a/website/glancy-website/src/components/index.js
+++ b/website/glancy-website/src/components/index.js
@@ -10,6 +10,7 @@ export { default as ICP } from './ui/ICP'
 export { default as Loader } from './ui/Loader'
 export { default as MessagePopup } from './ui/MessagePopup'
 export { default as VoiceSelector } from './tts/VoiceSelector.jsx'
+export { default as TtsButton } from './tts/TtsButton.jsx'
 
 export { default as AuthForm } from './form/AuthForm.jsx'
 export { default as AgeStepper } from './form/AgeStepper/AgeStepper.jsx'

--- a/website/glancy-website/src/components/tts/TtsButton.jsx
+++ b/website/glancy-website/src/components/tts/TtsButton.jsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+import ThemeIcon from '@/components/ui/Icon'
+import { useTtsPlayer } from '@/hooks/useTtsPlayer.js'
+import styles from './TtsButton.module.css'
+
+/**
+ * Unified TTS play button for words and sentences.
+ * Handles loading/playing states and stops playback on second click.
+ */
+export default function TtsButton({
+  text,
+  lang,
+  voice,
+  scope = 'word',
+  size,
+  disabled = false,
+}) {
+  const { play, audio, loading, playing } = useTtsPlayer({ scope })
+  const tooltip = useMemo(
+    () => (scope === 'sentence' ? '播放例句发音' : '播放发音'),
+    [scope],
+  )
+
+  const handleClick = async () => {
+    if (disabled || loading) return
+    if (playing && audio) {
+      audio.pause()
+      return
+    }
+    await play({ text, lang, voice })
+  }
+
+  const btnClass = [
+    styles.button,
+    playing && styles.playing,
+    loading && styles.loading,
+    disabled && styles.disabled,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const iconSize = size || (scope === 'sentence' ? 24 : 20)
+
+  return (
+    <button
+      type="button"
+      className={btnClass}
+      onClick={handleClick}
+      disabled={disabled || loading}
+      aria-label={tooltip}
+      title={tooltip}
+    >
+      <ThemeIcon name="voice-button" width={iconSize} height={iconSize} />
+    </button>
+  )
+}

--- a/website/glancy-website/src/components/tts/TtsButton.module.css
+++ b/website/glancy-website/src/components/tts/TtsButton.module.css
@@ -1,0 +1,54 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  opacity: 1;
+}
+
+.playing {
+  opacity: 1;
+  animation: pulse 1.2s infinite;
+  box-shadow: 0 0 0 2px var(--accent-color);
+  border-radius: 50%;
+}
+
+.loading {
+  opacity: 1;
+  animation: spin 1s linear infinite;
+}
+
+.disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/website/glancy-website/src/components/tts/__tests__/TtsButton.test.jsx
+++ b/website/glancy-website/src/components/tts/__tests__/TtsButton.test.jsx
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { jest } from '@jest/globals'
+
+// mock hooks and icon to isolate button behavior
+const play = jest.fn()
+
+jest.unstable_mockModule('@/hooks/useTtsPlayer.js', () => ({
+  useTtsPlayer: () => ({ play, audio: {}, loading: false, playing: false }),
+}))
+
+jest.unstable_mockModule('@/components/ui/Icon', () => ({
+  __esModule: true,
+  default: () => <span data-testid="icon" />,
+}))
+
+const { default: TtsButton } = await import('@/components/tts/TtsButton.jsx')
+
+describe('TtsButton', () => {
+  /**
+   * Renders button and verifies clicking triggers play with correct params.
+   */
+  test('invokes play with text and lang', () => {
+    const { getByRole } = render(<TtsButton text="hello" lang="en" />)
+    fireEvent.click(getByRole('button'))
+    expect(play).toHaveBeenCalledWith({ text: 'hello', lang: 'en', voice: undefined })
+  })
+})

--- a/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
+++ b/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
@@ -1,8 +1,9 @@
 import { useLanguage } from '@/context'
+import { TtsButton } from '@/components'
 import styles from './DictionaryEntry.module.css'
 
 function DictionaryEntry({ entry }) {
-  const { t } = useLanguage()
+  const { t, lang } = useLanguage()
   if (!entry) return null
 
   // new format detected by the presence of Chinese keys
@@ -33,7 +34,10 @@ function DictionaryEntry({ entry }) {
         {example && (
           <section className={styles.example} aria-labelledby="ex-title">
             <h2 id="ex-title" className={styles['section-title']}>【{t.exampleLabel}】</h2>
-            <blockquote>{example}</blockquote>
+            <blockquote>
+              {example}
+              <TtsButton text={example} lang={lang} scope="sentence" />
+            </blockquote>
           </section>
         )}
       </article>
@@ -60,7 +64,12 @@ function DictionaryEntry({ entry }) {
 
   return (
     <article className={styles['dictionary-entry']}>
-      {term && <h2 className={styles['section-title']}>{term}</h2>}
+      {term && (
+        <h2 className={styles['section-title']}>
+          {term}
+          <TtsButton text={term} lang={lang} scope="word" />
+        </h2>
+      )}
       {phoneticText && (
         <section className={styles['phonetic-section']} aria-labelledby="phon-title">
           <h2 id="phon-title" className={styles['section-title']}>【{t.phoneticLabel}】</h2>
@@ -110,7 +119,14 @@ function DictionaryEntry({ entry }) {
                   <ul className={styles.examples}>
                     {d.例句.map((ex, j) => (
                       <li key={j}>
-                        <blockquote>{ex.源语言}</blockquote>
+                        <blockquote>
+                          {ex.源语言}
+                          <TtsButton
+                            text={ex.源语言}
+                            lang={lang}
+                            scope="sentence"
+                          />
+                        </blockquote>
                         <blockquote>{ex.翻译}</blockquote>
                       </li>
                     ))}


### PR DESCRIPTION
## Summary
- add reusable TtsButton component that handles word or sentence playback
- integrate TTS buttons into dictionary entries for headwords and example sentences
- cover TtsButton behavior with unit test

## Testing
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npx jest src/components/tts/__tests__/TtsButton.test.jsx --runInBand`
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npx jest --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689ad3d6cc5083328cdaa0b0ad80c72e