### PR TITLE
feat: add streaming chat endpoint

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/ChatController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/ChatController.java
@@ -1,0 +1,49 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.ChatRequest;
+import com.glancy.backend.llm.llm.LLMClient;
+import com.glancy.backend.llm.llm.LLMClientFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+/**
+ * 提供与大语言模型进行流式对话的接口。
+ */
+@RestController
+@Slf4j
+public class ChatController {
+
+    private final LLMClientFactory clientFactory;
+
+    public ChatController(LLMClientFactory clientFactory) {
+        this.clientFactory = clientFactory;
+    }
+
+    /**
+     * 以 Server-Sent Events 方式流式返回模型响应。连接关闭或出现异常时，
+     * 会记录日志并优雅结束输出。
+     */
+    @PostMapping(value = "/api/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<String>> chat(@RequestBody ChatRequest request) {
+        LLMClient client = clientFactory.get(request.getModel());
+        if (client == null) {
+            return Flux.error(new IllegalArgumentException("Unknown model: " + request.getModel()));
+        }
+        return client
+            .streamChat(request.getMessages(), request.getTemperature())
+            .map(data -> ServerSentEvent.builder(data).build())
+            .doOnCancel(() -> log.info("SSE connection cancelled: model={}", request.getModel()))
+            .onErrorResume(
+                ex -> {
+                    log.error("SSE streaming failed: model={}", request.getModel(), ex);
+                    return Flux.just(ServerSentEvent.builder("[ERROR] stream terminated").event("error").build());
+                }
+            )
+            .doFinally(signal -> log.info("SSE stream terminated: {}", signal));
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/dto/ChatRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/ChatRequest.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.dto;
+
+import com.glancy.backend.llm.model.ChatMessage;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * 请求模型与消息历史以启动流式聊天。
+ */
+@Data
+public class ChatRequest {
+
+    /**
+     * 指定要使用的大模型名称。
+     */
+    private String model;
+
+    /**
+     * 聊天消息历史，按顺序排列。
+     */
+    private List<ChatMessage> messages;
+
+    /**
+     * 温度参数，缺省采用适中的 0.7。
+     */
+    private double temperature = 0.7d;
+}

--- a/backend/src/test/java/com/glancy/backend/controller/ChatControllerIT.java
+++ b/backend/src/test/java/com/glancy/backend/controller/ChatControllerIT.java
@@ -1,0 +1,81 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.ChatRequest;
+import com.glancy.backend.llm.llm.LLMClient;
+import com.glancy.backend.llm.llm.LLMClientFactory;
+import com.glancy.backend.llm.model.ChatMessage;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.test.web.reactive.server.FluxExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+
+/**
+ * 集成测试：验证在持续输出场景下 SSE 通道的稳定性。
+ *
+ * <p>测试通过自定义的 {@link LLMClient} 模拟长时间的流式响应，并断言所有片段
+ * 均被客户端完整接收。</p>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ChatControllerIT {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @TestConfiguration
+    static class StubConfig {
+
+        @Bean
+        LLMClientFactory llmClientFactory() {
+            LLMClient stub = new LLMClient() {
+                @Override
+                public Flux<String> streamChat(List<ChatMessage> messages, double temperature) {
+                    return Flux.interval(Duration.ofMillis(5)).map(i -> "chunk-" + i).take(50);
+                }
+
+                @Override
+                public String name() {
+                    return "stub";
+                }
+            };
+            return new LLMClientFactory(List.of(stub));
+        }
+    }
+
+    /**
+     * 长时间流式输出应保持稳定并最终完整关闭连接。
+     */
+    @Test
+    void streamChatShouldRemainStableForLongOutput() {
+        ChatRequest req = new ChatRequest();
+        req.setModel("stub");
+        req.setMessages(List.of(new ChatMessage("user", "hello")));
+
+        FluxExchangeResult<ServerSentEvent<String>> result = webTestClient
+            .post()
+            .uri("/api/chat")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(req)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .returnResult(new org.springframework.core.ParameterizedTypeReference<ServerSentEvent<String>>() {});
+
+        List<String> chunks = result
+            .getResponseBody()
+            .map(ServerSentEvent::data)
+            .collectList()
+            .block(Duration.ofSeconds(10));
+
+        org.junit.jupiter.api.Assertions.assertNotNull(chunks);
+        org.junit.jupiter.api.Assertions.assertEquals(50, chunks.size());
+        org.junit.jupiter.api.Assertions.assertEquals("chunk-49", chunks.get(49));
+    }
+}


### PR DESCRIPTION
## Summary
- 建立 `ChatController`，通过 SSE 暴露 `/api/chat` 流式聊天能力
- 新增 `ChatRequest` DTO，封装模型与消息参数
- 编写 `ChatControllerIT` 集成测试，模拟长时输出验证 SSE 稳定性

## Testing
- `eslint --fix .` *(command not found)*
- `stylelint --fix "**/*.{css,scss}"` *(command not found)*
- `prettier -w .` *(command not found)*
- `mvn -q spotless:apply` *(network is unreachable and parent POM cannot be resolved)*
- `mvn -q test` *(network is unreachable and parent POM cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bd2f45e48332a6c6d0f29ba253a7