### PR TITLE
feat: add doubao sse streaming client

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,10 +39,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-                  <dependency>
-                          <groupId>org.springframework.boot</groupId>
-                          <artifactId>spring-boot-starter-web</artifactId>
-                  </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-webflux</artifactId>
+                </dependency>
                   <dependency>
                           <groupId>org.springframework.boot</groupId>
                           <artifactId>spring-boot-starter-security</artifactId>
@@ -85,6 +89,12 @@
                 <dependency>
                         <groupId>org.springframework.security</groupId>
                         <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>mockwebserver</artifactId>
+                        <version>4.12.0</version>
                         <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -5,6 +5,7 @@ import com.glancy.backend.config.DoubaoProperties;
 import com.glancy.backend.dto.ChatCompletionResponse;
 import com.glancy.backend.llm.llm.LLMClient;
 import com.glancy.backend.llm.model.ChatMessage;
+import com.glancy.backend.util.UrlUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,8 +30,8 @@ public class DoubaoClient implements LLMClient {
 
     public DoubaoClient(RestTemplate restTemplate, DoubaoProperties properties) {
         this.restTemplate = restTemplate;
-        this.baseUrl = trimTrailingSlash(properties.getBaseUrl());
-        this.chatPath = ensureLeadingSlash(properties.getChatPath());
+        this.baseUrl = UrlUtils.trimTrailingSlash(properties.getBaseUrl());
+        this.chatPath = UrlUtils.ensureLeadingSlash(properties.getChatPath());
         this.apiKey = properties.getApiKey() == null ? null : properties.getApiKey().trim();
         this.model = properties.getModel();
         if (apiKey == null || apiKey.isBlank()) {
@@ -85,20 +86,6 @@ public class DoubaoClient implements LLMClient {
             log.warn("Failed to parse Doubao response", e);
             return "";
         }
-    }
-
-    private String trimTrailingSlash(String url) {
-        if (url == null || url.isBlank()) {
-            return "";
-        }
-        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
-    }
-
-    private String ensureLeadingSlash(String path) {
-        if (path == null || path.isBlank()) {
-            return "";
-        }
-        return path.startsWith("/") ? path : "/" + path;
     }
 
     private String maskKey(String key) {

--- a/backend/src/main/java/com/glancy/backend/client/DoubaoStreamClient.java
+++ b/backend/src/main/java/com/glancy/backend/client/DoubaoStreamClient.java
@@ -1,0 +1,82 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.config.DoubaoProperties;
+import com.glancy.backend.exception.BusinessException;
+import com.glancy.backend.exception.UnauthorizedException;
+import com.glancy.backend.llm.model.ChatMessage;
+import com.glancy.backend.util.UrlUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive client for Doubao chat completions using Server-Sent Events.
+ */
+@Component
+public class DoubaoStreamClient {
+
+    private final WebClient webClient;
+    private final DoubaoStreamDecoder decoder;
+    private final String chatPath;
+    private final String model;
+
+    public DoubaoStreamClient(
+        WebClient.Builder builder,
+        DoubaoProperties properties,
+        DoubaoStreamDecoder decoder
+    ) {
+        String baseUrl = UrlUtils.trimTrailingSlash(properties.getBaseUrl());
+        this.chatPath = UrlUtils.ensureLeadingSlash(properties.getChatPath());
+        this.model = properties.getModel();
+        this.decoder = decoder;
+        String apiKey = properties.getApiKey() == null ? null : properties.getApiKey().trim();
+        this.webClient = builder
+            .baseUrl(baseUrl)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, apiKey == null ? "" : "Bearer " + apiKey)
+            .build();
+    }
+
+    /**
+     * Streams chat completions from Doubao API.
+     *
+     * @param messages conversation history
+     * @param temperature randomness parameter
+     * @return flux of response segments
+     */
+    public Flux<String> streamChat(List<ChatMessage> messages, double temperature) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", model);
+        body.put("temperature", temperature);
+        body.put("stream", true);
+        List<Map<String, String>> reqMessages = new ArrayList<>();
+        for (ChatMessage m : messages) {
+            reqMessages.add(Map.of("role", m.getRole(), "content", m.getContent()));
+        }
+        body.put("messages", reqMessages);
+
+        return webClient
+            .post()
+            .uri(chatPath)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .bodyValue(body)
+            .retrieve()
+            .onStatus(
+                status -> status.value() == 401,
+                resp -> Mono.error(new UnauthorizedException("Invalid Doubao API key"))
+            )
+            .onStatus(
+                status -> status.isError(),
+                resp -> Mono.error(new BusinessException("Failed to call Doubao API: " + resp.statusCode()))
+            )
+            .bodyToFlux(String.class)
+            .transform(decoder::decode);
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/client/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/client/DoubaoStreamDecoder.java
@@ -1,0 +1,76 @@
+package com.glancy.backend.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.SynchronousSink;
+
+/**
+ * Decodes Doubao Server-Sent Events stream into content fragments.
+ * Designed with extensibility so new event types can be registered easily.
+ */
+@Component
+public class DoubaoStreamDecoder {
+
+    private final ObjectMapper mapper;
+    private final Map<String, BiConsumer<String, SynchronousSink<String>>> handlers = new HashMap<>();
+
+    public DoubaoStreamDecoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+        handlers.put("message", this::handleMessage);
+        handlers.put("end", this::handleEnd);
+    }
+
+    /**
+     * Decode raw SSE lines into a flux of content strings.
+     */
+    public Flux<String> decode(Flux<String> lines) {
+        return Flux.defer(() -> {
+            AtomicReference<String> currentEvent = new AtomicReference<>();
+            return lines.handle((line, sink) -> {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty()) {
+                    // event block finished
+                    currentEvent.set(null);
+                    return;
+                }
+                if (trimmed.startsWith("event:")) {
+                    currentEvent.set(trimmed.substring(6).trim());
+                    return;
+                }
+                if (trimmed.startsWith("data:")) {
+                    String event = currentEvent.get();
+                    String data = trimmed.substring(5).trim();
+                    BiConsumer<String, SynchronousSink<String>> handler = handlers.get(event);
+                    if (handler != null) {
+                        handler.accept(data, sink);
+                    }
+                }
+            });
+        });
+    }
+
+    private void handleMessage(String data, SynchronousSink<String> sink) {
+        try {
+            JsonNode node = mapper.readTree(data);
+            JsonNode content = node.path("choices").get(0).path("delta").path("content");
+            if (!content.isMissingNode()) {
+                String text = content.asText();
+                if (!text.isEmpty()) {
+                    sink.next(text);
+                }
+            }
+        } catch (Exception ignored) {
+            // ignore malformed data
+        }
+    }
+
+    private void handleEnd(String data, SynchronousSink<String> sink) {
+        sink.complete();
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/util/UrlUtils.java
+++ b/backend/src/main/java/com/glancy/backend/util/UrlUtils.java
@@ -1,0 +1,33 @@
+package com.glancy.backend.util;
+
+/** Utility methods for URL and path normalization. */
+public final class UrlUtils {
+
+    private UrlUtils() {}
+
+    /**
+     * Removes trailing slash from a URL if present.
+     *
+     * @param url raw URL
+     * @return URL without trailing slash
+     */
+    public static String trimTrailingSlash(String url) {
+        if (url == null || url.isBlank()) {
+            return "";
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /**
+     * Ensures the path starts with a leading slash.
+     *
+     * @param path raw path
+     * @return normalized path
+     */
+    public static String ensureLeadingSlash(String path) {
+        if (path == null || path.isBlank()) {
+            return "";
+        }
+        return path.startsWith("/") ? path : "/" + path;
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/client/DoubaoStreamClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/client/DoubaoStreamClientTest.java
@@ -1,0 +1,74 @@
+package com.glancy.backend.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glancy.backend.config.DoubaoProperties;
+import com.glancy.backend.exception.UnauthorizedException;
+import com.glancy.backend.llm.model.ChatMessage;
+import java.io.IOException;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/** Tests for {@link DoubaoStreamClient}. */
+class DoubaoStreamClientTest {
+
+    private MockWebServer server;
+    private DoubaoStreamClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        DoubaoProperties properties = new DoubaoProperties();
+        properties.setBaseUrl(server.url("/").toString());
+        properties.setChatPath("/v3/chat/completions");
+        properties.setApiKey("key");
+        properties.setModel("model");
+        DoubaoStreamDecoder decoder = new DoubaoStreamDecoder(new ObjectMapper());
+        client = new DoubaoStreamClient(WebClient.builder(), properties, decoder);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    /**
+     * Verify that streaming produces each fragment in order and completes on end event.
+     */
+    @Test
+    void streamChatEmitsFragments() throws InterruptedException {
+        String body = "event: message\n" +
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n" +
+            "event: message\n" +
+            "data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n" +
+            "event: end\n" +
+            "data: [DONE]\n\n";
+        server.enqueue(new MockResponse().setHeader("Content-Type", "text/event-stream").setBody(body));
+
+        Flux<String> flux = client.streamChat(List.of(new ChatMessage("user", "hi")), 0.5);
+        StepVerifier.create(flux).expectNext("Hel").expectNext("lo").verifyComplete();
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("text/event-stream", request.getHeader("Accept"));
+    }
+
+    /**
+     * Verify that unauthorized responses trigger {@link UnauthorizedException}.
+     */
+    @Test
+    void streamChatUnauthorized() {
+        server.enqueue(new MockResponse().setResponseCode(401));
+        Flux<String> flux = client.streamChat(List.of(new ChatMessage("user", "hi")), 0.5);
+        StepVerifier.create(flux).expectError(UnauthorizedException.class).verify();
+    }
+}


### PR DESCRIPTION
## Summary
- integrate WebClient-based Doubao streaming client with SSE decoding
- extract UrlUtils for shared URL normalization helpers
- add integration test simulating SSE and unauthorized responses

## Testing
- `npm ci`
- `npx eslint . --fix`
- `npx stylelint "**/*" --config stylelint.config.cjs --fix` *(fails: JSONError in package.json)*
- `npx --yes prettier -w .` *(fails: SyntaxError in package.json)*
- `mvn -q -s /tmp/mvn-settings.xml spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -q -s /tmp/mvn-settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ba7deddc833280c7dd9f21e096c0