### PR TITLE
feat: expose streaming errors

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/WordController.java
@@ -76,7 +76,12 @@ public class WordController {
             .doOnCancel(() -> log.info("Streaming canceled for user {} term '{}'", userId, term))
             .onErrorResume(e -> {
                 log.error("Streaming error for user {} term '{}'", userId, term, e);
-                return Flux.just(ServerSentEvent.builder("ERROR").event("error").build());
+                return Flux.just(
+                    ServerSentEvent
+                        .<String>builder(e.getMessage())
+                        .event("error")
+                        .build()
+                );
             })
             .doFinally(sig -> log.info("Streaming finished with signal {} for user {} term '{}'", sig, userId, term));
     }

--- a/backend/src/main/java/com/glancy/backend/service/WordService.java
+++ b/backend/src/main/java/com/glancy/backend/service/WordService.java
@@ -91,7 +91,8 @@ public class WordService {
             searchRecordService.saveRecord(userId, req);
         } catch (Exception e) {
             log.error("Failed to save search record for user {}", userId, e);
-            return Flux.error(e);
+            String msg = "Failed to save search record: " + e.getMessage();
+            return Flux.error(new IllegalStateException(msg, e));
         }
         try {
             return wordSearcher
@@ -100,7 +101,8 @@ public class WordService {
                 .doOnError(err -> log.error("Error streaming term '{}': {}", term, err.getMessage(), err));
         } catch (Exception e) {
             log.error("Error initiating streaming search for term '{}': {}", term, e.getMessage(), e);
-            return Flux.error(e);
+            String msg = "Failed to initiate streaming search: " + e.getMessage();
+            return Flux.error(new IllegalStateException(msg, e));
         }
     }
 

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerStreamingTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerStreamingTest.java
@@ -13,7 +13,9 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.core.ParameterizedTypeReference;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -71,5 +73,37 @@ class WordControllerStreamingTest {
             .getResponseBody();
 
         StepVerifier.create(body).expectNext("part1", "part2").verifyComplete();
+    }
+
+    /**
+     * 测试流式接口在服务抛出错误时能够返回错误事件。
+     */
+    @Test
+    void testStreamWordError() {
+        when(wordService.streamWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null)))
+            .thenReturn(Flux.error(new IllegalStateException("boom")));
+        when(userService.authenticateToken("tkn")).thenReturn(1L);
+
+        Flux<ServerSentEvent<String>> body = webTestClient
+            .get()
+            .uri(uriBuilder ->
+                uriBuilder
+                    .path("/api/words/stream")
+                    .queryParam("term", "hello")
+                    .queryParam("language", "ENGLISH")
+                    .build()
+            )
+            .header("X-USER-TOKEN", "tkn")
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .returnResult(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
+            .getResponseBody();
+
+        StepVerifier
+            .create(body)
+            .expectNextMatches(evt -> "error".equals(evt.event()) && "boom".equals(evt.data()))
+            .verifyComplete();
     }
 }

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
@@ -1,0 +1,59 @@
+package com.glancy.backend.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.glancy.backend.client.DictionaryClient;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.llm.service.WordSearcher;
+import com.glancy.backend.repository.UserPreferenceRepository;
+import com.glancy.backend.repository.WordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * 验证 streamWordForUser 在出现异常时会封装 IllegalStateException。
+ */
+class WordServiceStreamingErrorTest {
+
+    private WordService wordService;
+
+    @Mock
+    private DictionaryClient dictionaryClient;
+
+    @Mock
+    private WordSearcher wordSearcher;
+
+    @Mock
+    private WordRepository wordRepository;
+
+    @Mock
+    private UserPreferenceRepository userPreferenceRepository;
+
+    @Mock
+    private SearchRecordService searchRecordService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        wordService =
+            new WordService(
+                dictionaryClient,
+                wordSearcher,
+                wordRepository,
+                userPreferenceRepository,
+                searchRecordService
+            );
+    }
+
+    @Test
+    void wrapsExceptionFromSearcher() {
+        when(wordSearcher.streamSearch(any(), any(), any())).thenThrow(new RuntimeException("boom"));
+        Flux<String> result = wordService.streamWordForUser(1L, "hello", Language.ENGLISH, null);
+        StepVerifier.create(result).expectErrorMatches(e -> e instanceof IllegalStateException && e.getMessage().contains("boom")).verify();
+    }
+}

--- a/website/glancy-website/src/api/words.js
+++ b/website/glancy-website/src/api/words.js
@@ -57,11 +57,24 @@ export function createWordsApi(request = apiRequest) {
         const parts = buffer.split("\n\n");
         buffer = parts.pop();
         for (const part of parts) {
-          const line = part.trim();
-          if (!line.startsWith("data:")) continue;
-          const text = line.replace(/^data:\s*/, "");
-          console.info("streamWord chunk", text);
-          yield text;
+          const lines = part.split("\n");
+          let event = "message";
+          let data = "";
+          for (const line of lines) {
+            if (line.startsWith("event:")) {
+              event = line.replace(/^event:\s*/, "");
+            } else if (line.startsWith("data:")) {
+              data += line.replace(/^data:\s*/, "");
+            }
+          }
+          if (event === "error") {
+            console.info("streamWord error", data);
+            throw new Error(data);
+          }
+          if (data) {
+            console.info("streamWord chunk", data);
+            yield data;
+          }
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- propagate detailed errors through SSE
- wrap streaming exceptions for clear messages
- parse frontend SSE error events and surface to UI

## Testing
- `npx eslint src/api/words.js src/api/__tests__/words.stream.test.js --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/api/words.js src/api/__tests__/words.stream.test.js`
- `npm test -- src/api/__tests__/words.stream.test.js` *(fails: Syntax error reading regular expression)*
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cb65acb48332a26490dd1ebe56d8