### PR TITLE
refactor: streamline cache busting util

### DIFF
--- a/website/glancy-website/src/components/ui/Avatar/Avatar.jsx
+++ b/website/glancy-website/src/components/ui/Avatar/Avatar.jsx
@@ -1,26 +1,21 @@
-import { useUser } from '@/context'
-import { useMemo } from 'react'
-import { cacheBust } from '@/utils/url.js'
-import ThemeIcon from '@/components/ui/Icon'
-import styles from './Avatar.module.css'
+import { useUser } from "@/context";
+import { useMemo } from "react";
+import { cacheBust } from "@/utils";
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./Avatar.module.css";
 
 // 基于当前主题切换默认头像
-function Avatar({ src, alt = 'User Avatar', ...props }) {
-  const { user } = useUser()
-  const finalSrc = src || user?.avatar
+function Avatar({ src, alt = "User Avatar", ...props }) {
+  const { user } = useUser();
+  const finalSrc = src || user?.avatar;
   const displaySrc = useMemo(
     () => (finalSrc ? cacheBust(finalSrc) : null),
-    [finalSrc]
-  )
+    [finalSrc],
+  );
   if (finalSrc) {
     return (
-      <img
-        src={displaySrc}
-        alt={alt}
-        className={styles.avatar}
-        {...props}
-      />
-    )
+      <img src={displaySrc} alt={alt} className={styles.avatar} {...props} />
+    );
   }
   return (
     <ThemeIcon
@@ -29,7 +24,7 @@ function Avatar({ src, alt = 'User Avatar', ...props }) {
       className={styles.avatar}
       {...props}
     />
-  )
+  );
 }
 
-export default Avatar
+export default Avatar;

--- a/website/glancy-website/src/pages/profile/index.jsx
+++ b/website/glancy-website/src/pages/profile/index.jsx
@@ -1,133 +1,132 @@
-import { useState, useEffect } from 'react'
-import '@/pages/App/App.css'
-import styles from './Profile.module.css'
-import Avatar from '@/components/ui/Avatar'
-import { useLanguage } from '@/context'
-import MessagePopup from '@/components/ui/MessagePopup'
-import AgeStepper from '@/components/form/AgeStepper/AgeStepper.jsx'
-import GenderSelect from '@/components/form/GenderSelect/GenderSelect.jsx'
-import EditableField from '@/components/form/EditableField/EditableField.jsx'
-import FormField from '@/components/form/FormField.jsx'
-import { useApi } from '@/hooks'
-import { useUser } from '@/context'
-import { cacheBust } from '@/utils/url.js'
-import ThemeIcon from '@/components/ui/Icon'
-import Tooltip from '@/components/ui/Tooltip'
+import { useState, useEffect } from "react";
+import "@/pages/App/App.css";
+import styles from "./Profile.module.css";
+import Avatar from "@/components/ui/Avatar";
+import { useLanguage } from "@/context";
+import MessagePopup from "@/components/ui/MessagePopup";
+import AgeStepper from "@/components/form/AgeStepper/AgeStepper.jsx";
+import GenderSelect from "@/components/form/GenderSelect/GenderSelect.jsx";
+import EditableField from "@/components/form/EditableField/EditableField.jsx";
+import FormField from "@/components/form/FormField.jsx";
+import { useApi } from "@/hooks";
+import { useUser } from "@/context";
+import { cacheBust } from "@/utils";
+import ThemeIcon from "@/components/ui/Icon";
+import Tooltip from "@/components/ui/Tooltip";
 
 function Profile({ onCancel }) {
-  const { t } = useLanguage()
-  const { user: currentUser, setUser } = useUser()
-  const api = useApi()
-  const [username, setUsername] = useState(currentUser?.username || '')
-  const [email, setEmail] = useState(currentUser?.email || '')
-  const [phone, setPhone] = useState(currentUser?.phone || '')
-  const [age, setAge] = useState('')
-  const [gender, setGender] = useState('')
-  const [interests, setInterests] = useState('')
-  const [goal, setGoal] = useState('')
-  const [avatar, setAvatar] = useState('')
-  const [popupOpen, setPopupOpen] = useState(false)
-  const [popupMsg, setPopupMsg] = useState('')
+  const { t } = useLanguage();
+  const { user: currentUser, setUser } = useUser();
+  const api = useApi();
+  const [username, setUsername] = useState(currentUser?.username || "");
+  const [email, setEmail] = useState(currentUser?.email || "");
+  const [phone, setPhone] = useState(currentUser?.phone || "");
+  const [age, setAge] = useState("");
+  const [gender, setGender] = useState("");
+  const [interests, setInterests] = useState("");
+  const [goal, setGoal] = useState("");
+  const [avatar, setAvatar] = useState("");
+  const [popupOpen, setPopupOpen] = useState(false);
+  const [popupMsg, setPopupMsg] = useState("");
 
   const handleAvatarChange = async (e) => {
-    const file = e.target.files?.[0]
-    if (!file || !currentUser) return
-    const preview = URL.createObjectURL(file)
-    setAvatar(preview)
+    const file = e.target.files?.[0];
+    if (!file || !currentUser) return;
+    const preview = URL.createObjectURL(file);
+    setAvatar(preview);
     try {
       const data = await api.users.uploadAvatar({
         userId: currentUser.id,
         file,
-        token: currentUser.token
-      })
-      const url = cacheBust(data.avatar)
-      setAvatar(url)
-      setUser({ ...currentUser, avatar: url })
+        token: currentUser.token,
+      });
+      const url = cacheBust(data.avatar);
+      setAvatar(url);
+      setUser({ ...currentUser, avatar: url });
     } catch (err) {
-      console.error(err)
-      setPopupMsg(t.fail)
-      setPopupOpen(true)
+      console.error(err);
+      setPopupMsg(t.fail);
+      setPopupOpen(true);
     } finally {
-      URL.revokeObjectURL(preview)
+      URL.revokeObjectURL(preview);
     }
