### PR TITLE
feat: 增强流式日志追踪

### DIFF
--- a/website/glancy-website/src/api/__tests__/words.stream.test.js
+++ b/website/glancy-website/src/api/__tests__/words.stream.test.js
@@ -16,7 +16,9 @@ test("streamWord yields chunks with logging", async () => {
   });
 
   const originalFetch = global.fetch;
-  global.fetch = jest.fn().mockResolvedValue({ body: stream });
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ body: stream, ok: true, status: 200 });
   const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
 
   const chunks = [];
@@ -37,8 +39,16 @@ test("streamWord yields chunks with logging", async () => {
     }),
   );
   expect(chunks).toEqual(["part1", "part2"]);
-  expect(infoSpy).toHaveBeenCalledWith("streamWord chunk", "part1");
-  expect(infoSpy).toHaveBeenCalledWith("streamWord chunk", "part2");
+  expect(infoSpy).toHaveBeenCalledWith("[streamWord] chunk", {
+    userId: "u",
+    term: "hello",
+    chunk: "part1",
+  });
+  expect(infoSpy).toHaveBeenCalledWith("[streamWord] chunk", {
+    userId: "u",
+    term: "hello",
+    chunk: "part2",
+  });
 
   infoSpy.mockRestore();
   global.fetch = originalFetch;
@@ -58,7 +68,9 @@ test("streamWord throws on error event", async () => {
   });
 
   const originalFetch = global.fetch;
-  global.fetch = jest.fn().mockResolvedValue({ body: stream });
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ body: stream, ok: true, status: 200 });
   const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
 
   await expect(
@@ -73,7 +85,11 @@ test("streamWord throws on error event", async () => {
     })(),
   ).rejects.toThrow("boom");
 
-  expect(infoSpy).toHaveBeenCalledWith("streamWord error", "boom");
+  expect(infoSpy).toHaveBeenCalledWith("[streamWord] error", {
+    userId: "u",
+    term: "hello",
+    error: "boom",
+  });
 
   infoSpy.mockRestore();
   global.fetch = originalFetch;

--- a/website/glancy-website/src/hooks/useStreamWord.js
+++ b/website/glancy-website/src/hooks/useStreamWord.js
@@ -2,16 +2,19 @@ import { useApi } from "@/hooks/useApi.js";
 import { detectWordLanguage, clientNameFromModel } from "@/utils";
 
 /**
- * 提供基于 SSE 的词汇查询流式接口。
+ * 提供基于 SSE 的词汇查询流式接口，并输出统一格式日志。
+ * 日志格式:
+ *   console.info("[streamWordWithHandling] <阶段>", { userId, term, chunk?, error? })
  * 对每个流片段返回文本及检测语言。
  */
 export function useStreamWord() {
   const api = useApi();
   const { streamWord } = api.words;
 
-  return async function* ({ user, term, model, signal }) {
+  return async function* streamWordWithHandling({ user, term, model, signal }) {
     const language = detectWordLanguage(term);
-    console.info("[useStreamWord] start", term);
+    const logCtx = { userId: user.id, term };
+    console.info("[streamWordWithHandling] start", logCtx);
     try {
       for await (const chunk of streamWord({
         userId: user.id,
@@ -21,12 +24,12 @@ export function useStreamWord() {
         token: user.token,
         signal,
       })) {
-        console.info("[useStreamWord] chunk", chunk);
+        console.info("[streamWordWithHandling] chunk", { ...logCtx, chunk });
         yield { chunk, language };
       }
-      console.info("[useStreamWord] end", term);
+      console.info("[streamWordWithHandling] end", logCtx);
     } catch (error) {
-      console.info("[useStreamWord] error", error);
+      console.info("[streamWordWithHandling] error", { ...logCtx, error });
       throw error;
     }
   };


### PR DESCRIPTION
## Summary
- 统一 streamWord 词汇流式查询日志格式，记录用户与词条
- 为聊天流式接口输出模型与消息数量的追踪信息
- 更新前端词汇流式测试以匹配新的日志结构

## Testing
- `npx prettier -w src/api/words.js src/hooks/useStreamWord.js src/api/chat.js src/api/__tests__/words.stream.test.js`
- `npx eslint src/hooks/useStreamWord.js src/api/words.js src/api/chat.js src/api/__tests__/words.stream.test.js --fix`
- `npx stylelint "src/**/*.css" --fix`
- `NODE_OPTIONS='--experimental-vm-modules' npx jest src/api/__tests__/words.stream.test.js --runInBand` *(fails: Syntax error reading regular expression)*
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a613f994048332be7e230500515808