### PR TITLE
feat: tolerate TTS storage failures

### DIFF
--- a/backend/src/main/java/com/glancy/backend/service/tts/storage/TtsStorageService.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/storage/TtsStorageService.java
@@ -24,9 +24,9 @@ public interface TtsStorageService {
      * @param audio binary audio payload
      * @param scope word or sentence context
      * @param ttlDays days until the cache entry expires
-     * @return persisted metadata entity
+     * @return persisted metadata entity, or {@link Optional#empty()} if the operation fails
      */
-    TtsAudio save(
+    Optional<TtsAudio> save(
         String hashKey,
         String lang,
         String voiceId,

--- a/backend/src/test/java/com/glancy/backend/service/tts/storage/TtsStorageServiceImplTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/storage/TtsStorageServiceImplTest.java
@@ -1,10 +1,14 @@
 package com.glancy.backend.service.tts.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 
 import com.glancy.backend.entity.TtsAudio;
 import com.glancy.backend.entity.TtsScope;
@@ -14,6 +18,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -50,20 +55,33 @@ class TtsStorageServiceImplTest {
         when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
         byte[] audio = new byte[] { 1, 2, 3 };
         String hash = "hash";
-        service.save(hash, "en", "v1", "mp3", 500L, audio, TtsScope.WORD, 30);
+        Optional<TtsAudio> result = service.save(hash, "en", "v1", "mp3", 500L, audio, TtsScope.WORD, 30);
 
         String expectedKey = "tts/word/en/2024/01/02/hash.mp3";
         verify(storageClient).putObject(eq(expectedKey), eq(audio));
 
         ArgumentCaptor<TtsAudio> captor = ArgumentCaptor.forClass(TtsAudio.class);
         verify(repository).save(captor.capture());
-        TtsAudio saved = captor.getValue();
+        assertTrue(result.isPresent());
+        TtsAudio saved = result.get();
         assertEquals(expectedKey, saved.getObjectKey());
         assertEquals("en", saved.getLang());
         assertEquals("v1", saved.getVoiceId());
         assertEquals(500L, saved.getDurationMs());
         assertEquals(TtsScope.WORD, saved.getScope());
         assertEquals(LocalDateTime.of(2024, 1, 2, 3, 4, 5).plusDays(30), saved.getExpiredAt());
+    }
+
+    /**
+     * Upload failures should not propagate exceptions and skip caching.
+     */
+    @Test
+    void saveReturnsEmptyWhenUploadFails() {
+        byte[] audio = new byte[] { 1 };
+        doThrow(new RuntimeException("boom")).when(storageClient).putObject(any(), any());
+        Optional<TtsAudio> result = service.save("hash", "en", "v1", "mp3", 100L, audio, TtsScope.WORD, 30);
+        assertFalse(result.isPresent());
+        verify(repository, never()).save(any());
     }
 
     /**


### PR DESCRIPTION
## Summary
- make TTS storage save method optional to avoid breaking flow on failures
- handle OSS upload and metadata persistence errors gracefully and log
- cover storage failure scenario with unit test

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b81ac117c8332ba9e2d0e1e015d34