### PR TITLE
feat: expose Volcengine TTS action property

### DIFF
--- a/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
@@ -52,6 +52,7 @@ public class VolcengineTtsClient {
         Map<String, Object> payload = new HashMap<>();
         payload.put("appid", props.getAppId());
         payload.put("access_token", props.getAccessToken());
+        payload.put("action", props.getAction());
         String voice = StringUtils.hasText(request.getVoice()) ? request.getVoice() : props.getVoiceType();
         payload.put("voice_type", voice);
         payload.put("text", request.getText());
@@ -98,7 +99,7 @@ public class VolcengineTtsClient {
     }
 
     private void logPayload(Map<String, Object> payload) {
-        List<String> required = List.of("appid", "access_token", "voice_type", "text", "lang");
+        List<String> required = List.of("appid", "access_token", "action", "voice_type", "text", "lang");
         List<String> missing = new ArrayList<>();
         Map<String, Object> sanitized = new LinkedHashMap<>();
         payload.forEach((k, v) -> {

--- a/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsProperties.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsProperties.java
@@ -18,6 +18,11 @@ public class VolcengineTtsProperties {
     private String accessToken;
     /** Default voice type used when request does not specify one. */
     private String voiceType;
+    /**
+     * Operation of Volcengine TTS service. Defaults to "text_to_speech" and
+     * should match the action name expected by the remote API.
+     */
+    private String action = "text_to_speech";
     /** Base URL of the TTS endpoint. */
     private String apiUrl = "https://open.volcengineapi.com/v1/tts";
 }

--- a/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
@@ -17,8 +17,9 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * Verify that {@link VolcengineTtsClient} constructs requests
- * containing mandatory credentials required by the provider.
+ * Verify that {@link VolcengineTtsClient} constructs requests containing
+ * mandatory credentials required by the provider. The test ensures that the
+ * default action parameter is forwarded alongside authentication data.
  */
 class VolcengineTtsClientTest {
 
@@ -37,6 +38,10 @@ class VolcengineTtsClientTest {
         server = MockRestServiceServer.createServer(restTemplate);
     }
 
+    /**
+     * Ensures {@link VolcengineTtsClient#synthesize} sends authentication,
+     * configuration (voice) and the default action parameter in the JSON payload.
+     */
     @Test
     void includesCredentialsInPayload() {
         server
@@ -45,6 +50,7 @@ class VolcengineTtsClientTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.appid").value("app"))
             .andExpect(jsonPath("$.access_token").value("token"))
+            .andExpect(jsonPath("$.action").value("text_to_speech"))
             .andExpect(jsonPath("$.voice_type").value("v2"))
             .andRespond(
                 withSuccess(


### PR DESCRIPTION
## Summary
- expose `action` field in `VolcengineTtsProperties` with default `text_to_speech`
- include action in VolcengineTtsClient payload and logging
- assert action property in VolcengineTtsClientTest

## Testing
- `npx eslint --fix .` *(fails: ESLint couldn't find configuration)*
- `npx stylelint "**/*.{css,scss}" --fix` *(fails: Could not find stylelint-config-standard)*
- `npx prettier -w .`
- `mvn -f backend/pom.xml spotless:apply` *(fails: Non-resolvable parent POM due to network is unreachable)*
- `mvn -f backend/pom.xml test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e169dd7948332b24815a039422652