### PR TITLE
Add parameter verification and masking in TTS model calls

### DIFF
--- a/backend/src/main/java/com/glancy/backend/util/SensitiveDataUtil.java
+++ b/backend/src/main/java/com/glancy/backend/util/SensitiveDataUtil.java
@@ -1,0 +1,37 @@
+package com.glancy.backend.util;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility methods for masking or previewing sensitive data before logging.
+ */
+public final class SensitiveDataUtil {
+    private SensitiveDataUtil() {}
+
+    /**
+     * Masks a credential-like value by keeping only the last four characters.
+     * @param value the original credential
+     * @return masked credential retaining last four characters
+     */
+    public static String maskCredential(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "****";
+        }
+        int unmasked = Math.min(4, value.length());
+        String maskedPart = "*".repeat(value.length() - unmasked);
+        return maskedPart + value.substring(value.length() - unmasked);
+    }
+
+    /**
+     * Produces a short preview of text, limited to ten characters.
+     * Longer text will be truncated and suffixed with ellipsis.
+     * @param text original text
+     * @return preview of the text
+     */
+    public static String previewText(String text) {
+        if (!StringUtils.hasText(text)) {
+            return "";
+        }
+        return text.length() <= 10 ? text : text.substring(0, 10) + "...";
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/util/SensitiveDataUtilTest.java
+++ b/backend/src/test/java/com/glancy/backend/util/SensitiveDataUtilTest.java
@@ -1,0 +1,30 @@
+package com.glancy.backend.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SensitiveDataUtil}. Ensures masking and previewing behave as expected.
+ */
+class SensitiveDataUtilTest {
+
+    /**
+     * Verifies that maskCredential keeps only the last four characters of the original value
+     * to avoid leaking secrets in logs.
+     */
+    @Test
+    void maskCredentialKeepsLastFour() {
+        String masked = SensitiveDataUtil.maskCredential("abcdef1234");
+        assertEquals("******1234", masked);
+    }
+
+    /**
+     * Ensures previewText truncates strings longer than ten characters and appends an ellipsis.
+     */
+    @Test
+    void previewTextTruncatesLongInput() {
+        String preview = SensitiveDataUtil.previewText("hello world");
+        assertEquals("hello worl...", preview);
+    }
+}


### PR DESCRIPTION
## Summary
- add SensitiveDataUtil for credential masking and text preview
- log sanitized parameters and missing required params in VolcengineTtsClient
- test masking utilities

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e204c948332b089ec3f5cae044e