### PR TITLE
feat: centralize oss client configuration

### DIFF
--- a/backend/src/main/java/com/glancy/backend/config/OssClientConfig.java
+++ b/backend/src/main/java/com/glancy/backend/config/OssClientConfig.java
@@ -1,0 +1,56 @@
+package com.glancy.backend.config;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Centralizes creation of the Aliyun OSS client so that all services share
+ * a single, properly configured instance.
+ */
+@Configuration
+@Slf4j
+public class OssClientConfig {
+
+    @Bean(destroyMethod = "shutdown")
+    public OSS ossClient(OssProperties properties) {
+        OSS client = buildClient(properties.getEndpoint(), properties);
+        if (properties.isVerifyLocation()) {
+            try {
+                String location = client.getBucketLocation(properties.getBucket());
+                String expected = formatEndpoint(location);
+                String configured = removeProtocol(properties.getEndpoint());
+                if (!configured.contains(location)) {
+                    client.shutdown();
+                    client = buildClient(expected, properties);
+                    properties.setEndpoint(expected);
+                }
+            } catch (Exception e) {
+                log.warn("Failed to verify OSS endpoint: {}", e.getMessage());
+            }
+        }
+        return client;
+    }
+
+    private OSS buildClient(String endpoint, OssProperties props) {
+        OSSClientBuilder builder = new OSSClientBuilder();
+        if (props.getSecurityToken() != null && !props.getSecurityToken().isEmpty()) {
+            return builder.build(endpoint, props.getAccessKeyId(), props.getAccessKeySecret(), props.getSecurityToken());
+        }
+        return builder.build(endpoint, props.getAccessKeyId(), props.getAccessKeySecret());
+    }
+
+    private static String removeProtocol(String url) {
+        return url.replaceFirst("https?://", "");
+    }
+
+    private static String formatEndpoint(String location) {
+        String loc = location.startsWith("http") ? removeProtocol(location) : location;
+        if (!loc.startsWith("oss-")) {
+            loc = "oss-" + loc;
+        }
+        return "https://" + loc + ".aliyuncs.com";
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
@@ -1,6 +1,5 @@
 package com.glancy.backend.service;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import com.aliyun.oss.OSS;
@@ -18,22 +17,6 @@ import org.springframework.mock.web.MockMultipartFile;
 class OssAvatarStorageTest {
 
     /**
-     * 测试 uploadWithoutClientThrows 接口
-     */
-    @Test
-    void uploadWithoutClientThrows() {
-        OssProperties props = new OssProperties();
-        props.setEndpoint("https://oss-cn-beijing.aliyuncs.com");
-        props.setBucket("bucket");
-        props.setAccessKeyId("");
-        props.setAccessKeySecret("");
-        props.setAvatarDir("avatars/");
-        OssAvatarStorage storage = new OssAvatarStorage(props);
-        MockMultipartFile file = new MockMultipartFile("file", "avatar.jpg", "image/jpeg", "data".getBytes());
-        assertThrows(IllegalStateException.class, () -> storage.upload(file));
-    }
-
-    /**
      * 测试 setPublicReadAcl failure is swallowed
      */
     @Test
@@ -46,19 +29,14 @@ class OssAvatarStorageTest {
         props.setAvatarDir("avatars/");
         props.setPublicRead(true);
 
-        OssAvatarStorage storage = new OssAvatarStorage(props);
-
         OSS client = mock(OSS.class);
+        OssAvatarStorage storage = new OssAvatarStorage(client, props);
         when(client.putObject(eq("bucket"), anyString(), any(java.io.InputStream.class))).thenReturn(null);
         OSSException ex = new OSSException("AccessDenied");
         doThrow(ex).when(client).setObjectAcl(eq("bucket"), anyString(), eq(CannedAccessControlList.PublicRead));
         when(client.generatePresignedUrl(eq("bucket"), anyString(), any(Date.class))).thenReturn(
             new java.net.URL("https://example.com")
         );
-
-        var field = OssAvatarStorage.class.getDeclaredField("ossClient");
-        field.setAccessible(true);
-        field.set(storage, client);
 
         MockMultipartFile file = new MockMultipartFile("file", "avatar.jpg", "image/jpeg", "data".getBytes());
         storage.upload(file);
@@ -76,17 +54,12 @@ class OssAvatarStorageTest {
         props.setAvatarDir("avatars/");
         props.setPublicRead(false);
 
-        OssAvatarStorage storage = new OssAvatarStorage(props);
-
         OSS client = mock(OSS.class);
+        OssAvatarStorage storage = new OssAvatarStorage(client, props);
         when(client.putObject(eq("bucket"), anyString(), any(java.io.InputStream.class))).thenReturn(null);
         when(client.generatePresignedUrl(eq("bucket"), anyString(), any(Date.class))).thenReturn(
             new java.net.URL("https://example.com")
         );
-
-        var field = OssAvatarStorage.class.getDeclaredField("ossClient");
-        field.setAccessible(true);
-        field.set(storage, client);
 
         MockMultipartFile file = new MockMultipartFile("file", "avatar.jpg", "image/jpeg", "data".getBytes());
         storage.upload(file);
@@ -105,17 +78,12 @@ class OssAvatarStorageTest {
         props.setAvatarDir("avatars/");
         props.setPublicRead(false);
 
-        OssAvatarStorage storage = new OssAvatarStorage(props);
-
         OSS client = mock(OSS.class);
+        OssAvatarStorage storage = new OssAvatarStorage(client, props);
         when(client.putObject(eq("bucket"), anyString(), any(java.io.InputStream.class))).thenReturn(null);
         when(client.generatePresignedUrl(any(GeneratePresignedUrlRequest.class))).thenReturn(
             new java.net.URL("https://example.com")
         );
-
-        var field = OssAvatarStorage.class.getDeclaredField("ossClient");
-        field.setAccessible(true);
-        field.set(storage, client);
 
         MockMultipartFile file = new MockMultipartFile("file", "avatar.jpg", "image/jpeg", "data".getBytes());
         storage.upload(file);


### PR DESCRIPTION
## Summary
- provide shared OSS client bean
- inject shared client into avatar storage service
- adjust avatar storage tests for injected client

## Testing
- `npx eslint . --fix`
- `npx stylelint "**/*.{css,scss,vue}" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply` (failed: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at wrong local POM)
- `mvn -q test` (failed: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at wrong local POM)

------
https://chatgpt.com/codex/tasks/task_e_689cce78052c8332b6b7b9aaa7c23d51