### PR TITLE
fix audio mime handling for tts

### DIFF
--- a/website/glancy-website/src/__tests__/Preferences.test.jsx
+++ b/website/glancy-website/src/__tests__/Preferences.test.jsx
@@ -1,73 +1,83 @@
 /* eslint-env jest */
-import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { jest } from '@jest/globals'
-import { API_PATHS } from '@/config/api.js'
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import { API_PATHS } from "@/config/api.js";
 
-const mockRequest = jest.fn().mockResolvedValue({})
-const mockFetchModels = jest.fn().mockResolvedValue(['M1'])
-const mockSetTheme = jest.fn()
-const mockSetModel = jest.fn()
-const mockTtsVoices = jest.fn().mockResolvedValue([])
+const mockRequest = jest.fn().mockResolvedValue({});
+const mockFetchModels = jest.fn().mockResolvedValue(["M1"]);
+const mockSetTheme = jest.fn();
+const mockSetModel = jest.fn();
+const mockTtsVoices = jest.fn().mockResolvedValue([]);
 const mockT = {
-  prefTitle: 'Preferences',
-  prefLanguage: 'Language',
-  prefSearchLanguage: 'Search Language',
-  prefDictionaryModel: 'Model',
-  prefVoiceEn: 'English Voice',
-  prefVoiceZh: 'Chinese Voice',
-  prefTheme: 'Theme',
-  saveButton: 'Save',
-  saveSuccess: 'Saved',
-  fail: 'Fail',
-  autoDetect: 'Auto',
-  CHINESE: 'CHINESE',
-  ENGLISH: 'ENGLISH',
-  M1: 'M1'
-}
+  prefTitle: "Preferences",
+  prefLanguage: "Language",
+  prefSearchLanguage: "Search Language",
+  prefDictionaryModel: "Model",
+  prefVoiceEn: "English Voice",
+  prefVoiceZh: "Chinese Voice",
+  prefTheme: "Theme",
+  saveButton: "Save",
+  saveSuccess: "Saved",
+  fail: "Fail",
+  autoDetect: "Auto",
+  CHINESE: "CHINESE",
+  ENGLISH: "ENGLISH",
+  M1: "M1",
+};
 
-jest.unstable_mockModule('@/context', () => ({
+jest.unstable_mockModule("@/context", () => ({
   // Aggregate all required context hooks for clarity
   useLanguage: () => ({ t: mockT }),
-  useTheme: () => ({ theme: 'light', setTheme: mockSetTheme }),
-  useUser: () => ({ user: { id: '1', token: 't' } }),
+  useTheme: () => ({ theme: "light", setTheme: mockSetTheme }),
+  useUser: () => ({ user: { id: "1", token: "t" } }),
   useHistory: () => ({}),
   useApiContext: () => ({}),
-  useLocale: () => ({ locale: { lang: 'en' } })
-}))
-jest.unstable_mockModule('@/hooks', () => ({
+  useLocale: () => ({ locale: { lang: "en" } }),
+}));
+jest.unstable_mockModule("@/hooks", () => ({
   useApi: () => ({
     request: mockRequest,
     jsonRequest: mockRequest,
     llm: { fetchModels: mockFetchModels },
-    tts: { fetchVoices: mockTtsVoices }
+    tts: { fetchVoices: mockTtsVoices },
   }),
   useEscapeKey: () => ({ on: () => {}, off: () => {} }),
-  useOutsideToggle: () => ({ open: false, setOpen: () => {}, ref: { current: null } })
-}))
-jest.unstable_mockModule('@/store', () => ({
-  useModelStore: () => ({ model: 'M1', setModel: mockSetModel }),
-  useUserStore: (fn) => fn({ user: { plan: 'free' } }),
+  useOutsideToggle: () => ({
+    open: false,
+    setOpen: () => {},
+    ref: { current: null },
+  }),
+  useMediaQuery: () => false,
+}));
+jest.unstable_mockModule("@/store", () => ({
+  useModelStore: () => ({ model: "M1", setModel: mockSetModel }),
+  useUserStore: (fn) => fn({ user: { plan: "free" } }),
   useVoiceStore: (fn) =>
-    fn({ voices: {}, setVoice: jest.fn(), getVoice: () => undefined })
-}))
-jest.unstable_mockModule('@/assets/icons.js', () => ({ __esModule: true, default: {} }))
+    fn({ voices: {}, setVoice: jest.fn(), getVoice: () => undefined }),
+}));
+jest.unstable_mockModule("@/assets/icons.js", () => ({
+  __esModule: true,
+  default: {},
+}));
 
