### PR TITLE
feat: improve Doubao stream decoding

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -35,7 +35,13 @@ public class DoubaoStreamDecoder implements StreamDecoder {
             .bufferUntil(String::isEmpty)
             .map(this::toEvent)
             .takeUntil(evt -> "end".equals(evt.type))
-            .flatMap(evt -> handlers.getOrDefault(evt.type, d -> Flux.empty()).apply(evt.data.toString()));
+            .flatMap(
+                evt -> {
+                    if (evt.type == null || !handlers.containsKey(evt.type)) {
+                        return Flux.empty();
+                    }
+                    return handlers.get(evt.type).apply(evt.data.toString());
+                });
     }
 
     private Event toEvent(List<String> lines) {
@@ -49,6 +55,9 @@ public class DoubaoStreamDecoder implements StreamDecoder {
                 }
                 evt.data.append(line.substring(5).trim());
             }
+        }
+        if (evt.type == null) {
+            evt.type = "message";
         }
         return evt;
     }


### PR DESCRIPTION
## Summary
- default event type to message when none parsed
- skip unknown events during stream decoding

## Testing
- `npx eslint --fix backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java` *(fails: ESLint couldn't find a configuration file)*
- `npx stylelint "backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java" --fix` *(fails: npm error canceled)*
- `npx prettier -w backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java` *(fails: No parser could be inferred for file)*
- `mvn -q spotless:apply` *(fails: No plugin found for prefix 'spotless')*
- `mvn test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a619106fb88332bb3aa777f3d92ccd