### PR TITLE
refactor: drop object key from TTS response

### DIFF
--- a/backend/src/main/java/com/glancy/backend/dto/TtsResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/TtsResponse.java
@@ -26,8 +26,4 @@ public class TtsResponse {
     /** Indicates whether the result was served from cache. */
     @JsonProperty("from_cache")
     private boolean fromCache;
-
-    /** Object storage key for the audio file. */
-    @JsonProperty("object_key")
-    private String objectKey;
 }

--- a/backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java
@@ -61,7 +61,7 @@ class TtsControllerTest {
      */
     @Test
     void synthesizeWordReturnsAudio() throws Exception {
-        TtsResponse resp = new TtsResponse("url", 1000L, "mp3", true, "obj");
+        TtsResponse resp = new TtsResponse("url", 1000L, "mp3", true);
         when(ttsService.synthesizeWord(eq(1L), anyString(), any(TtsRequest.class))).thenReturn(Optional.of(resp));
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 
@@ -119,7 +119,7 @@ class TtsControllerTest {
      */
     @Test
     void streamSentenceRedirectsToAudio() throws Exception {
-        TtsResponse resp = new TtsResponse("http://audio/url", 800L, "mp3", false, "obj");
+        TtsResponse resp = new TtsResponse("http://audio/url", 800L, "mp3", false);
         when(ttsService.synthesizeSentence(eq(1L), anyString(), any(TtsRequest.class))).thenReturn(Optional.of(resp));
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 
@@ -136,7 +136,7 @@ class TtsControllerTest {
      */
     @Test
     void streamSentenceAudioReturnsBytes() throws Exception {
-        TtsResponse resp = new TtsResponse("http://audio/url", 800L, "mp3", false, "obj");
+        TtsResponse resp = new TtsResponse("http://audio/url", 800L, "mp3", false);
         when(ttsService.synthesizeSentence(eq(1L), anyString(), any(TtsRequest.class))).thenReturn(Optional.of(resp));
         when(restTemplate.getForObject("http://audio/url", byte[].class)).thenReturn(
             "data".getBytes(StandardCharsets.UTF_8)
@@ -160,7 +160,7 @@ class TtsControllerTest {
      */
     @Test
     void streamWordAudioReturnsBytes() throws Exception {
-        TtsResponse resp = new TtsResponse("http://audio/word", 500L, "mp3", true, "obj");
+        TtsResponse resp = new TtsResponse("http://audio/word", 500L, "mp3", true);
         when(ttsService.synthesizeWord(eq(1L), anyString(), any(TtsRequest.class))).thenReturn(Optional.of(resp));
         when(restTemplate.getForObject("http://audio/word", byte[].class)).thenReturn(
             "data".getBytes(StandardCharsets.UTF_8)

--- a/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
@@ -61,7 +61,7 @@ class VolcengineTtsClientTest {
             .andExpect(jsonPath("$.speed").value(1.0))
             .andRespond(
                 withSuccess(
-                    "{\"url\":\"u\",\"duration_ms\":1,\"format\":\"mp3\",\"from_cache\":false,\"object_key\":\"k\"}",
+                    "{\"url\":\"u\",\"duration_ms\":1,\"format\":\"mp3\",\"from_cache\":false}",
                     MediaType.APPLICATION_JSON
                 )
             );


### PR DESCRIPTION
## Summary
- remove objectKey from TtsResponse
- adapt tests for updated TTS payload

## Testing
- `npx eslint --fix backend/src/main/java/com/glancy/backend/dto/TtsResponse.java backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java`
- `npx stylelint backend/src/main/java/com/glancy/backend/dto/TtsResponse.java backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java --fix`
- `npx prettier backend/src/main/java/com/glancy/backend/dto/TtsResponse.java backend/src/test/java/com/glancy/backend/controller/TtsControllerTest.java backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java -w`
- `./mvnw -q spotless:apply`
- `./mvnw -q test`

------
https://chatgpt.com/codex/tasks/task_e_68a1f3a671148332822c311f4857c4be