### PR TITLE
fix: include user context in tts requests

### DIFF
--- a/website/glancy-website/src/api/tts.js
+++ b/website/glancy-website/src/api/tts.js
@@ -1,5 +1,5 @@
-import { API_PATHS } from '@/config/api.js'
-import { apiRequest } from './client.js'
+import { API_PATHS } from "@/config/api.js";
+import { apiRequest } from "./client.js";
 
 /**
  * Create TTS API helpers.
@@ -7,19 +7,24 @@ import { apiRequest } from './client.js'
  * content type, allowing callers to handle 204 responses gracefully.
  */
 export function createTtsApi(request = apiRequest) {
-  const post = (path, body) =>
-    request(path, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body)
-    })
+  const post = (path, { userId, token, ...body }) => {
+    const params = new URLSearchParams({ userId });
+    return request(`${path}?${params.toString()}`, {
+      token,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  };
 
-  const speakWord = (body) => post(API_PATHS.ttsWord, body)
-  const speakSentence = (body) => post(API_PATHS.ttsSentence, body)
-  const fetchVoices = ({ lang }) => request(`${API_PATHS.ttsVoices}?lang=${encodeURIComponent(lang)}`)
+  const speakWord = (opts) => post(API_PATHS.ttsWord, opts);
+  const speakSentence = (opts) => post(API_PATHS.ttsSentence, opts);
+  const fetchVoices = ({ userId, lang, token }) => {
+    const params = new URLSearchParams({ userId, lang });
+    return request(`${API_PATHS.ttsVoices}?${params.toString()}`, { token });
+  };
 
-  return { speakWord, speakSentence, fetchVoices }
+  return { speakWord, speakSentence, fetchVoices };
 }
 
-export const { speakWord, speakSentence, fetchVoices } = createTtsApi(
-)
+export const { speakWord, speakSentence, fetchVoices } = createTtsApi();

--- a/website/glancy-website/src/components/tts/VoiceSelector.jsx
+++ b/website/glancy-website/src/components/tts/VoiceSelector.jsx
@@ -1,50 +1,50 @@
-import { useEffect, useState } from 'react'
-import { useApi } from '@/hooks'
-import { useLanguage } from '@/context'
-import { useUserStore, useVoiceStore } from '@/store'
-import styles from './VoiceSelector.module.css'
+import { useEffect, useState } from "react";
+import { useApi } from "@/hooks";
+import { useLanguage } from "@/context";
+import { useUserStore, useVoiceStore } from "@/store";
+import styles from "./VoiceSelector.module.css";
 
 /**
  * Dropdown for selecting available voices for a given language.
  * Voices requiring Pro plan are disabled for non-pro users.
  */
 export default function VoiceSelector({ lang }) {
-  const api = useApi()
-  const { t } = useLanguage()
-  const user = useUserStore((s) => s.user)
-  const [voices, setVoices] = useState([])
-  const selected = useVoiceStore((s) => s.getVoice(lang))
-  const setVoice = useVoiceStore((s) => s.setVoice)
+  const api = useApi();
+  const { t } = useLanguage();
+  const user = useUserStore((s) => s.user);
+  const [voices, setVoices] = useState([]);
+  const selected = useVoiceStore((s) => s.getVoice(lang));
+  const setVoice = useVoiceStore((s) => s.setVoice);
 
   useEffect(() => {
-    let cancelled = false
-    if (!lang) return
+    let cancelled = false;
+    if (!lang || !user?.id) return;
     api.tts
-      .fetchVoices({ lang })
+      .fetchVoices({ lang, userId: user.id })
       .then((list) => {
-        if (!cancelled) setVoices(list)
+        if (!cancelled) setVoices(list);
       })
-      .catch((err) => console.error(err))
+      .catch((err) => console.error(err));
     return () => {
-      cancelled = true
-    }
-  }, [lang, api])
+      cancelled = true;
+    };
+  }, [lang, api, user?.id]);
 
   const isPro = !!(
     user?.member ||
     user?.isPro ||
-    (user?.plan && user.plan !== 'free')
-  )
+    (user?.plan && user.plan !== "free")
+  );
 
   return (
     <select
       className={styles.select}
-      value={selected || ''}
+      value={selected || ""}
       onChange={(e) => setVoice(lang, e.target.value)}
     >
       {voices.map((v) => {
-        const disabled = v.plan === 'pro' && !isPro
-        const label = disabled ? `${v.label} (${t.upgradeAvailable})` : v.label
+        const disabled = v.plan === "pro" && !isPro;
+        const label = disabled ? `${v.label} (${t.upgradeAvailable})` : v.label;
         return (
           <option
             key={v.id}
@@ -54,8 +54,8 @@ export default function VoiceSelector({ lang }) {
           >
             {label}
           </option>
-        )
+        );
       })}
     </select>
-  )
+  );
 }

