### PR TITLE
feat: decode tts audio with object URL

### DIFF
--- a/website/glancy-website/src/utils/audio.js
+++ b/website/glancy-website/src/utils/audio.js
@@ -1,0 +1,13 @@
+/**
+ * Decode base64 TTS audio data to a Blob URL.
+ *
+ * @param {Object} params
+ * @param {string} params.data Base64 encoded audio data
+ * @param {string} params.format Audio format, e.g. "mp3"
+ * @returns {string} Object URL representing the decoded audio
+ */
+export function decodeTtsAudio({ data, format }) {
+  const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
+  const blob = new Blob([bytes], { type: `audio/${format}` });
+  return URL.createObjectURL(blob);
+}

--- a/website/glancy-website/src/utils/audioManager.js
+++ b/website/glancy-website/src/utils/audioManager.js
@@ -4,7 +4,7 @@
  */
 class AudioManager {
   constructor() {
-    this.current = null
+    this.current = null;
   }
 
   /**
@@ -13,10 +13,10 @@ class AudioManager {
    */
   async play(audio) {
     if (this.current && this.current !== audio) {
-      this.current.pause()
+      this.current.pause();
     }
-    this.current = audio
-    return audio.play()
+    this.current = audio;
+    return audio.play();
   }
 
   /**
@@ -24,12 +24,13 @@ class AudioManager {
    * @param {HTMLAudioElement} audio
    */
   stop(audio) {
-    if (!audio) return
-    audio.pause()
+    if (!audio) return;
+    audio.pause();
+    audio.src = "";
     if (this.current === audio) {
-      this.current = null
+      this.current = null;
     }
   }
 }
 
-export const audioManager = new AudioManager()
+export const audioManager = new AudioManager();

--- a/website/glancy-website/src/utils/index.js
+++ b/website/glancy-website/src/utils/index.js
@@ -7,3 +7,4 @@ export { clientNameFromModel } from "./model.js";
 export { getBrandText, BRAND_TEXT } from "./brand.js";
 export { validateEmail, validatePhone, validateAccount } from "./validators.js";
 export { audioManager } from "./audioManager.js";
+export { decodeTtsAudio } from "./audio.js";


### PR DESCRIPTION
## Summary
- decode TTS base64 payloads into playable object URLs
- revoke object URLs and clear audio sources after playback
- reset audio sources on stop to avoid stale URLs

## Testing
- `npx eslint src/utils/audio.js src/utils/index.js src/utils/audioManager.js src/hooks/useTtsPlayer.js src/hooks/__tests__/useTtsPlayer.test.js --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/utils/audio.js src/utils/index.js src/utils/audioManager.js src/hooks/useTtsPlayer.js src/hooks/__tests__/useTtsPlayer.test.js`
- `npm test` *(fails: The requested module '@/hooks' does not provide an export named 'useMediaQuery')*
- `./mvnw -q spotless:apply` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4125b87d88332925eb9d0cc07ca36