-const { default: Preferences } = await import('@/pages/preferences')
+const { default: Preferences } = await import("@/pages/preferences");
 
 beforeEach(() => {
-  localStorage.clear()
-})
+  localStorage.clear();
+});
 
 /**
  * Ensures user preference changes trigger API requests and persist through
  * the mocked backend service.
  */
-test('saves preferences via api', async () => {
-  render(<Preferences />)
-  await waitFor(() => expect(mockFetchModels).toHaveBeenCalled())
-  fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'CHINESE' } })
-  fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-  await waitFor(() => expect(mockRequest).toHaveBeenCalled())
-  expect(mockRequest.mock.calls[0][0]).toBe(`${API_PATHS.preferences}/user/1`)
-})
+test("saves preferences via api", async () => {
+  render(<Preferences />);
+  await waitFor(() => expect(mockFetchModels).toHaveBeenCalled());
+  fireEvent.change(screen.getByLabelText("Language"), {
+    target: { value: "CHINESE" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+  expect(mockRequest.mock.calls[0][0]).toBe(`${API_PATHS.preferences}/user/1`);
+});

--- a/website/glancy-website/src/utils/audio.js
+++ b/website/glancy-website/src/utils/audio.js
@@ -6,8 +6,15 @@
  * @param {string} params.format Audio format, e.g. "mp3"
  * @returns {string} Object URL representing the decoded audio
  */
+const MIME_TYPES = {
+  mp3: "audio/mpeg",
+};
+
 export function decodeTtsAudio({ data, format }) {
-  const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
-  const blob = new Blob([bytes], { type: `audio/${format}` });
+  const base64 = data.split(",").pop();
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  const blob = new Blob([bytes], {
+    type: MIME_TYPES[format] ?? `audio/${format}`,
+  });
   return URL.createObjectURL(blob);
 }

--- a/website/glancy-website/src/utils/audio.test.js
+++ b/website/glancy-website/src/utils/audio.test.js
@@ -1,0 +1,25 @@
+import { decodeTtsAudio } from "./audio.js";
+
+describe("decodeTtsAudio", () => {
+  test("maps mp3 to audio/mpeg", () => {
+    const base64 = btoa("audio");
+    const blobSpy = jest.spyOn(global, "Blob");
+    decodeTtsAudio({ data: base64, format: "mp3" });
+    expect(blobSpy).toHaveBeenCalledWith(expect.any(Array), {
+      type: "audio/mpeg",
+    });
+    blobSpy.mockRestore();
+  });
+
+  test("strips data URI prefix", () => {
+    const base64 = btoa("audio");
+    const prefixed = `data:audio/mp3;base64,${base64}`;
+    const blobSpy = jest.spyOn(global, "Blob");
+    decodeTtsAudio({ data: prefixed, format: "mp3" });
+    const call = blobSpy.mock.calls[0];
+    expect(call[0][0]).toEqual(
+      Uint8Array.from(atob(base64), (c) => c.charCodeAt(0)),
+    );
+    blobSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- map mp3 format to audio/mpeg and strip data URI prefixes when decoding TTS audio
- add unit tests for audio decoding and stub missing hook in preferences test

## Testing
- `npm run lint -- --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/utils/audio.js src/utils/audio.test.js`
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npm test`
- `./mvnw -q spotless:apply` *(fail: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a45ab9ffd483328e1f68bc1f8b951e