--- a/website/glancy-website/src/hooks/__tests__/useTtsPlayer.test.js
+++ b/website/glancy-website/src/hooks/__tests__/useTtsPlayer.test.js
@@ -1,125 +1,135 @@
 /* eslint-env jest */
-import { renderHook, act } from '@testing-library/react'
-import { jest } from '@jest/globals'
-import { ApiError } from '@/api/client.js'
+import { renderHook, act } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import { ApiError } from "@/api/client.js";
 
 // mock global Audio element with basic event system
-const playSpy = jest.fn().mockResolvedValue()
-const pauseSpies = []
+const playSpy = jest.fn().mockResolvedValue();
+const pauseSpies = [];
 beforeAll(() => {
   class MockResponse {
     constructor(_body, init = {}) {
-      this.status = init.status
+      this.status = init.status;
     }
   }
-  global.Response = MockResponse
+  global.Response = MockResponse;
   global.Audio = jest.fn().mockImplementation(() => {
-    const handlers = {}
-    const pause = jest.fn(() => handlers.pause?.())
-    pauseSpies.push(pause)
+    const handlers = {};
+    const pause = jest.fn(() => handlers.pause?.());
+    pauseSpies.push(pause);
     return {
       play: playSpy,
       pause,
       addEventListener: jest.fn((e, cb) => {
-        handlers[e] = cb
+        handlers[e] = cb;
       }),
       removeEventListener: jest.fn((e) => {
-        delete handlers[e]
+        delete handlers[e];
       }),
-    }
-  })
-})
+    };
+  });
+});
 
 // mock useApi to supply tts methods
-const speakWord = jest.fn()
-jest.unstable_mockModule('@/hooks/useApi.js', () => ({
+const speakWord = jest.fn();
+jest.unstable_mockModule("@/hooks/useApi.js", () => ({
   useApi: () => ({ tts: { speakWord } }),
-}))
+}));
+jest.unstable_mockModule("@/store", () => ({
+  useUserStore: (sel) => sel({ user: { id: "1" } }),
+}));
 
-const { useTtsPlayer } = await import('@/hooks/useTtsPlayer.js')
+const { useTtsPlayer } = await import("@/hooks/useTtsPlayer.js");
 
-describe('useTtsPlayer', () => {
+describe("useTtsPlayer", () => {
   afterEach(() => {
-    speakWord.mockReset()
-    playSpy.mockClear()
-    pauseSpies.length = 0
-  })
+    speakWord.mockReset();
+    playSpy.mockClear();
+    pauseSpies.length = 0;
+  });
 
   /**
    * Ensures shortcut request retries with shortcut=false when server responds 204
    * and that all parameters are forwarded correctly.
    */
-  test('retries with fallback when cache miss', async () => {
-    speakWord.mockResolvedValueOnce(new Response(null, { status: 204 }))
-    speakWord.mockResolvedValueOnce({ url: 'audio.mp3' })
+  test("retries with fallback when cache miss", async () => {
+    speakWord.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    speakWord.mockResolvedValueOnce({ url: "audio.mp3" });
 
-    const { result } = renderHook(() => useTtsPlayer())
+    const { result } = renderHook(() => useTtsPlayer());
 
     await act(async () => {
-      await result.current.play({ text: 'hi', lang: 'en', voice: 'v1' })
-    })
+      await result.current.play({ text: "hi", lang: "en", voice: "v1" });
+    });
 
     const payload = {
-      text: 'hi',
-      lang: 'en',
-      voice: 'v1',
+      userId: "1",
+      text: "hi",
+      lang: "en",
+      voice: "v1",
       speed: 1,
-      format: 'mp3',
+      format: "mp3",
       shortcut: true,
-    }
-    expect(speakWord).toHaveBeenNthCalledWith(1, payload)
-    expect(speakWord).toHaveBeenNthCalledWith(2, { ...payload, shortcut: false })
-    expect(playSpy).toHaveBeenCalled()
-  })
+    };
+    expect(speakWord).toHaveBeenNthCalledWith(1, payload);
+    expect(speakWord).toHaveBeenNthCalledWith(2, {
+      ...payload,
+      shortcut: false,
+    });
+    expect(playSpy).toHaveBeenCalled();
+  });
 
   /**
    * Confirms 401 errors prompt login feedback.
    */
