### PR TITLE
feat: introduce DoubaoEventType enum for stream decoding

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoEventType.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoEventType.java
@@ -1,0 +1,34 @@
+package com.glancy.backend.llm.stream;
+
+/**
+ * 抖宝流式事件类型枚举。使用统一的枚举有助于在解析和测试中避免魔法字符串，
+ * 并为未来协议扩展提供集中管理的入口。
+ */
+public enum DoubaoEventType {
+    MESSAGE("message"),
+    ERROR("error"),
+    END("end");
+
+    private final String label;
+
+    DoubaoEventType(String label) {
+        this.label = label;
+    }
+
+    /**
+     * 根据事件字符串解析枚举，无法识别的值默认为 MESSAGE。
+     */
+    public static DoubaoEventType from(String value) {
+        for (DoubaoEventType type : values()) {
+            if (type.label.equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        return MESSAGE;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -12,18 +12,19 @@ import reactor.core.publisher.Flux;
 /**
  * 针对抖宝流式事件格式的解析器。通过事件类型与处理器映射，
  * 保持协议扩展的开放性，同时对常见事件进行内聚处理。
+ * 事件类型由 {@link DoubaoEventType} 统一定义。
  */
 @Component("doubaoStreamDecoder")
 public class DoubaoStreamDecoder implements StreamDecoder {
 
     private final ObjectMapper mapper = new ObjectMapper();
-    private final Map<String, Function<String, Flux<String>>> handlers;
+    private final Map<DoubaoEventType, Function<String, Flux<String>>> handlers;
 
     public DoubaoStreamDecoder() {
-        Map<String, Function<String, Flux<String>>> map = new HashMap<>();
-        map.put("message", this::handleMessage);
-        map.put("error", this::handleError);
-        map.put("end", data -> Flux.empty());
+        Map<DoubaoEventType, Function<String, Flux<String>>> map = new HashMap<>();
+        map.put(DoubaoEventType.MESSAGE, this::handleMessage);
+        map.put(DoubaoEventType.ERROR, this::handleError);
+        map.put(DoubaoEventType.END, data -> Flux.empty());
         this.handlers = Map.copyOf(map);
     }
 
@@ -34,15 +35,21 @@ public class DoubaoStreamDecoder implements StreamDecoder {
             .map(String::trim)
             .bufferUntil(String::isEmpty)
             .map(this::toEvent)
-            .takeUntil(evt -> "end".equals(evt.type))
-            .flatMap(evt -> handlers.getOrDefault(evt.type, d -> Flux.empty()).apply(evt.data.toString()));
+            .takeUntil(evt -> DoubaoEventType.END == evt.type)
+            .flatMap(
+                evt ->
+                    handlers
+                        .getOrDefault(evt.type, d -> Flux.empty())
+                        .apply(evt.data.toString())
+            );
     }
 
     private Event toEvent(List<String> lines) {
         Event evt = new Event();
+        evt.type = DoubaoEventType.MESSAGE;
         for (String line : lines) {
             if (line.startsWith("event:")) {
-                evt.type = line.substring(6).trim();
+                evt.type = DoubaoEventType.from(line.substring(6).trim());
             } else if (line.startsWith("data:")) {
                 if (evt.data.length() > 0) {
                     evt.data.append('\n');
@@ -74,8 +81,7 @@ public class DoubaoStreamDecoder implements StreamDecoder {
     }
 
     private static class Event {
-
-        String type;
+        DoubaoEventType type;
         StringBuilder data = new StringBuilder();
     }
 }

--- a/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.glancy.backend.config.DoubaoProperties;
 import com.glancy.backend.llm.model.ChatMessage;
+import com.glancy.backend.llm.stream.DoubaoEventType;
 import com.glancy.backend.llm.stream.DoubaoStreamDecoder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,14 +76,16 @@ class DoubaoClientTest {
     private Mono<ClientResponse> successResponse(ClientRequest request) {
         assertEquals("http://mock/api/v3/chat/completions", request.url().toString());
         assertEquals("Bearer key", request.headers().getFirst(HttpHeaders.AUTHORIZATION));
-        String body = """
-            event: message
-            data: {"choices":[{"delta":{"content":"hi"}}]}
+        String body =
+            """
+                event: %s
+                data: {"choices":[{"delta":{"content":"hi"}}]}
 
-            event: end
-            data: {"code":0}
+                event: %s
+                data: {"code":0}
 
-            """;
+                """
+                .formatted(DoubaoEventType.MESSAGE, DoubaoEventType.END);
         return Mono.just(
             ClientResponse.create(HttpStatus.OK)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -92,17 +95,23 @@ class DoubaoClientTest {
     }
 
     private Mono<ClientResponse> streamSuccessResponse(ClientRequest request) {
-        String body = """
-            event: message
-            data: {"choices":[{"delta":{"content":"he"}}]}
+        String body =
+            """
+                event: %s
+                data: {"choices":[{"delta":{"content":"he"}}]}
 
-            event: message
-            data: {"choices":[{"delta":{"content":"llo"}}]}
+                event: %s
+                data: {"choices":[{"delta":{"content":"llo"}}]}
 
-            event: end
-            data: {"code":0}
+                event: %s
+                data: {"code":0}
 
-            """;
+                """
+                .formatted(
+                    DoubaoEventType.MESSAGE,
+                    DoubaoEventType.MESSAGE,
+                    DoubaoEventType.END
+                );
         return Mono.just(
             ClientResponse.create(HttpStatus.OK)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -112,14 +121,16 @@ class DoubaoClientTest {
     }
 
     private Mono<ClientResponse> streamErrorResponse(ClientRequest request) {
-        String body = """
-            event: message
-            data: {"choices":[{"delta":{"content":"hi"}}]}
+        String body =
+            """
+                event: %s
+                data: {"choices":[{"delta":{"content":"hi"}}]}
 
-            event: error
-            data: {"message":"boom"}
+                event: %s
+                data: {"message":"boom"}
 
-            """;
+                """
+                .formatted(DoubaoEventType.MESSAGE, DoubaoEventType.ERROR);
         return Mono.just(
             ClientResponse.create(HttpStatus.OK)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM_VALUE)


### PR DESCRIPTION
## Summary
- add DoubaoEventType enum to centralize stream event types
- update DoubaoStreamDecoder to use enums and simplify event parsing
- adjust client tests to build mock streams using DoubaoEventType

## Testing
- `npm --prefix website/glancy-website ci`
- `npx --yes --prefix website/glancy-website eslint --fix .` *(fails: ESLint couldn't find an eslint.config file)*
- `npx --yes --prefix website/glancy-website stylelint "**/*.{css,scss,vue}" --fix`
- `npx --yes --prefix website/glancy-website prettier -w .`
- `mvn -q spotless:apply` *(fails: could not resolve parent POM from aliyun repository)*
- `mvn -q test` *(fails: could not resolve parent POM from aliyun repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a618f156b883329913fdbbd2d2a04a