### PR TITLE
feat: handle doubao sse stream

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -1,0 +1,81 @@
+package com.glancy.backend.llm.stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+/**
+ * 针对抖宝流式事件格式的解析器。通过事件类型与处理器映射，
+ * 保持协议扩展的开放性，同时对常见事件进行内聚处理。
+ */
+@Component("doubaoStreamDecoder")
+public class DoubaoStreamDecoder implements StreamDecoder {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Map<String, Function<String, Flux<String>>> handlers;
+
+    public DoubaoStreamDecoder() {
+        Map<String, Function<String, Flux<String>>> map = new HashMap<>();
+        map.put("message", this::handleMessage);
+        map.put("error", this::handleError);
+        map.put("end", data -> Flux.empty());
+        this.handlers = Map.copyOf(map);
+    }
+
+    @Override
+    public Flux<String> decode(Flux<String> rawStream) {
+        return rawStream
+            .flatMap(s -> Flux.fromArray(s.split("\n")))
+            .map(String::trim)
+            .bufferUntil(String::isEmpty)
+            .map(this::toEvent)
+            .takeUntil(evt -> "end".equals(evt.type))
+            .flatMap(evt -> handlers.getOrDefault(evt.type, d -> Flux.empty()).apply(evt.data));
+    }
+
+    private Event toEvent(List<String> lines) {
+        Event evt = new Event();
+        for (String line : lines) {
+            if (line.startsWith("event:")) {
+                evt.type = line.substring(6).trim();
+            } else if (line.startsWith("data:")) {
+                if (evt.data.length() > 0) {
+                    evt.data.append('\n');
+                }
+                evt.data.append(line.substring(5).trim());
+            }
+        }
+        return evt;
+    }
+
+    private Flux<String> handleMessage(String json) {
+        try {
+            JsonNode node = mapper.readTree(json);
+            String content = node.path("choices").path(0).path("delta").path("content").asText();
+            return content.isEmpty() ? Flux.empty() : Flux.just(content);
+        } catch (Exception e) {
+            return Flux.empty();
+        }
+    }
+
+    private Flux<String> handleError(String json) {
+        try {
+            JsonNode node = mapper.readTree(json);
+            String msg = node.path("message").asText("Stream error");
+            return Flux.error(new IllegalStateException(msg));
+        } catch (Exception e) {
+            return Flux.error(new IllegalStateException("Stream error"));
+        }
+    }
+
+    private static class Event {
+        String type;
+        StringBuilder data = new StringBuilder();
+    }
+}
+

--- a/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.glancy.backend.config.DoubaoProperties;
 import com.glancy.backend.llm.model.ChatMessage;
-import com.glancy.backend.llm.stream.SseStreamDecoder;
+import com.glancy.backend.llm.stream.DoubaoStreamDecoder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,8 +16,11 @@ import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
+/** 集成测试，覆盖抖宝客户端的流式解析与异常处理。 */
 class DoubaoClientTest {
 
     private DoubaoClient client;
@@ -32,27 +35,95 @@ class DoubaoClientTest {
         properties.setModel("test-model");
     }
 
+    /** 验证同步调用在收到完整流后聚合内容。 */
     @Test
     void chatReturnsContent() {
         ExchangeFunction ef = this::successResponse;
-        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new SseStreamDecoder());
+        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
         String result = client.chat(List.of(new ChatMessage("user", "hi")), 0.5);
         assertEquals("hi", result);
     }
 
+    /** 验证 401 响应会抛出未授权异常。 */
     @Test
     void chatUnauthorizedThrowsException() {
         ExchangeFunction ef = req -> Mono.just(ClientResponse.create(HttpStatus.UNAUTHORIZED).build());
-        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new SseStreamDecoder());
-        assertThrows(com.glancy.backend.exception.UnauthorizedException.class, () ->
-            client.chat(List.of(new ChatMessage("user", "hi")), 0.5)
+        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
+        assertThrows(
+            com.glancy.backend.exception.UnauthorizedException.class,
+            () -> client.chat(List.of(new ChatMessage("user", "hi")), 0.5)
         );
+    }
+
+    /** 验证流式接口逐片段输出并在 end 事件后结束。 */
+    @Test
+    void streamChatEmitsSegments() {
+        ExchangeFunction ef = this::streamSuccessResponse;
+        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
+        Flux<String> flux = client.streamChat(List.of(new ChatMessage("u", "hi")), 0.5);
+        StepVerifier.create(flux).expectNext("he").expectNext("llo").verifyComplete();
+    }
+
+    /** 验证 error 事件会终止流并抛出异常。 */
+    @Test
+    void streamChatErrorEvent() {
+        ExchangeFunction ef = this::streamErrorResponse;
+        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
+        Flux<String> flux = client.streamChat(List.of(new ChatMessage("u", "hi")), 0.5);
+        StepVerifier.create(flux).expectNext("hi").expectErrorMessage("boom").verify();
     }
 
     private Mono<ClientResponse> successResponse(ClientRequest request) {
         assertEquals("http://mock/api/v3/chat/completions", request.url().toString());
         assertEquals("Bearer key", request.headers().getFirst(HttpHeaders.AUTHORIZATION));
-        String body = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n" + "data: [DONE]\n\n";
+        String body =
+            """
+            event: message
+            data: {"choices":[{"delta":{"content":"hi"}}]}
+            
+            event: end
+            data: {"code":0}
+            
+            """;
+        return Mono.just(
+            ClientResponse.create(HttpStatus.OK)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM_VALUE)
+                .body(body)
+                .build()
+        );
+    }
+
+    private Mono<ClientResponse> streamSuccessResponse(ClientRequest request) {
+        String body =
+            """
+            event: message
+            data: {"choices":[{"delta":{"content":"he"}}]}
+            
+            event: message
+            data: {"choices":[{"delta":{"content":"llo"}}]}
+            
+            event: end
+            data: {"code":0}
+            
+            """;
+        return Mono.just(
+            ClientResponse.create(HttpStatus.OK)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM_VALUE)
+                .body(body)
+                .build()
+        );
+    }
+
+    private Mono<ClientResponse> streamErrorResponse(ClientRequest request) {
+        String body =
+            """
+            event: message
+            data: {"choices":[{"delta":{"content":"hi"}}]}
+            
+            event: error
+            data: {"message":"boom"}
+            
+            """;
         return Mono.just(
             ClientResponse.create(HttpStatus.OK)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -61,3 +132,4 @@ class DoubaoClientTest {
         );
     }
 }
+


### PR DESCRIPTION
## Summary
- add DoubaoStreamDecoder to parse SSE events from Doubao chat completions
- stream chat responses using text/event-stream with WebClient and decoder
- cover streaming and error events in Doubao client tests

## Testing
- `npx eslint --fix .`
- `npx stylelint "**/*.{css,scss,less,vue}" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply` *(failed: Could not transfer org.springframework.boot:spring-boot-starter-parent from maven.aliyun.com)*
- `mvn -q test` *(failed: Non-resolvable parent POM for com.glancy:glancy-backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bdc21ff48332a02fd65296826b95