-  test('handles unauthorized error', async () => {
-    speakWord.mockRejectedValueOnce(new ApiError(401, 'Unauthorized'))
+  test("handles unauthorized error", async () => {
+    speakWord.mockRejectedValueOnce(new ApiError(401, "Unauthorized"));
 
-    const { result } = renderHook(() => useTtsPlayer())
+    const { result } = renderHook(() => useTtsPlayer());
 
     await act(async () => {
-      await result.current.play({ text: 'hi', lang: 'en' })
-    })
+      await result.current.play({ text: "hi", lang: "en" });
+    });
 
-    expect(result.current.error).toEqual({ code: 401, message: '请登录后重试' })
-  })
+    expect(result.current.error).toEqual({
+      code: 401,
+      message: "请登录后重试",
+    });
+  });
 
   /**
    * Verifies stop pauses audio and resets playing flag.
    */
-  test('stop halts playback', async () => {
-    speakWord.mockResolvedValueOnce({ url: 'audio.mp3' })
-    const { result } = renderHook(() => useTtsPlayer())
+  test("stop halts playback", async () => {
+    speakWord.mockResolvedValueOnce({ url: "audio.mp3" });
+    const { result } = renderHook(() => useTtsPlayer());
 
     await act(async () => {
-      await result.current.play({ text: 'hi', lang: 'en' })
-    })
-    expect(result.current.playing).toBe(true)
+      await result.current.play({ text: "hi", lang: "en" });
+    });
+    expect(result.current.playing).toBe(true);
 
     await act(() => {
-      result.current.stop()
-    })
-    expect(pauseSpies[0]).toHaveBeenCalled()
-    expect(result.current.playing).toBe(false)
-  })
+      result.current.stop();
+    });
+    expect(pauseSpies[0]).toHaveBeenCalled();
+    expect(result.current.playing).toBe(false);
+  });
 
   /**
    * Ensures a new play request pauses the previous audio element.
    */
-  test('new play pauses previous audio', async () => {
-    speakWord.mockResolvedValue({ url: 'audio.mp3' })
-    const first = renderHook(() => useTtsPlayer())
+  test("new play pauses previous audio", async () => {
+    speakWord.mockResolvedValue({ url: "audio.mp3" });
+    const first = renderHook(() => useTtsPlayer());
     await act(async () => {
-      await first.result.current.play({ text: 'a', lang: 'en' })
-    })
+      await first.result.current.play({ text: "a", lang: "en" });
+    });
 
-    const second = renderHook(() => useTtsPlayer())
+    const second = renderHook(() => useTtsPlayer());
     await act(async () => {
-      await second.result.current.play({ text: 'b', lang: 'en' })
-    })
-    expect(pauseSpies[0]).toHaveBeenCalled()
-  })
-})
+      await second.result.current.play({ text: "b", lang: "en" });
+    });
+    expect(pauseSpies[0]).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- pass userId and token through TTS API helpers
- include userId in TTS playback hook and voice selector
- update unit tests for user-aware TTS requests

## Testing
- `npx eslint src/api/tts.js src/hooks/useTtsPlayer.js src/components/tts/VoiceSelector.jsx src/hooks/__tests__/useTtsPlayer.test.js --fix`
- `npx stylelint src/components/tts/VoiceSelector.module.css --fix`
- `npx prettier -w src/api/tts.js src/hooks/useTtsPlayer.js src/components/tts/VoiceSelector.jsx src/hooks/__tests__/useTtsPlayer.test.js`
- `npm test`
- `./mvnw -q spotless:apply` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ca971a39c83329651e5095ea0a3a7