### PR TITLE
feat: handle empty SSE message events robustly

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -68,6 +68,13 @@ public class DoubaoStreamDecoder implements StreamDecoder {
 
     private Flux<String> handleMessage(String json) {
         log.debug("Handle message event: {}", json);
+        if (json == null || json.trim().isEmpty()) {
+            log.warn(
+                "Empty message event data, ignoring event: raw={}",
+                SensitiveDataUtil.previewText(json)
+            );
+            return Flux.empty();
+        }
         try {
             JsonNode node = mapper.readTree(json);
             JsonNode delta = node.path("choices").path(0).path("delta");
@@ -81,7 +88,11 @@ public class DoubaoStreamDecoder implements StreamDecoder {
             }
             return Flux.just(content);
         } catch (Exception e) {
-            log.warn("Failed to decode message event: {}", SensitiveDataUtil.previewText(json), e);
+            log.warn(
+                "Failed to decode message event, raw={}",
+                SensitiveDataUtil.previewText(json),
+                e
+            );
             return Flux.empty();
         }
     }


### PR DESCRIPTION
## Summary
- ensure SSE message handler ignores and logs empty data
- improve logging when message event JSON parsing fails
- test empty data message event handling

## Testing
- `npx eslint --fix` *(fails: ESLint couldn't find a configuration file)*
- `npx stylelint "**/*.{css,scss,vue}" --fix` *(fails: needs to install stylelint package)*
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: No plugin found for prefix 'spotless')*
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e5d2dd883329541865b087d2a1e