### PR TITLE
feat: add debug and warning logs in TtsRequestValidator

### DIFF
--- a/backend/src/main/java/com/glancy/backend/service/tts/TtsRequestValidator.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/TtsRequestValidator.java
@@ -6,8 +6,10 @@ import com.glancy.backend.exception.ForbiddenException;
 import com.glancy.backend.exception.InvalidRequestException;
 import com.glancy.backend.service.tts.config.TtsConfig;
 import com.glancy.backend.service.tts.config.TtsConfigManager;
+import com.glancy.backend.util.SensitiveDataUtil;
 import java.util.Locale;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -16,6 +18,7 @@ import org.springframework.util.StringUtils;
  * user privileges.
  */
 @Component
+@Slf4j
 public class TtsRequestValidator {
 
     private final TtsConfigManager configManager;
@@ -32,12 +35,21 @@ public class TtsRequestValidator {
      * @return resolved voice id
      */
     public String resolveVoice(User user, TtsRequest request) {
+        log.debug(
+            "Resolving voice for user={}, lang={}, requestedVoice={}, textPreview={}",
+            user.getId(),
+            request.getLang(),
+            request.getVoice(),
+            SensitiveDataUtil.previewText(request.getText())
+        );
+
         Map<String, TtsConfig.VoiceGroup> voices = configManager.current().getVoices();
         TtsConfig.VoiceGroup group = voices.get(request.getLang());
         if (group == null) {
             Locale locale = Locale.forLanguageTag(request.getLang());
             String prefix = locale.getLanguage();
             if (StringUtils.hasText(prefix)) {
+                log.debug("No exact match for lang={}, trying prefix={}", request.getLang(), prefix);
                 group = voices
                     .entrySet()
                     .stream()
@@ -48,18 +60,31 @@ public class TtsRequestValidator {
             }
         }
         if (group == null) {
+            log.warn("Unsupported language user={}, lang={}", user.getId(), request.getLang());
             throw new InvalidRequestException("不支持的语言");
         }
+
         String voiceId = StringUtils.hasText(request.getVoice()) ? request.getVoice() : group.getDefaultVoice();
+        if (!StringUtils.hasText(request.getVoice())) {
+            log.debug("Using default voice={} for lang={}", voiceId, request.getLang());
+        }
         TtsConfig.VoiceOption voice = group
             .getOptions()
             .stream()
             .filter(v -> v.getId().equals(voiceId))
             .findFirst()
-            .orElseThrow(() -> new InvalidRequestException("无效的音色"));
+            .orElse(null);
+        if (voice == null) {
+            log.warn("Invalid voice user={}, lang={}, voice={}", user.getId(), request.getLang(), voiceId);
+            throw new InvalidRequestException("无效的音色");
+        }
+
         if ("pro".equalsIgnoreCase(voice.getPlan()) && Boolean.FALSE.equals(user.getMember())) {
+            log.warn("Voice={} requires pro plan for user={}", voice.getId(), user.getId());
             throw new ForbiddenException("该音色仅对 Pro 用户开放");
         }
+
+        log.debug("Resolved voice={} for user={}", voice.getId(), user.getId());
         return voice.getId();
     }
 }


### PR DESCRIPTION
## Summary
- add debug logs for language parsing, default voice selection, and resolved voice
- warn on unsupported language, invalid voice, and insufficient plan privileges

## Testing
- `npx eslint --fix .` *(fails: Cannot find package '@eslint/js')*
- `npx stylelint --allow-empty-input --fix "src/**/*.{css,scss}"` *(fails: Need to install the following packages: stylelint@16.23.1)*
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a2002bb5c08332b0a8d08b7c2aefde