### PR TITLE
refactor: return tts audio bytes directly

### DIFF
--- a/backend/src/main/java/com/glancy/backend/dto/TtsResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/TtsResponse.java
@@ -6,15 +6,16 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Response payload containing synthesized audio metadata.
+ * Encapsulates synthesized audio bytes and related metadata.
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class TtsResponse {
 
-    /** Temporary URL for the audio file. */
-    private String url;
+    /** Raw audio data. */
+    @JsonProperty("data")
+    private byte[] data;
 
     /** Audio duration in milliseconds. */
     @JsonProperty("duration_ms")

--- a/backend/src/main/java/com/glancy/backend/service/tts/TtsService.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/TtsService.java
@@ -14,7 +14,7 @@ public interface TtsService {
      *
      * @param userId authenticated user performing the request
      * @param request synthesis parameters
-     * @return optional response; empty when cache miss and shortcut is true
+     * @return optional response containing raw audio bytes and metadata; empty when cache miss and shortcut is true
      */
     Optional<TtsResponse> synthesizeWord(Long userId, String ip, TtsRequest request);
 
@@ -23,7 +23,7 @@ public interface TtsService {
      *
      * @param userId authenticated user performing the request
      * @param request synthesis parameters
-     * @return optional response; empty when cache miss and shortcut is true
+     * @return optional response containing raw audio bytes and metadata; empty when cache miss and shortcut is true
      */
     Optional<TtsResponse> synthesizeSentence(Long userId, String ip, TtsRequest request);
 

--- a/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
@@ -76,11 +76,12 @@ public class VolcengineTtsClient {
             ResponseEntity<TtsResponse> resp = restTemplate.postForEntity(url, entity, TtsResponse.class);
             TtsResponse body = resp.getBody();
 
-            if (!resp.getStatusCode().is2xxSuccessful() || body == null) {
+            if (!resp.getStatusCode().is2xxSuccessful() || body == null || body.getData() == null) {
                 log.warn(
-                    "Volcengine TTS returned unexpected response: status={}, bodyNull={}",
+                    "Volcengine TTS returned unexpected response: status={}, bodyNull={}, dataNull={}",
                     resp.getStatusCode(),
-                    body == null
+                    body == null,
+                    body != null && body.getData() == null
                 );
                 throw new IllegalStateException(
                     "Upstream TTS (Text-To-Speech) returned empty body or non-2xx status: " + resp.getStatusCode()

--- a/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/tts/client/VolcengineTtsClientTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.glancy.backend.dto.TtsRequest;
 import com.glancy.backend.dto.TtsResponse;
 import com.glancy.backend.exception.TtsFailedException;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -67,7 +68,7 @@ class VolcengineTtsClientTest {
             .andExpect(jsonPath("$.speed").value(1.0))
             .andRespond(
                 withSuccess(
-                    "{\"url\":\"u\",\"duration_ms\":1,\"format\":\"mp3\",\"from_cache\":false}",
+                    "{\"data\":\"ZGF0YQ==\",\"duration_ms\":1,\"format\":\"mp3\",\"from_cache\":false}",
                     MediaType.APPLICATION_JSON
                 )
             );
@@ -78,6 +79,7 @@ class VolcengineTtsClientTest {
         req.setVoice("v2");
         TtsResponse resp = client.synthesize(req);
         assertThat(resp.getFormat()).isEqualTo("mp3");
+        assertThat(new String(resp.getData(), StandardCharsets.UTF_8)).isEqualTo("data");
         server.verify();
     }
 


### PR DESCRIPTION
## Summary
- stream word and sentence synthesis results as raw audio rather than temporary URLs
- carry audio bytes in `TtsResponse` and adjust `TtsService`/`VolcengineTtsClient` to honor new contract
- update controller and client tests for direct audio responses

## Testing
- `npm --prefix website/glancy-website ci`
- `cd website/glancy-website && npx eslint --fix .`
- `cd website/glancy-website && npx stylelint "src/**/*.css" --fix`
- `cd website/glancy-website && npx prettier -w .`
- `cd backend && ./mvnw spotless:apply` *(failed: Network is unreachable)*
- `cd backend && ./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fa0abf8c83329793918e283e574b