### PR TITLE
feat: stream word audio via new endpoint

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/TtsController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/TtsController.java
@@ -127,6 +127,48 @@ public class TtsController {
     }
 
     /**
+     * Directly streams synthesized audio data for a single word. This mirrors
+     * {@link #streamSentenceAudio} allowing clients that cannot follow
+     * redirects to obtain audio bytes in one request.
+     */
+    @GetMapping(value = "/word/audio", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public ResponseEntity<byte[]> streamWordAudio(
+        @AuthenticatedUser Long userId,
+        HttpServletRequest httpRequest,
+        @RequestParam String text,
+        @RequestParam String lang,
+        @RequestParam(required = false) String voice,
+        @RequestParam(defaultValue = "mp3") String format,
+        @RequestParam(defaultValue = "1.0") double speed
+    ) {
+        TtsRequest req = buildRequest(text, lang, voice, format, speed);
+        String ip = httpRequest.getRemoteAddr();
+        log.info(
+            "Streaming word audio for user={}, ip={}, lang={}, voice={}, text={}",
+            userId,
+            ip,
+            lang,
+            voice,
+            text
+        );
+        Optional<TtsResponse> resp = ttsService.synthesizeWord(userId, ip, req);
+        if (resp.isPresent()) {
+            TtsResponse body = resp.get();
+            byte[] data = restTemplate.getForObject(body.getUrl(), byte[].class);
+            log.info(
+                "Word audio stream succeeded for user={}, durationMs={}, format={}, fromCache={}",
+                userId,
+                body.getDurationMs(),
+                body.getFormat(),
+                body.isFromCache()
+            );
+            return ResponseEntity.ok().header(HttpHeaders.CONTENT_TYPE, "audio/" + body.getFormat()).body(data);
+        }
+        log.info("Word audio stream returned no content for user={}", userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
      * Synthesize pronunciation for a sentence or example phrase.
      */
     @PostMapping("/sentence")


### PR DESCRIPTION
## Summary
- add `/api/tts/word/audio` endpoint to deliver synthesized word audio directly
- stream word and sentence audio through new backend routes in `useTtsPlayer`
- cover new playback flow with updated unit tests

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c22a31a588332986153a587879c87