### PR TITLE
feat(tts): handle tts errors with prompts

### DIFF
--- a/website/glancy-website/src/components/index.js
+++ b/website/glancy-website/src/components/index.js
@@ -9,6 +9,7 @@ export { default as HistoryDisplay } from './ui/HistoryDisplay'
 export { default as ICP } from './ui/ICP'
 export { default as Loader } from './ui/Loader'
 export { default as MessagePopup } from './ui/MessagePopup'
+export { default as Toast } from './ui/Toast'
 export { default as VoiceSelector } from './tts/VoiceSelector.jsx'
 export { default as TtsButton } from './tts/TtsButton.jsx'
 

--- a/website/glancy-website/src/components/tts/TtsButton.jsx
+++ b/website/glancy-website/src/components/tts/TtsButton.jsx
@@ -1,7 +1,12 @@
-import { useMemo } from 'react'
+import { useMemo, useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import ThemeIcon from '@/components/ui/Icon'
+import MessagePopup from '@/components/ui/MessagePopup'
+import Toast from '@/components/ui/Toast'
+import UpgradeModal from '@/components/modals/UpgradeModal.jsx'
 import { useTtsPlayer } from '@/hooks/useTtsPlayer.js'
 import { useVoiceStore } from '@/store'
+import { useLanguage } from '@/context'
 import styles from './TtsButton.module.css'
 
 /**
@@ -16,7 +21,12 @@ export default function TtsButton({
   size,
   disabled = false,
 }) {
-  const { play, stop, loading, playing } = useTtsPlayer({ scope })
+  const navigate = useNavigate()
+  const { t } = useLanguage()
+  const { play, stop, loading, playing, error } = useTtsPlayer({ scope })
+  const [toastMsg, setToastMsg] = useState('')
+  const [popupMsg, setPopupMsg] = useState('')
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
   const tooltip = useMemo(
     () => (scope === 'sentence' ? '播放例句发音' : '播放发音'),
     [scope],
@@ -43,16 +53,50 @@ export default function TtsButton({
 
   const iconSize = size || (scope === 'sentence' ? 24 : 20)
 
+  useEffect(() => {
+    if (!error) return
+    switch (error.code) {
+      case 401:
+        navigate('/login')
+        break
+      case 403:
+        setPopupMsg(error.message)
+        break
+      default:
+        setToastMsg(error.message)
+    }
+  }, [error, navigate])
+
   return (
-    <button
-      type="button"
-      className={btnClass}
-      onClick={handleClick}
-      disabled={disabled || loading}
-      aria-label={tooltip}
-      title={tooltip}
-    >
-      <ThemeIcon name="voice-button" width={iconSize} height={iconSize} />
-    </button>
+    <>
+      <button
+        type="button"
+        className={btnClass}
+        onClick={handleClick}
+        disabled={disabled || loading}
+        aria-label={tooltip}
+        title={tooltip}
+      >
+        <ThemeIcon name="voice-button" width={iconSize} height={iconSize} />
+      </button>
+      <MessagePopup
+        open={!!popupMsg}
+        message={popupMsg}
+        onClose={() => setPopupMsg('')}
+      >
+        <button
+          type="button"
+          className={styles['upgrade-btn']}
+          onClick={() => {
+            setUpgradeOpen(true)
+            setPopupMsg('')
+          }}
+        >
+          {t.upgrade}
+        </button>
+      </MessagePopup>
+      <UpgradeModal open={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
+      <Toast open={!!toastMsg} message={toastMsg} onClose={() => setToastMsg('')} />
+    </>
   )
 }

--- a/website/glancy-website/src/components/tts/TtsButton.module.css
+++ b/website/glancy-website/src/components/tts/TtsButton.module.css
@@ -32,6 +32,20 @@
   cursor: not-allowed;
 }
 
+.upgrade-btn {
+  margin-top: var(--space-3);
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.upgrade-btn:hover {
+  opacity: 0.9;
+}
+
 @keyframes pulse {
   0% {
     transform: scale(1);

--- a/website/glancy-website/src/components/ui/MessagePopup/MessagePopup.jsx
+++ b/website/glancy-website/src/components/ui/MessagePopup/MessagePopup.jsx
@@ -2,7 +2,11 @@ import styles from './MessagePopup.module.css'
 import { useEscapeKey } from '@/hooks'
 import { withStopPropagation } from '@/utils/stopPropagation.js'
 
-function MessagePopup({ open, message, onClose }) {
+/**
+ * Generic popup for transient messages.
+ * Accepts optional children for action buttons.
+ */
+function MessagePopup({ open, message, onClose, children }) {
   useEscapeKey(onClose, open)
 
   if (!open) return null
@@ -10,6 +14,7 @@ function MessagePopup({ open, message, onClose }) {
     <div className={styles['popup-overlay']} onClick={onClose}>
       <div className={styles.popup} onClick={withStopPropagation()}>
         <div>{message}</div>
+        {children && <div className={styles.actions}>{children}</div>}
         <button
           type="button"
           onClick={onClose}

--- a/website/glancy-website/src/components/ui/MessagePopup/MessagePopup.module.css
+++ b/website/glancy-website/src/components/ui/MessagePopup/MessagePopup.module.css
@@ -21,3 +21,7 @@
   width: 90%;
   text-align: center;
 }
+
+.actions {
+  margin-top: var(--space-3);
+}

--- a/website/glancy-website/src/components/ui/Toast/Toast.jsx
+++ b/website/glancy-website/src/components/ui/Toast/Toast.jsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+import styles from './Toast.module.css'
+
+/**
+ * Minimal toast message. Auto hides after duration.
+ */
+function Toast({ open, message, duration = 3000, onClose }) {
+  useEffect(() => {
+    if (!open) return
+    const timer = setTimeout(() => {
+      onClose?.()
+    }, duration)
+    return () => clearTimeout(timer)
+  }, [open, duration, onClose])
+
+  if (!open) return null
+  return <div className={styles.toast}>{message}</div>
+}
+
+export default Toast

--- a/website/glancy-website/src/components/ui/Toast/Toast.module.css
+++ b/website/glancy-website/src/components/ui/Toast/Toast.module.css
@@ -1,0 +1,12 @@
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}

--- a/website/glancy-website/src/components/ui/Toast/index.js
+++ b/website/glancy-website/src/components/ui/Toast/index.js
@@ -1,0 +1,1 @@
+export { default } from './Toast.jsx'

--- a/website/glancy-website/src/hooks/__tests__/useTtsPlayer.test.js
+++ b/website/glancy-website/src/hooks/__tests__/useTtsPlayer.test.js
@@ -84,7 +84,7 @@ describe('useTtsPlayer', () => {
       await result.current.play({ text: 'hi', lang: 'en' })
     })
 
-    expect(result.current.error).toBe('请登录后重试')
+    expect(result.current.error).toEqual({ code: 401, message: '请登录后重试' })
   })
 
   /**

--- a/website/glancy-website/src/hooks/useTtsPlayer.js
+++ b/website/glancy-website/src/hooks/useTtsPlayer.js
@@ -72,25 +72,28 @@ export function useTtsPlayer({ scope = 'word' } = {}) {
         if (err instanceof ApiError) {
           switch (err.status) {
             case 401:
-              setError('请登录后重试')
+              setError({ code: 401, message: '请登录后重试' })
               break
             case 403:
-              setError('升级以继续使用或切换可用音色')
+              setError({ code: 403, message: '升级以继续使用或切换可用音色' })
               break
             case 429: {
               const retry = err.headers?.get('Retry-After')
-              setError(`请求过于频繁，请在${retry || '稍后'}秒后重试`)
+              setError({
+                code: 429,
+                message: `请求过于频繁，请在${retry || '稍后'}秒后重试`,
+              })
               break
             }
             case 424:
             case 503:
-              setError('服务繁忙，请稍后再试')
+              setError({ code: err.status, message: '服务繁忙，请稍后再试' })
               break
             default:
-              setError(err.message)
+              setError({ code: err.status, message: err.message })
           }
         } else {
-          setError('网络错误')
+          setError({ code: 0, message: '网络错误' })
         }
       } finally {
         setLoading(false)


### PR DESCRIPTION
## Summary
- surface TTS permission and rate-limit errors with contextual prompts
- extend MessagePopup for custom actions and add reusable Toast component
- navigate to login on unauthorized TTS requests and offer upgrade flow on 403s

## Testing
- `npm test src/hooks/__tests__/useTtsPlayer.test.js src/components/tts/__tests__/TtsButton.test.jsx`
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689b649c6144833297679d75690396ca