### PR TITLE
feat: allow clicking words to hear pronunciation

### DIFF
--- a/website/glancy-website/src/components/index.js
+++ b/website/glancy-website/src/components/index.js
@@ -12,6 +12,7 @@ export { default as MessagePopup } from './ui/MessagePopup'
 export { default as Toast } from './ui/Toast'
 export { default as VoiceSelector } from './tts/VoiceSelector.jsx'
 export { default as TtsButton } from './tts/TtsButton.jsx'
+export { default as PronounceableWord } from './tts/PronounceableWord.jsx'
 
 export { default as AuthForm } from './form/AuthForm.jsx'
 export { default as AgeStepper } from './form/AgeStepper/AgeStepper.jsx'

--- a/website/glancy-website/src/components/tts/PronounceableWord.jsx
+++ b/website/glancy-website/src/components/tts/PronounceableWord.jsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import MessagePopup from '@/components/ui/MessagePopup'
+import Toast from '@/components/ui/Toast'
+import UpgradeModal from '@/components/modals/UpgradeModal.jsx'
+import { useTtsPlayer } from '@/hooks/useTtsPlayer.js'
+import { useVoiceStore } from '@/store'
+import { useLanguage } from '@/context'
+import styles from './PronounceableWord.module.css'
+
+/**
+ * Text element that plays word pronunciation when clicked.
+ * Mirrors error handling of TtsButton for consistent UX.
+ */
+export default function PronounceableWord({ text, lang, className }) {
+  const navigate = useNavigate()
+  const { t } = useLanguage()
+  const { play, stop, loading, playing, error } = useTtsPlayer({ scope: 'word' })
+  const [toastMsg, setToastMsg] = useState('')
+  const [popupMsg, setPopupMsg] = useState('')
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
+
+  const handleClick = async () => {
+    if (loading) return
+    if (playing) {
+      stop()
+      return
+    }
+    const voice = useVoiceStore.getState().getVoice(lang)
+    await play({ text, lang, voice })
+  }
+
+  useEffect(() => {
+    if (!error) return
+    switch (error.code) {
+      case 401:
+        navigate('/login')
+        break
+      case 403:
+        setPopupMsg(error.message)
+        break
+      default:
+        setToastMsg(error.message)
+    }
+  }, [error, navigate])
+
+  const cls = [
+    styles.word,
+    playing && styles.playing,
+    loading && styles.loading,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <>
+      <span
+        role="button"
+        tabIndex={0}
+        className={cls}
+        onClick={handleClick}
+        onKeyDown={(e) => e.key === 'Enter' && handleClick()}
+        aria-label="播放发音"
+      >
+        {text}
+      </span>
+      <MessagePopup
+        open={!!popupMsg}
+        message={popupMsg}
+        onClose={() => setPopupMsg('')}
+      >
+        <button
+          type="button"
+          className={styles['upgrade-btn']}
+          onClick={() => {
+            setUpgradeOpen(true)
+            setPopupMsg('')
+          }}
+        >
+          {t.upgrade}
+        </button>
+      </MessagePopup>
+      <UpgradeModal open={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
+      <Toast open={!!toastMsg} message={toastMsg} onClose={() => setToastMsg('')} />
+    </>
+  )
+}

--- a/website/glancy-website/src/components/tts/PronounceableWord.module.css
+++ b/website/glancy-website/src/components/tts/PronounceableWord.module.css
@@ -1,0 +1,54 @@
+.word {
+  cursor: pointer;
+  position: relative;
+  display: inline-block;
+  transition: color 0.2s ease;
+}
+
+.word::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 1px;
+  background: currentcolor;
+  transform: scaleX(0);
+  transition: transform 0.2s ease;
+}
+
+.word:hover,
+.word:focus {
+  color: var(--accent-color);
+}
+
+.word:hover::after,
+.word:focus::after {
+  transform: scaleX(1);
+}
+
+.playing {
+  color: var(--accent-color);
+}
+
+.playing::after {
+  transform: scaleX(1);
+}
+
+.loading {
+  opacity: 0.6;
+}
+
+.upgrade-btn {
+  margin-top: var(--space-3);
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.upgrade-btn:hover {
+  opacity: 0.9;
+}

--- a/website/glancy-website/src/components/tts/__tests__/PronounceableWord.test.jsx
+++ b/website/glancy-website/src/components/tts/__tests__/PronounceableWord.test.jsx
@@ -1,0 +1,110 @@
+/* eslint-env jest */
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { jest } from '@jest/globals'
+
+// mock hooks and UI components to isolate pronunciation behavior
+const play = jest.fn()
+const stop = jest.fn()
+const useTtsPlayer = jest.fn(() => ({
+  play,
+  stop,
+  loading: false,
+  playing: false,
+  error: null,
+}))
+
+jest.unstable_mockModule('@/hooks/useTtsPlayer.js', () => ({ useTtsPlayer }))
+
+const navigate = jest.fn()
+jest.unstable_mockModule('react-router-dom', () => ({ useNavigate: () => navigate }))
+
+jest.unstable_mockModule('@/context', () => ({
+  useLanguage: () => ({ t: { upgrade: '升级' } }),
+  useApiContext: () => ({}),
+  useTheme: () => ({ resolvedTheme: 'light' }),
+  useLocale: () => ({ locale: 'en-US' }),
+  useAppContext: () => ({}),
+}))
+
+jest.unstable_mockModule('@/components/ui/MessagePopup', () => ({
+  __esModule: true,
+  default: ({ open, message, children }) =>
+    open ? (
+      <div>
+        <span>{message}</span>
+        {children}
+      </div>
+    ) : null,
+}))
+
+jest.unstable_mockModule('@/components/ui/Toast', () => ({
+  __esModule: true,
+  default: ({ open, message }) => (open ? <div>{message}</div> : null),
+}))
+
+jest.unstable_mockModule('@/components/modals/UpgradeModal.jsx', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+const { default: PronounceableWord } = await import('@/components/tts/PronounceableWord.jsx')
+
+describe('PronounceableWord', () => {
+  afterEach(() => {
+    play.mockReset()
+    stop.mockReset()
+    useTtsPlayer.mockClear()
+  })
+
+  /**
+   * Clicking text invokes play with provided parameters.
+   */
+  test('invokes play on click', () => {
+    const { getByText } = render(<PronounceableWord text="hello" lang="en" />)
+    fireEvent.click(getByText('hello'))
+    expect(play).toHaveBeenCalledWith({ text: 'hello', lang: 'en', voice: undefined })
+  })
+
+  /**
+   * When already playing, click stops playback.
+   */
+  test('stops when playing', () => {
+    useTtsPlayer.mockReturnValueOnce({ play, stop, loading: false, playing: true, error: null })
+    const { getByText } = render(<PronounceableWord text="hi" lang="en" />)
+    fireEvent.click(getByText('hi'))
+    expect(stop).toHaveBeenCalled()
+    expect(play).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Forbidden errors show upgrade popup.
+   */
+  test('renders upgrade popup on 403 error', async () => {
+    useTtsPlayer.mockReturnValueOnce({
+      play,
+      stop,
+      loading: false,
+      playing: false,
+      error: { code: 403, message: 'Pro only' },
+    })
+    const { findByText } = render(<PronounceableWord text="hi" lang="en" />)
+    expect(await findByText('Pro only')).toBeInTheDocument()
+    expect(await findByText('升级')).toBeInTheDocument()
+  })
+
+  /**
+   * Rate limit errors render toast.
+   */
+  test('renders toast on 429 error', async () => {
+    useTtsPlayer.mockReturnValueOnce({
+      play,
+      stop,
+      loading: false,
+      playing: false,
+      error: { code: 429, message: 'Too many' },
+    })
+    const { findByText } = render(<PronounceableWord text="hi" lang="en" />)
+    expect(await findByText('Too many')).toBeInTheDocument()
+  })
+})

--- a/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
+++ b/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
@@ -1,5 +1,5 @@
 import { useLanguage } from '@/context'
-import { TtsButton } from '@/components'
+import { TtsButton, PronounceableWord } from '@/components'
 import styles from './DictionaryEntry.module.css'
 
 function DictionaryEntry({ entry }) {
@@ -66,8 +66,7 @@ function DictionaryEntry({ entry }) {
     <article className={styles['dictionary-entry']}>
       {term && (
         <h2 className={styles['section-title']}>
-          {term}
-          <TtsButton text={term} lang={lang} scope="word" />
+          <PronounceableWord text={term} lang={lang} />
         </h2>
       )}
       {phoneticText && (


### PR DESCRIPTION
## Summary
- add PronounceableWord component for clickable word audio playback
- integrate PronounceableWord into dictionary entries
- cover pronunciation component with unit tests

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test` *(fails: JavaScript heap out of memory after suites passed)*
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npm test src/components/tts/__tests__/PronounceableWord.test.jsx src/components/tts/__tests__/TtsButton.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_689b8e6ee9b48332aaddc38749d4bff7