### PR TITLE
refactor: propagate stream decode errors

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
@@ -13,6 +14,7 @@ import reactor.core.publisher.Flux;
  * 针对抖宝流式事件格式的解析器。通过事件类型与处理器映射，
  * 保持协议扩展的开放性，同时对常见事件进行内聚处理。
  */
+@Slf4j
 @Component("doubaoStreamDecoder")
 public class DoubaoStreamDecoder implements StreamDecoder {
 
@@ -68,7 +70,9 @@ public class DoubaoStreamDecoder implements StreamDecoder {
             String content = node.path("choices").path(0).path("delta").path("content").asText();
             return content.isEmpty() ? Flux.empty() : Flux.just(content);
         } catch (Exception e) {
-            return Flux.empty();
+            StreamDecodeException ex = new StreamDecodeException("message", json, e);
+            log.error("Failed to decode message event: {}", json, e);
+            return Flux.error(ex);
         }
     }
 
@@ -78,7 +82,9 @@ public class DoubaoStreamDecoder implements StreamDecoder {
             String msg = node.path("message").asText("Stream error");
             return Flux.error(new IllegalStateException(msg));
         } catch (Exception e) {
-            return Flux.error(new IllegalStateException("Stream error"));
+            StreamDecodeException ex = new StreamDecodeException("error", json, e);
+            log.error("Failed to decode error event: {}", json, e);
+            return Flux.error(ex);
         }
     }
 

--- a/backend/src/main/java/com/glancy/backend/llm/stream/StreamDecodeException.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/StreamDecodeException.java
@@ -1,0 +1,24 @@
+package com.glancy.backend.llm.stream;
+
+/**
+ * 表示流式事件在解析过程中出现问题，携带事件类型与原始负载，便于定位。
+ */
+public class StreamDecodeException extends RuntimeException {
+
+    private final String eventType;
+    private final String payload;
+
+    public StreamDecodeException(String eventType, String payload, Throwable cause) {
+        super("Failed to decode event '" + eventType + "'", cause);
+        this.eventType = eventType;
+        this.payload = payload;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/WordService.java
+++ b/backend/src/main/java/com/glancy/backend/service/WordService.java
@@ -98,7 +98,17 @@ public class WordService {
             return wordSearcher
                 .streamSearch(term, language, model)
                 .doOnNext(chunk -> log.info("Streaming chunk for term '{}': {}", term, chunk))
-                .doOnError(err -> log.error("Error streaming term '{}': {}", term, err.getMessage(), err));
+                .doOnError(err ->
+                    log.error(
+                        "Streaming error for user {} term '{}' in language {} using model {}: {}",
+                        userId,
+                        term,
+                        language,
+                        model,
+                        err.getMessage(),
+                        err
+                    )
+                );
         } catch (Exception e) {
             log.error("Error initiating streaming search for term '{}': {}", term, e.getMessage(), e);
             String msg = "Failed to initiate streaming search: " + e.getMessage();


### PR DESCRIPTION
## Summary
- add StreamDecodeException and propagate parsing errors in Doubao decoder
- enrich streaming error logs with user context in WordService

## Testing
- `npx eslint --fix .` *(fails: Cannot find package '@eslint/js')*
- `npx stylelint --fix "**/*.{css,scss,vue}"` *(fails: Need to install the following packages: stylelint@16.23.1)*
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: No plugin found for prefix 'spotless')*
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a61e734a04833291372a7c08624699