-  }
+  };
 
   useEffect(() => {
-    if (!currentUser) return
+    if (!currentUser) return;
     api.profiles
       .fetchProfile({ userId: currentUser.id, token: currentUser.token })
       .then((data) => {
-        setAge(data.age)
-        setGender(data.gender)
-        setInterests(data.interest)
-        setGoal(data.goal)
+        setAge(data.age);
+        setGender(data.gender);
+        setInterests(data.interest);
+        setGoal(data.goal);
         if (data.avatar) {
-          const url = cacheBust(data.avatar)
-          setAvatar(url)
+          const url = cacheBust(data.avatar);
+          setAvatar(url);
         }
       })
       .catch((err) => {
-        console.error(err)
-        setPopupMsg(t.fail)
-        setPopupOpen(true)
-      })
-  }, [api, t, currentUser])
+        console.error(err);
+        setPopupMsg(t.fail);
+        setPopupOpen(true);
+      });
+  }, [api, t, currentUser]);
 
   const handleSave = async (e) => {
-    e.preventDefault()
-    if (!currentUser) return
+    e.preventDefault();
+    if (!currentUser) return;
     await api.profiles.saveProfile({
       userId: currentUser.id,
       token: currentUser.token,
       profile: {
         age,
         gender,
-        job: '',
+        job: "",
         interest: interests,
-        goal
-      }
-    })
-    setPopupMsg(t.updateSuccess)
-    setPopupOpen(true)
-  }
-
+        goal,
+      },
+    });
+    setPopupMsg(t.updateSuccess);
+    setPopupOpen(true);
+  };
 
   return (
     <div className="app">
       <h2>{t.profileTitle}</h2>
-      <form onSubmit={handleSave} className={styles['profile-card']}>
-        <div className={styles['avatar-area']}>
-          {avatar && typeof avatar === 'string' ? (
+      <form onSubmit={handleSave} className={styles["profile-card"]}>
+        <div className={styles["avatar-area"]}>
+          {avatar && typeof avatar === "string" ? (
             <img src={avatar} alt="avatar" />
           ) : (
-            <Avatar width={100} height={100} style={{ borderRadius: '20px' }} />
+            <Avatar width={100} height={100} style={{ borderRadius: "20px" }} />
           )}
-          <span className={styles['avatar-hint']}>{t.avatarHint}</span>
+          <span className={styles["avatar-hint"]}>{t.avatarHint}</span>
           <input
             type="file"
             onChange={handleAvatarChange}
-            style={{ position: 'absolute', inset: 0, opacity: 0 }}
+            style={{ position: "absolute", inset: 0, opacity: 0 }}
           />
         </div>
         <EditableField
           value={username}
           onChange={(e) => setUsername(e.target.value)}
           placeholder={t.usernamePlaceholder}
-          inputClassName={styles['username-input']}
+          inputClassName={styles["username-input"]}
           buttonText={t.editButton}
         />
         <EditableField
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder={t.emailPlaceholder}
-          inputClassName={styles['email-input']}
+          inputClassName={styles["email-input"]}
           buttonText={t.editButton}
         />
         <EditableField
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
           placeholder={t.phonePlaceholder}
-          inputClassName={styles['phone-input']}
+          inputClassName={styles["phone-input"]}
           buttonText={t.editButton}
         />
         <div className={styles.basic}>
@@ -209,10 +208,14 @@ function Profile({ onCancel }) {
           </FormField>
         </div>
         <div className={styles.actions}>
-          <button type="submit" className={styles['save-btn']}>
+          <button type="submit" className={styles["save-btn"]}>
             {t.saveButton}
           </button>
-          <button type="button" className={styles['cancel-btn']} onClick={onCancel}>
+          <button
+            type="button"
+            className={styles["cancel-btn"]}
+            onClick={onCancel}
+          >
             {t.cancelButton}
           </button>
         </div>
@@ -223,7 +226,7 @@ function Profile({ onCancel }) {
         onClose={() => setPopupOpen(false)}
       />
     </div>
-  )
+  );
 }
 
-export default Profile
+export default Profile;

--- a/website/glancy-website/src/utils/index.js
+++ b/website/glancy-website/src/utils/index.js
@@ -1,9 +1,9 @@
-export { extractMessage, safeJSONParse } from './json.js'
-export { getModifierKey, useIsMobile } from './device.js'
-export { isPresignedUrl, cacheBust } from './url.js'
-export { withStopPropagation } from './stopPropagation.js'
-export { detectWordLanguage } from './language.js'
-export { clientNameFromModel } from './model.js'
-export { getBrandText, BRAND_TEXT } from './brand.js'
-export { validateEmail, validatePhone, validateAccount } from './validators.js'
-export { audioManager } from './audioManager.js'
+export { extractMessage, safeJSONParse } from "./json.js";
+export { getModifierKey, useIsMobile } from "./device.js";
+export { cacheBust } from "./url.js";
+export { withStopPropagation } from "./stopPropagation.js";
+export { detectWordLanguage } from "./language.js";
+export { clientNameFromModel } from "./model.js";
+export { getBrandText, BRAND_TEXT } from "./brand.js";
+export { validateEmail, validatePhone, validateAccount } from "./validators.js";
+export { audioManager } from "./audioManager.js";

--- a/website/glancy-website/src/utils/url.js
+++ b/website/glancy-website/src/utils/url.js
@@ -1,23 +1,6 @@
-const PRESIGNED_QUERY_KEYS = ['Signature', 'OSSAccessKeyId']
-
-export function isPresignedUrl(url) {
-  if (!url) return false
-  try {
-    const base =
-      typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
-    const params = new URL(url, base).searchParams
-    return PRESIGNED_QUERY_KEYS.some((key) => params.has(key))
-  } catch {
-    return PRESIGNED_QUERY_KEYS.some((key) =>
-      new RegExp(`[?&]${key}=`).test(url)
-    )
-  }
-}
-
 export function cacheBust(url) {
-  if (!url) return url
-  if (url.includes('_v=')) return url
-  if (isPresignedUrl(url)) return url
-  const sep = url.includes('?') ? '&' : '?'
-  return `${url}${sep}_v=${Date.now()}`
+  if (!url) return url;
+  if (url.includes("_v=")) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}_v=${Date.now()}`;
 }


### PR DESCRIPTION
## Summary
- simplify cache busting utility by removing presigned URL handling
- export cacheBust via utils index and update avatar/profile imports

## Testing
- `npx prettier -w src/utils/url.js src/utils/index.js src/pages/profile/index.jsx src/components/ui/Avatar/Avatar.jsx`
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npm test` *(fails: SyntaxError about useMediaQuery export, heap out of memory)*
- `npm run build`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f3acf6108332b6a2f2f8f0af44ab