### PR TITLE
fix: adjust doubao stream decoding and add tests

### DIFF
--- a/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -94,7 +94,7 @@ class DoubaoClientTest {
         assertEquals("Bearer key", request.headers().getFirst(HttpHeaders.AUTHORIZATION));
         String body = """
             event: message
-            data: {"choices":[{"delta":{"content":"hi"}}]}
+            data: {"choices":[{"delta":{"content":[{"text":"hi"}]}}]}
 
             event: end
             data: {"code":0}
@@ -111,10 +111,10 @@ class DoubaoClientTest {
     private Mono<ClientResponse> streamSuccessResponse(ClientRequest request) {
         String body = """
             event: message
-            data: {"choices":[{"delta":{"content":"he"}}]}
+            data: {"choices":[{"delta":{"content":[{"text":"he"}]}}]}
 
             event: message
-            data: {"choices":[{"delta":{"content":"llo"}}]}
+            data: {"choices":[{"delta":{"content":[{"text":"llo"}]}}]}
 
             event: end
             data: {"code":0}
@@ -131,7 +131,7 @@ class DoubaoClientTest {
     private Mono<ClientResponse> streamErrorResponse(ClientRequest request) {
         String body = """
             event: message
-            data: {"choices":[{"delta":{"content":"hi"}}]}
+            data: {"choices":[{"delta":{"content":[{"text":"hi"}]}}]}
 
             event: error
             data: {"message":"boom"}

--- a/backend/src/test/java/com/glancy/backend/llm/stream/DoubaoStreamDecoderTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/stream/DoubaoStreamDecoderTest.java
@@ -1,0 +1,65 @@
+package com.glancy.backend.llm.stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/** 针对抖宝流式事件解析的单元测试。 */
+class DoubaoStreamDecoderTest {
+
+    private final DoubaoStreamDecoder decoder = new DoubaoStreamDecoder(new ObjectMapper());
+
+    /**
+     * 模拟两个 message 事件与 end 事件，验证解码器按顺序输出内容。
+     */
+    @Test
+    void decodeMessageEvent() {
+        String body = """
+            event: message
+            data: {"choices":[{"delta":{"content":[{"text":"he"}]}}]}
+
+            event: message
+            data: {"choices":[{"delta":{"content":[{"text":"llo"}]}}]}
+
+            event: end
+            data: {"code":0}
+
+            """;
+        Flux<String> flux = decoder.decode(Flux.just(body));
+        StepVerifier.create(flux).expectNext("he").expectNext("llo").verifyComplete();
+    }
+
+    /**
+     * 模拟 message 事件缺失内容字段，验证解析失败并记录 WARN 日志。
+     */
+    @Test
+    void decodeInvalidMessageLogsWarn() {
+        Logger logger = (Logger) LoggerFactory.getLogger(DoubaoStreamDecoder.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        String body = """
+            event: message
+            data: {"choices":[{"delta":{}}]}
+
+            event: end
+            data: {"code":0}
+
+            """;
+        StepVerifier.create(decoder.decode(Flux.just(body))).verifyComplete();
+        boolean hasWarn = appender
+            .list
+            .stream()
+            .anyMatch(e -> e.getLevel() == Level.WARN && e.getMessage().contains("Failed to parse"));
+        assertTrue(hasWarn);
+    }
+}


### PR DESCRIPTION
## Summary
- update Doubao stream decoder to parse official JSON structure and log warnings on parse failure
- cover typical and malformed Doubao stream events with dedicated unit tests

## Testing
- `npx --yes eslint . --fix` *(fails: Cannot find package '@eslint/js')*
- `npx --yes stylelint "src/**/*.css" --fix` *(fails: Could not find stylelint-config-standard)*
- `npx --yes prettier -w .`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a61e733f248332827408a41c9b2b5f