### PR TITLE
feat: add tts controls to top bar

### DIFF
--- a/website/glancy-website/src/components/TopBar/DesktopTopBar.jsx
+++ b/website/glancy-website/src/components/TopBar/DesktopTopBar.jsx
@@ -1,14 +1,16 @@
 import styles from './DesktopTopBar.module.css'
 import common from './TopBarCommon.module.css'
 import TopBarActions from './TopBarActions.jsx'
+import { TtsButton } from '@/components'
 
 function DesktopTopBar({
   term = '',
+  lang,
   showBack = false,
   onBack,
   favorited = false,
   onToggleFavorite,
-  canFavorite = false
+  canFavorite = false,
 }) {
 
   return (
@@ -20,7 +22,10 @@ function DesktopTopBar({
       >
         ←
       </button>
-      <div className={`${common['term-text']} ${styles['term-text']}`}>{term}</div>
+      <div className={`${common['term-text']} ${styles['term-text']}`}>
+        <span className={styles['term-label']}>{term}</span>
+        {term && <TtsButton text={term} lang={lang} size={20} />}
+      </div>
       <TopBarActions
         favorited={favorited}
         onToggleFavorite={onToggleFavorite}

--- a/website/glancy-website/src/components/TopBar/DesktopTopBar.module.css
+++ b/website/glancy-website/src/components/TopBar/DesktopTopBar.module.css
@@ -18,7 +18,15 @@
 }
 
 .term-text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   text-align: center;
+}
+
+.term-label {
+  line-height: 1;
 }
 
 .topbar-right .favorite-toggle {

--- a/website/glancy-website/src/components/TopBar/MobileTopBar.jsx
+++ b/website/glancy-website/src/components/TopBar/MobileTopBar.jsx
@@ -1,20 +1,20 @@
-import { useLanguage } from '@/context'
 import ThemeIcon from '@/components/ui/Icon'
 import TopBarActions from './TopBarActions.jsx'
 import common from './TopBarCommon.module.css'
 import styles from './MobileTopBar.module.css'
 import { getBrandText } from '@/utils'
+import { TtsButton } from '@/components'
 
 function MobileTopBar({
   term = '',
+  lang,
   showBack = false,
   onBack,
   favorited = false,
   onToggleFavorite,
   canFavorite = false,
-  onOpenSidebar
+  onOpenSidebar,
 }) {
-  const { lang } = useLanguage()
   const brandText = getBrandText(lang)
 
   return (
@@ -29,7 +29,10 @@ function MobileTopBar({
       >
         ←
       </button>
-      <div className={`${common['term-text']} ${styles['term-text']}`}>{term || brandText}</div>
+      <div className={`${common['term-text']} ${styles['term-text']}`}>
+        <span className={styles['term-label']}>{term || brandText}</span>
+        {term && <TtsButton text={term} lang={lang} size={20} />}
+      </div>
       <TopBarActions
         favorited={favorited}
         onToggleFavorite={onToggleFavorite}

--- a/website/glancy-website/src/components/TopBar/MobileTopBar.module.css
+++ b/website/glancy-website/src/components/TopBar/MobileTopBar.module.css
@@ -19,6 +19,13 @@
 
 .term-text {
   margin-left: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.term-label {
+  line-height: 1;
 }
 
 .mobile-topbar {

--- a/website/glancy-website/src/components/TopBar/__tests__/DesktopTopBar.test.jsx
+++ b/website/glancy-website/src/components/TopBar/__tests__/DesktopTopBar.test.jsx
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+import React from 'react'
+import { render } from '@testing-library/react'
+import { jest } from '@jest/globals'
+
+// mock TtsButton to isolate top bar behaviour
+const TtsButton = jest.fn(() => <div data-testid="tts" />)
+
+jest.unstable_mockModule('@/components', () => ({ TtsButton }))
+
+const { default: DesktopTopBar } = await import('@/components/TopBar/DesktopTopBar.jsx')
+
+describe('DesktopTopBar', () => {
+  afterEach(() => {
+    TtsButton.mockClear()
+  })
+
+  /**
+   * Renders play button when a term is provided.
+   */
+  test('renders tts button for term', () => {
+    render(<DesktopTopBar term="hello" lang="en" />)
+    expect(TtsButton).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'hello', lang: 'en', size: 20 }),
+      {}
+    )
+  })
+
+  /**
+   * Omits play button when term is empty.
+   */
+  test('hides tts button without term', () => {
+    render(<DesktopTopBar term="" lang="en" />)
+    expect(TtsButton).not.toHaveBeenCalled()
+  })
+})

--- a/website/glancy-website/src/components/TopBar/__tests__/MobileTopBar.test.jsx
+++ b/website/glancy-website/src/components/TopBar/__tests__/MobileTopBar.test.jsx
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+import React from 'react'
+import { render } from '@testing-library/react'
+import { jest } from '@jest/globals'
+
+// mock TtsButton to isolate top bar behaviour
+const TtsButton = jest.fn(() => <div data-testid="tts" />)
+
+jest.unstable_mockModule('@/components', () => ({ TtsButton }))
+
+const { default: MobileTopBar } = await import('@/components/TopBar/MobileTopBar.jsx')
+
+describe('MobileTopBar', () => {
+  afterEach(() => {
+    TtsButton.mockClear()
+  })
+
+  /**
+   * Renders play button when a term is provided.
+   */
+  test('renders tts button for term', () => {
+    render(<MobileTopBar term="world" lang="en" />)
+    expect(TtsButton).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'world', lang: 'en', size: 20 }),
+      {}
+    )
+  })
+
+  /**
+   * Omits play button when term is empty.
+   */
+  test('hides tts button without term', () => {
+    render(<MobileTopBar term="" lang="en" />)
+    expect(TtsButton).not.toHaveBeenCalled()
+  })
+})

--- a/website/glancy-website/src/pages/App/index.jsx
+++ b/website/glancy-website/src/pages/App/index.jsx
@@ -147,11 +147,12 @@ function App() {
         }}
         topBarProps={{
           term: entry?.term || '',
+          lang,
           showBack: !showFavorites && fromFavorites,
           onBack: handleBackFromFavorite,
           favorited: favorites.includes(entry?.term),
           onToggleFavorite: toggleFavoriteEntry,
-          canFavorite: !!entry && !showFavorites && !showHistory
+          canFavorite: !!entry && !showFavorites && !showHistory,
         }}
         bottomContent={(
           <ChatInput


### PR DESCRIPTION
## Summary
- add play-pronunciation button beside term in both desktop and mobile top bars
- wire top bar to receive language and tests for new controls

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689c1e4eaa7483329e4453ecdb8e358e