### PR TITLE
Remove user ID from authenticated endpoints

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/NotificationController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.controller;
 
+import com.glancy.backend.config.auth.AuthenticatedUser;
 import com.glancy.backend.dto.NotificationRequest;
 import com.glancy.backend.dto.NotificationResponse;
 import com.glancy.backend.service.NotificationService;
@@ -38,9 +39,9 @@ public class NotificationController {
      * Create a notification for a specific user. This serves the
      * requirement of user targeted messages.
      */
-    @PostMapping("/user/{userId}")
+    @PostMapping("/user")
     public ResponseEntity<NotificationResponse> createUser(
-        @PathVariable Long userId,
+        @AuthenticatedUser Long userId,
         @Valid @RequestBody NotificationRequest req
     ) {
         NotificationResponse resp = notificationService.createUserNotification(userId, req);
@@ -51,8 +52,8 @@ public class NotificationController {
      * Retrieve all notifications available to a user including
      * system announcements.
      */
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<List<NotificationResponse>> getForUser(@PathVariable Long userId) {
+    @GetMapping("/user")
+    public ResponseEntity<List<NotificationResponse>> getForUser(@AuthenticatedUser Long userId) {
         List<NotificationResponse> resp = notificationService.getNotificationsForUser(userId);
         return ResponseEntity.ok(resp);
     }

--- a/backend/src/main/java/com/glancy/backend/controller/SearchRecordController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/SearchRecordController.java
@@ -30,7 +30,7 @@ public class SearchRecordController {
      * Record a search term for a user. Non-members are limited to
      * 10 searches per day as enforced in the service layer.
      */
-    @PostMapping("/user/{userId}")
+    @PostMapping("/user")
     public ResponseEntity<SearchRecordResponse> create(
         @AuthenticatedUser Long userId,
         @Valid @RequestBody SearchRecordRequest req
@@ -42,7 +42,7 @@ public class SearchRecordController {
     /**
      * Get a user's search history ordered by latest first.
      */
-    @GetMapping("/user/{userId}")
+    @GetMapping("/user")
     public ResponseEntity<List<SearchRecordResponse>> list(@AuthenticatedUser Long userId) {
         List<SearchRecordResponse> resp = searchRecordService.getRecords(userId);
         return ResponseEntity.ok(resp);
@@ -51,7 +51,7 @@ public class SearchRecordController {
     /**
      * Clear all search records for a user.
      */
-    @DeleteMapping("/user/{userId}")
+    @DeleteMapping("/user")
     public ResponseEntity<Void> clear(@AuthenticatedUser Long userId) {
         searchRecordService.clearRecords(userId);
         return ResponseEntity.noContent().build();
@@ -60,8 +60,11 @@ public class SearchRecordController {
     /**
      * Mark a search record as favorite for the user.
      */
-    @PostMapping("/user/{userId}/{recordId}/favorite")
-    public ResponseEntity<SearchRecordResponse> favorite(@AuthenticatedUser Long userId, @PathVariable Long recordId) {
+    @PostMapping("/user/{recordId}/favorite")
+    public ResponseEntity<SearchRecordResponse> favorite(
+        @AuthenticatedUser Long userId,
+        @PathVariable Long recordId
+    ) {
         SearchRecordResponse resp = searchRecordService.favoriteRecord(userId, recordId);
         return ResponseEntity.ok(resp);
     }
@@ -69,8 +72,11 @@ public class SearchRecordController {
     /**
      * Cancel favorite for a specific search record of the user.
      */
-    @DeleteMapping("/user/{userId}/{recordId}/favorite")
-    public ResponseEntity<Void> unfavorite(@AuthenticatedUser Long userId, @PathVariable Long recordId) {
+    @DeleteMapping("/user/{recordId}/favorite")
+    public ResponseEntity<Void> unfavorite(
+        @AuthenticatedUser Long userId,
+        @PathVariable Long recordId
+    ) {
         searchRecordService.unfavoriteRecord(userId, recordId);
         return ResponseEntity.noContent().build();
     }
@@ -78,8 +84,11 @@ public class SearchRecordController {
     /**
      * Delete a specific search record of a user.
      */
-    @DeleteMapping("/user/{userId}/{recordId}")
-    public ResponseEntity<Void> delete(@AuthenticatedUser Long userId, @PathVariable Long recordId) {
+    @DeleteMapping("/user/{recordId}")
+    public ResponseEntity<Void> delete(
+        @AuthenticatedUser Long userId,
+        @PathVariable Long recordId
+    ) {
         searchRecordService.deleteRecord(userId, recordId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/glancy/backend/controller/UserPreferenceController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/UserPreferenceController.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.controller;
 
+import com.glancy.backend.config.auth.AuthenticatedUser;
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
 import com.glancy.backend.service.UserPreferenceService;
@@ -26,9 +27,9 @@ public class UserPreferenceController {
     /**
      * Persist UI and language preferences for a user.
      */
-    @PostMapping("/user/{userId}")
+    @PostMapping("/user")
     public ResponseEntity<UserPreferenceResponse> savePreference(
-        @PathVariable Long userId,
+        @AuthenticatedUser Long userId,
         @Valid @RequestBody UserPreferenceRequest req
     ) {
         UserPreferenceResponse resp = userPreferenceService.savePreference(userId, req);
@@ -38,8 +39,8 @@ public class UserPreferenceController {
     /**
      * Retrieve preferences previously saved for the user.
      */
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<UserPreferenceResponse> getPreference(@PathVariable Long userId) {
+    @GetMapping("/user")
+    public ResponseEntity<UserPreferenceResponse> getPreference(@AuthenticatedUser Long userId) {
         UserPreferenceResponse resp = userPreferenceService.getPreference(userId);
         return ResponseEntity.ok(resp);
     }

--- a/backend/src/main/java/com/glancy/backend/controller/UserProfileController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/UserProfileController.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.controller;
 
+import com.glancy.backend.config.auth.AuthenticatedUser;
 import com.glancy.backend.dto.UserProfileRequest;
 import com.glancy.backend.dto.UserProfileResponse;
 import com.glancy.backend.service.UserProfileService;
@@ -25,9 +26,9 @@ public class UserProfileController {
     /**
      * Save profile for a user.
      */
-    @PostMapping("/user/{userId}")
+    @PostMapping("/user")
     public ResponseEntity<UserProfileResponse> saveProfile(
-        @PathVariable Long userId,
+        @AuthenticatedUser Long userId,
         @RequestBody UserProfileRequest req
     ) {
         UserProfileResponse resp = userProfileService.saveProfile(userId, req);
@@ -37,8 +38,8 @@ public class UserProfileController {
     /**
      * Retrieve profile for a user.
      */
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<UserProfileResponse> getProfile(@PathVariable Long userId) {
+    @GetMapping("/user")
+    public ResponseEntity<UserProfileResponse> getProfile(@AuthenticatedUser Long userId) {
         UserProfileResponse resp = userProfileService.getProfile(userId);
         return ResponseEntity.ok(resp);
     }

--- a/backend/src/test/java/com/glancy/backend/config/TokenAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/glancy/backend/config/TokenAuthenticationFilterTest.java
@@ -38,7 +38,7 @@ class TokenAuthenticationFilterTest {
      */
     @Test
     void missingTokenReturnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/api/search-records/user/7")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/search-records/user")).andExpect(status().isUnauthorized());
     }
 
     /**
@@ -49,7 +49,9 @@ class TokenAuthenticationFilterTest {
         when(userService.authenticateToken("good")).thenReturn(7L);
         when(searchRecordService.getRecords(7L)).thenReturn(Collections.emptyList());
 
-        mockMvc.perform(get("/api/search-records/user/7").header("X-USER-TOKEN", "good")).andExpect(status().isOk());
+        mockMvc
+            .perform(get("/api/search-records/user").header("X-USER-TOKEN", "good"))
+            .andExpect(status().isOk());
     }
 
     /**
@@ -60,7 +62,7 @@ class TokenAuthenticationFilterTest {
         when(userService.authenticateToken("bad")).thenThrow(new IllegalArgumentException("invalid"));
 
         mockMvc
-            .perform(get("/api/search-records/user/7").header("X-USER-TOKEN", "bad"))
+            .perform(get("/api/search-records/user").header("X-USER-TOKEN", "bad"))
             .andExpect(status().isUnauthorized());
     }
 
@@ -72,6 +74,8 @@ class TokenAuthenticationFilterTest {
         when(userService.authenticateToken("tkn")).thenReturn(7L);
         when(searchRecordService.getRecords(7L)).thenReturn(Collections.emptyList());
 
-        mockMvc.perform(get("/api/search-records/user/7").param("token", "tkn")).andExpect(status().isOk());
+        mockMvc
+            .perform(get("/api/search-records/user").param("token", "tkn"))
+            .andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -58,7 +58,7 @@ class SearchRecordControllerTest {
 
         mockMvc
             .perform(
-                post("/api/search-records/user/1")
+                post("/api/search-records/user")
                     .header("X-USER-TOKEN", "tkn")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{\"term\":\"hello\",\"language\":\"ENGLISH\"}")
@@ -86,7 +86,7 @@ class SearchRecordControllerTest {
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 
         mockMvc
-            .perform(get("/api/search-records/user/1").header("X-USER-TOKEN", "tkn"))
+            .perform(get("/api/search-records/user").header("X-USER-TOKEN", "tkn"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].id").value(1))
             .andExpect(jsonPath("$[0].term").value("hello"));

--- a/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -20,7 +20,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserPreferenceController.class)
-@Import(com.glancy.backend.config.security.SecurityConfig.class)
+@Import(
+    {
+        com.glancy.backend.config.security.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
+    }
+)
 class UserPreferenceControllerTest {
 
     @Autowired
@@ -49,9 +55,12 @@ class UserPreferenceControllerTest {
         req.setSearchLanguage("en");
         req.setDictionaryModel(DictionaryModel.DEEPSEEK);
 
+        when(userService.authenticateToken("tkn")).thenReturn(2L);
+
         mockMvc
             .perform(
-                post("/api/preferences/user/2")
+                post("/api/preferences/user")
+                    .header("X-USER-TOKEN", "tkn")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(req))
             )
@@ -67,8 +76,10 @@ class UserPreferenceControllerTest {
         UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en", DictionaryModel.DEEPSEEK);
         when(userPreferenceService.getPreference(2L)).thenReturn(resp);
 
+        when(userService.authenticateToken("tkn")).thenReturn(2L);
+
         mockMvc
-            .perform(get("/api/preferences/user/2"))
+            .perform(get("/api/preferences/user").header("X-USER-TOKEN", "tkn"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.userId").value(2L));
     }

--- a/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
@@ -19,7 +19,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserProfileController.class)
-@Import(com.glancy.backend.config.security.SecurityConfig.class)
+@Import(
+    {
+        com.glancy.backend.config.security.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
+    }
+)
 class UserProfileControllerTest {
 
     @Autowired
@@ -49,9 +55,12 @@ class UserProfileControllerTest {
         req.setInterest("code");
         req.setGoal("learn");
 
+        when(userService.authenticateToken("tkn")).thenReturn(2L);
+
         mockMvc
             .perform(
-                post("/api/profiles/user/2")
+                post("/api/profiles/user")
+                    .header("X-USER-TOKEN", "tkn")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(req))
             )
@@ -67,8 +76,10 @@ class UserProfileControllerTest {
         UserProfileResponse resp = new UserProfileResponse(1L, 2L, 20, "M", "dev", "code", "learn");
         when(userProfileService.getProfile(2L)).thenReturn(resp);
 
+        when(userService.authenticateToken("tkn")).thenReturn(2L);
+
         mockMvc
-            .perform(get("/api/profiles/user/2"))
+            .perform(get("/api/profiles/user").header("X-USER-TOKEN", "tkn"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.userId").value(2L));
     }

--- a/website/glancy-website/src/api/__tests__/searchRecords.test.js
+++ b/website/glancy-website/src/api/__tests__/searchRecords.test.js
@@ -1,17 +1,19 @@
-import { createSearchRecordsApi } from '@/api/searchRecords.js'
-import { API_PATHS } from '@/config/api.js'
-import { jest } from '@jest/globals'
+import { createSearchRecordsApi } from "@/api/searchRecords.js";
+import { API_PATHS } from "@/config/api.js";
+import { jest } from "@jest/globals";
 
-test('fetchSearchRecords calls with token', async () => {
-  const request = jest.fn().mockResolvedValue([])
-  const api = createSearchRecordsApi(request)
-  await api.fetchSearchRecords({ userId: 'u', token: 't' })
-  expect(request).toHaveBeenCalledWith(`${API_PATHS.searchRecords}/user/u`, { token: 't' })
-})
+test("fetchSearchRecords calls with token", async () => {
+  const request = jest.fn().mockResolvedValue([]);
+  const api = createSearchRecordsApi(request);
+  await api.fetchSearchRecords({ token: "t" });
+  expect(request).toHaveBeenCalledWith(`${API_PATHS.searchRecords}/user`, {
+    token: "t",
+  });
+});
 
-test('deleteSearchRecord uses record id', async () => {
-  const request = jest.fn().mockResolvedValue()
-  const api = createSearchRecordsApi(request)
-  await api.deleteSearchRecord({ userId: 'u', recordId: 'r1', token: 't' })
-  expect(request.mock.calls[0][0]).toBe(`${API_PATHS.searchRecords}/user/u/r1`)
-})
+test("deleteSearchRecord uses record id", async () => {
+  const request = jest.fn().mockResolvedValue();
+  const api = createSearchRecordsApi(request);
+  await api.deleteSearchRecord({ recordId: "r1", token: "t" });
+  expect(request.mock.calls[0][0]).toBe(`${API_PATHS.searchRecords}/user/r1`);
+});

--- a/website/glancy-website/src/api/searchRecords.js
+++ b/website/glancy-website/src/api/searchRecords.js
@@ -1,48 +1,42 @@
-import { API_PATHS } from '@/config/api.js'
-import { apiRequest, createJsonRequest } from './client.js'
-import { useApi } from '@/hooks'
+import { API_PATHS } from "@/config/api.js";
+import { apiRequest, createJsonRequest } from "./client.js";
+import { useApi } from "@/hooks";
 
 export function createSearchRecordsApi(request = apiRequest) {
-  const jsonRequest = createJsonRequest(request)
-  const fetchSearchRecords = ({ userId, token }) =>
-    request(`${API_PATHS.searchRecords}/user/${userId}`, { token })
+  const jsonRequest = createJsonRequest(request);
+  const fetchSearchRecords = ({ token }) =>
+    request(`${API_PATHS.searchRecords}/user`, { token });
 
-  const saveSearchRecord = ({ userId, token, term, language }) =>
-    jsonRequest(`${API_PATHS.searchRecords}/user/${userId}`, {
-      method: 'POST',
+  const saveSearchRecord = ({ token, term, language }) =>
+    jsonRequest(`${API_PATHS.searchRecords}/user`, {
+      method: "POST",
       token,
-      body: { term, language }
-    })
+      body: { term, language },
+    });
 
-  const clearSearchRecords = ({ userId, token }) =>
-    request(`${API_PATHS.searchRecords}/user/${userId}`, {
-      method: 'DELETE',
-      token
-    })
+  const clearSearchRecords = ({ token }) =>
+    request(`${API_PATHS.searchRecords}/user`, {
+      method: "DELETE",
+      token,
+    });
 
-  const deleteSearchRecord = ({ userId, recordId, token }) =>
-    request(`${API_PATHS.searchRecords}/user/${userId}/${recordId}`, {
-      method: 'DELETE',
-      token
-    })
+  const deleteSearchRecord = ({ recordId, token }) =>
+    request(`${API_PATHS.searchRecords}/user/${recordId}`, {
+      method: "DELETE",
+      token,
+    });
 
-  const favoriteSearchRecord = ({ userId, token, recordId }) =>
-    request(
-      `${API_PATHS.searchRecords}/user/${userId}/${recordId}/favorite`,
-      {
-        method: 'POST',
-        token
-      }
-    )
+  const favoriteSearchRecord = ({ token, recordId }) =>
+    request(`${API_PATHS.searchRecords}/user/${recordId}/favorite`, {
+      method: "POST",
+      token,
+    });
 
-  const unfavoriteSearchRecord = ({ userId, token, recordId }) =>
-    request(
-      `${API_PATHS.searchRecords}/user/${userId}/${recordId}/favorite`,
-      {
-        method: 'DELETE',
-        token
-      }
-    )
+  const unfavoriteSearchRecord = ({ token, recordId }) =>
+    request(`${API_PATHS.searchRecords}/user/${recordId}/favorite`, {
+      method: "DELETE",
+      token,
+    });
 
   return {
     fetchSearchRecords,
@@ -50,8 +44,8 @@ export function createSearchRecordsApi(request = apiRequest) {
     clearSearchRecords,
     deleteSearchRecord,
     favoriteSearchRecord,
-    unfavoriteSearchRecord
-  }
+    unfavoriteSearchRecord,
+  };
 }
 
 export const {
@@ -60,9 +54,9 @@ export const {
   clearSearchRecords,
   deleteSearchRecord,
   favoriteSearchRecord,
-  unfavoriteSearchRecord
-} = createSearchRecordsApi()
+  unfavoriteSearchRecord,
+} = createSearchRecordsApi();
 
 export function useSearchRecordsApi() {
-  return useApi().searchRecords
+  return useApi().searchRecords;
 }


### PR DESCRIPTION
## Summary
- drop `userId` path segments from search record and user-related endpoints
- adjust frontend API calls and stores to rely solely on authenticated user context
- align controller and API tests with new `/user` routes

## Testing
- `npx eslint src/api/searchRecords.js src/api/__tests__/searchRecords.test.js src/store/historyStore.ts --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/api/searchRecords.js src/api/__tests__/searchRecords.test.js src/store/historyStore.ts`
- `npm test` *(fails: JavaScript heap out of memory)*
- `mvn -s /tmp/mvn-settings.xml spotless:apply` *(fails: Network is unreachable)*
- `mvn -s /tmp/mvn-settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e1ac617d883329c5e497e4409515e