### PR TITLE
refactor: inject shared ObjectMapper

### DIFF
--- a/backend/src/main/java/com/glancy/backend/config/JacksonConfig.java
+++ b/backend/src/main/java/com/glancy/backend/config/JacksonConfig.java
@@ -1,0 +1,19 @@
+package com.glancy.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+/**
+ * 统一的 Jackson 配置，集中管理 JSON 序列化策略，避免各处自行创建实例。
+ */
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+        return builder.build();
+    }
+}
+

--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -16,10 +16,11 @@ import reactor.core.publisher.Flux;
 @Component("doubaoStreamDecoder")
 public class DoubaoStreamDecoder implements StreamDecoder {
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper;
     private final Map<String, Function<String, Flux<String>>> handlers;
 
-    public DoubaoStreamDecoder() {
+    public DoubaoStreamDecoder(ObjectMapper mapper) {
+        this.mapper = mapper;
         Map<String, Function<String, Flux<String>>> map = new HashMap<>();
         map.put("message", this::handleMessage);
         map.put("error", this::handleError);

--- a/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -3,6 +3,7 @@ package com.glancy.backend.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glancy.backend.config.DoubaoProperties;
 import com.glancy.backend.llm.model.ChatMessage;
 import com.glancy.backend.llm.stream.DoubaoStreamDecoder;
@@ -39,7 +40,11 @@ class DoubaoClientTest {
     @Test
     void chatReturnsContent() {
         ExchangeFunction ef = this::successResponse;
-        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
+        client = new DoubaoClient(
+            WebClient.builder().exchangeFunction(ef),
+            properties,
+            new DoubaoStreamDecoder(new ObjectMapper())
+        );
         String result = client.chat(List.of(new ChatMessage("user", "hi")), 0.5);
         assertEquals("hi", result);
     }
@@ -48,7 +53,11 @@ class DoubaoClientTest {
     @Test
     void chatUnauthorizedThrowsException() {
         ExchangeFunction ef = req -> Mono.just(ClientResponse.create(HttpStatus.UNAUTHORIZED).build());
-        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
+        client = new DoubaoClient(
+            WebClient.builder().exchangeFunction(ef),
+            properties,
+            new DoubaoStreamDecoder(new ObjectMapper())
+        );
         assertThrows(com.glancy.backend.exception.UnauthorizedException.class, () ->
             client.chat(List.of(new ChatMessage("user", "hi")), 0.5)
         );
@@ -58,7 +67,11 @@ class DoubaoClientTest {
     @Test
     void streamChatEmitsSegments() {
         ExchangeFunction ef = this::streamSuccessResponse;
-        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
+        client = new DoubaoClient(
+            WebClient.builder().exchangeFunction(ef),
+            properties,
+            new DoubaoStreamDecoder(new ObjectMapper())
+        );
         Flux<String> flux = client.streamChat(List.of(new ChatMessage("u", "hi")), 0.5);
         StepVerifier.create(flux).expectNext("he").expectNext("llo").verifyComplete();
     }
@@ -67,7 +80,11 @@ class DoubaoClientTest {
     @Test
     void streamChatErrorEvent() {
         ExchangeFunction ef = this::streamErrorResponse;
-        client = new DoubaoClient(WebClient.builder().exchangeFunction(ef), properties, new DoubaoStreamDecoder());
+        client = new DoubaoClient(
+            WebClient.builder().exchangeFunction(ef),
+            properties,
+            new DoubaoStreamDecoder(new ObjectMapper())
+        );
         Flux<String> flux = client.streamChat(List.of(new ChatMessage("u", "hi")), 0.5);
         StepVerifier.create(flux).expectNext("hi").expectErrorMessage("boom").verify();
     }


### PR DESCRIPTION
## Summary
- refactor DoubaoStreamDecoder to receive ObjectMapper via constructor
- centralize ObjectMapper creation in JacksonConfig
- update Doubao client tests for new constructor

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply` *(failed: The build could not read 1 project: Non-resolvable parent POM due to network is unreachable)*
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a61901761c8332bbcd166fd28086e7