### PR TITLE
Wrap TTS client errors with detailed exception

### DIFF
--- a/backend/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -77,8 +77,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(TtsFailedException.class)
     public ResponseEntity<ErrorResponse> handleTtsFailure(TtsFailedException ex) {
-        log.error("TTS failed: {}", ex.getMessage());
-        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.FAILED_DEPENDENCY);
+        String msg = "TTS provider error: " + ex.getMessage();
+        log.error(msg, ex);
+        return new ResponseEntity<>(new ErrorResponse(msg), HttpStatus.FAILED_DEPENDENCY);
     }
 
     @ExceptionHandler(ServiceDegradedException.class)


### PR DESCRIPTION
## Summary
- Wrap RestClientException from VolcengineTtsClient.synthesize into TtsFailedException with status and body preview
- Log and surface provider error details in GlobalExceptionHandler.handleTtsFailure
- Cover TTS client 4xx/5xx error translation in tests

## Testing
- `npx eslint --fix backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java` *(fails: ESLint couldn't find an eslint.config file)*
- `npx stylelint backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java --fix` *(fails: stylelint package missing)*
- `npx prettier -w backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java backend/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java` *(fails: No parser could be inferred for file)*
- `mvn spotless:apply` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e16b097348332bd3df0308cfd00f4