### PR TITLE
feat(tts): polish loading and playback feedback

### DIFF
--- a/website/glancy-website/src/components/tts/TtsButton.module.css
+++ b/website/glancy-website/src/components/tts/TtsButton.module.css
@@ -7,7 +7,8 @@
   padding: 0;
   cursor: pointer;
   opacity: 0.6;
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  position: relative;
+  transition: opacity 0.2s ease;
 }
 
 .button:hover,
@@ -17,13 +18,23 @@
 
 .playing {
   opacity: 1;
-  animation: pulse 1.2s infinite;
-  box-shadow: 0 0 0 2px var(--accent-color);
+  color: var(--accent-color);
+}
+
+.playing::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--accent-color);
+  animation: ripple 1.4s ease-out infinite;
 }
 
 .loading {
   opacity: 1;
+}
+
+.loading svg {
   animation: spin 1s linear infinite;
 }
 
@@ -46,26 +57,24 @@
   opacity: 0.9;
 }
 
-@keyframes pulse {
-  0% {
-    transform: scale(1);
-  }
-
-  50% {
-    transform: scale(1.1);
-  }
-
-  100% {
-    transform: scale(1);
-  }
-}
-
 @keyframes spin {
   0% {
     transform: rotate(0deg);
   }
-  
+
   100% {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes ripple {
+  from {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+
+  to {
+    transform: scale(1.6);
+    opacity: 0;
   }
 }

--- a/website/glancy-website/src/components/ui/Toast/Toast.module.css
+++ b/website/glancy-website/src/components/ui/Toast/Toast.module.css
@@ -3,10 +3,10 @@
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.8);
+  background: rgb(0 0 0 / 80%);
   color: #fff;
   padding: 8px 16px;
   border-radius: 4px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
   z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- refine TTS button with ripple playback feedback and icon spin during loading
- modernize toast styles for CSS lint compliance

## Testing
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `NODE_OPTIONS="--experimental-vm-modules" npx jest src/components/tts/__tests__/TtsButton.test.jsx`
- `npm run lint`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_689b6701e9ec8332839f7e0cfa3505b2