### PR TITLE
feat: refactor volcengine tts client payload

### DIFF
--- a/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
@@ -3,8 +3,8 @@ package com.glancy.backend.service.tts.client;
 import com.glancy.backend.dto.TtsRequest;
 import com.glancy.backend.dto.TtsResponse;
 import com.glancy.backend.util.SensitiveDataUtil;
+import com.glancy.backend.service.tts.client.VolcengineTtsPayload;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,21 +52,24 @@ public class VolcengineTtsClient {
      * @return response from remote service
      */
     public TtsResponse synthesize(TtsRequest request) {
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("appid", props.getAppId());
-        payload.put("access_token", props.getAccessToken());
         String voice = StringUtils.hasText(request.getVoice()) ? request.getVoice() : props.getVoiceType();
-        payload.put("voice_type", voice);
-        payload.put("text", request.getText());
-        payload.put("lang", request.getLang());
-        payload.put("format", request.getFormat());
-        payload.put("speed", request.getSpeed());
+        VolcengineTtsPayload payload =
+            VolcengineTtsPayload
+                .builder()
+                .appId(props.getAppId())
+                .accessToken(props.getAccessToken())
+                .voiceType(voice)
+                .text(request.getText())
+                .lang(request.getLang())
+                .format(request.getFormat())
+                .speed(request.getSpeed())
+                .build();
 
         logPayload(payload);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+        HttpEntity<VolcengineTtsPayload> entity = new HttpEntity<>(payload, headers);
         String url =
             UriComponentsBuilder.fromHttpUrl(props.getApiUrl())
                 .queryParam("Action", props.getAction())
@@ -109,19 +112,39 @@ public class VolcengineTtsClient {
         }
     }
 
-    private void logPayload(Map<String, Object> payload) {
-        List<String> required = List.of("appid", "access_token", "voice_type", "text", "lang");
+    private void logPayload(VolcengineTtsPayload payload) {
         List<String> missing = new ArrayList<>();
         Map<String, Object> sanitized = new LinkedHashMap<>();
-        payload.forEach((k, v) -> {
-            boolean hasValue = v != null && (!(v instanceof String) || StringUtils.hasText((String) v));
-            if (required.contains(k) && !hasValue) {
-                missing.add(k);
-            } else {
-                sanitized.put(k, sanitize(k, v));
-            }
-        });
+
+        if (!StringUtils.hasText(payload.getAppId())) {
+            missing.add("appid");
+        }
+        sanitized.put("appid", sanitize("appid", payload.getAppId()));
+
+        if (!StringUtils.hasText(payload.getAccessToken())) {
+            missing.add("access_token");
+        }
+        sanitized.put("access_token", sanitize("access_token", payload.getAccessToken()));
+
+        if (!StringUtils.hasText(payload.getVoiceType())) {
+            missing.add("voice_type");
+        }
+        sanitized.put("voice_type", sanitize("voice_type", payload.getVoiceType()));
+
+        if (!StringUtils.hasText(payload.getText())) {
+            missing.add("text");
+        }
+        sanitized.put("text", sanitize("text", payload.getText()));
+
+        if (!StringUtils.hasText(payload.getLang())) {
+            missing.add("lang");
+        }
+        sanitized.put("lang", sanitize("lang", payload.getLang()));
+
+        sanitized.put("format", sanitize("format", payload.getFormat()));
+        sanitized.put("speed", sanitize("speed", payload.getSpeed()));
         sanitized.put("action", sanitize("action", props.getAction()));
+
         if (!missing.isEmpty()) {
             log.warn("Missing required parameters for TTS model call: {}", missing);
         } else {

--- a/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsPayload.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsPayload.java
@@ -1,0 +1,50 @@
+package com.glancy.backend.service.tts.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Payload sent to Volcengine TTS API. The class captures all parameters
+ * required by the upstream service and leverages bean validation to guard
+ * against accidental omission of mandatory fields.
+ */
+@Value
+@Builder
+public class VolcengineTtsPayload {
+
+    /** Application identifier issued by Volcengine. */
+    @NotBlank
+    @JsonProperty("appid")
+    String appId;
+
+    /** Access token for authentication. */
+    @NotBlank
+    @JsonProperty("access_token")
+    String accessToken;
+
+    /** Voice preset to synthesize. */
+    @NotBlank
+    @JsonProperty("voice_type")
+    String voiceType;
+
+    /** Text content to synthesize. */
+    @NotBlank
+    @JsonProperty("text")
+    String text;
+
+    /** Language code of the text. */
+    @NotBlank
+    @JsonProperty("lang")
+    String lang;
+
+    /** Desired audio format, e.g. mp3. */
+    @JsonProperty("format")
+    String format;
+
+    /** Playback speed multiplier. */
+    @JsonProperty("speed")
+    Double speed;
+}
+

--- a/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
@@ -57,6 +57,8 @@ class VolcengineTtsClientTest {
             .andExpect(jsonPath("$.appid").value("app"))
             .andExpect(jsonPath("$.access_token").value("token"))
             .andExpect(jsonPath("$.voice_type").value("v2"))
+            .andExpect(jsonPath("$.format").value("mp3"))
+            .andExpect(jsonPath("$.speed").value(1.0))
             .andRespond(
                 withSuccess(
                     "{\"url\":\"u\",\"duration_ms\":1,\"format\":\"mp3\",\"from_cache\":false,\"object_key\":\"k\"}",


### PR DESCRIPTION
## Summary
- introduce VolcengineTtsPayload with validation annotations
- send typed payload in VolcengineTtsClient and extend request logging
- update client unit test for new fields

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply -s /tmp/settings.xml` *(failed: Non-resolvable parent POM for com.glancy:glancy-backend:0.0.1-SNAPSHOT)*
- `mvn -q test -s /tmp/settings.xml` *(failed: Non-resolvable parent POM for com.glancy:glancy-backend:0.0.1-SNAPSHOT)*


------
https://chatgpt.com/codex/tasks/task_e_689e24e817908332897409453e4d93a2