### PR TITLE
修复搜索记录语言参数缺失

### DIFF
--- a/website/glancy-website/src/store/__tests__/historyStore.test.js
+++ b/website/glancy-website/src/store/__tests__/historyStore.test.js
@@ -1,41 +1,52 @@
-import { jest } from '@jest/globals'
-import { act } from '@testing-library/react'
-import api from '@/api/index.js'
-import { useHistoryStore } from '@/store'
+import { jest } from "@jest/globals";
+import { act } from "@testing-library/react";
+import api from "@/api/index.js";
+import { useHistoryStore } from "@/store";
 
-const mockApi = api
+const mockApi = api;
 mockApi.searchRecords = {
   fetchSearchRecords: jest.fn().mockResolvedValue([]),
-  saveSearchRecord: jest.fn().mockResolvedValue({ id: 'r1' }),
+  saveSearchRecord: jest.fn().mockResolvedValue({ id: "r1" }),
   clearSearchRecords: jest.fn().mockResolvedValue(undefined),
   deleteSearchRecord: jest.fn().mockResolvedValue(undefined),
   favoriteSearchRecord: jest.fn().mockResolvedValue(undefined),
-  unfavoriteSearchRecord: jest.fn().mockResolvedValue(undefined)
-}
+  unfavoriteSearchRecord: jest.fn().mockResolvedValue(undefined),
+};
 
-const user = { id: 'u1', token: 't' }
+const user = { id: "u1", token: "t" };
 
-describe('historyStore', () => {
+describe("historyStore", () => {
   beforeEach(() => {
-    localStorage.clear()
-    jest.clearAllMocks()
-  })
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
 
-  test('addHistory stores term and calls api', async () => {
+  test("addHistory stores term and calls api", async () => {
     await act(async () => {
-      await useHistoryStore.getState().addHistory('test', user, 'ENGLISH')
-    })
-    expect(mockApi.searchRecords.saveSearchRecord).toHaveBeenCalled()
-    expect(useHistoryStore.getState().history[0]).toBe('test')
-  })
+      await useHistoryStore.getState().addHistory("test", user, "ENGLISH");
+    });
+    expect(mockApi.searchRecords.saveSearchRecord).toHaveBeenCalled();
+    expect(useHistoryStore.getState().history[0]).toBe("test");
+  });
 
-  test('clearHistory empties store', async () => {
+  test("addHistory infers language when missing", async () => {
     await act(async () => {
-      await useHistoryStore.getState().addHistory('a', user)
-    })
+      await useHistoryStore.getState().addHistory("word", user);
+    });
+    expect(mockApi.searchRecords.saveSearchRecord).toHaveBeenCalledWith({
+      token: user.token,
+      term: "word",
+      language: "ENGLISH",
+    });
+  });
+
+  test("clearHistory empties store", async () => {
     await act(async () => {
-      await useHistoryStore.getState().clearHistory(user)
-    })
-    expect(useHistoryStore.getState().history).toHaveLength(0)
-  })
-})
+      await useHistoryStore.getState().addHistory("a", user);
+    });
+    await act(async () => {
+      await useHistoryStore.getState().clearHistory(user);
+    });
+    expect(useHistoryStore.getState().history).toHaveLength(0);
+  });
+});

--- a/website/glancy-website/src/store/historyStore.ts
+++ b/website/glancy-website/src/store/historyStore.ts
@@ -2,6 +2,7 @@ import api from "@/api/index.js";
 import { createPersistentStore } from "./createPersistentStore.ts";
 import { pickState } from "./persistUtils.ts";
 import type { User } from "./userStore.ts";
+import { detectWordLanguage } from "@/utils";
 
 interface HistoryState {
   history: string[];
@@ -72,12 +73,13 @@ export const useHistoryStore = createPersistentStore<HistoryState>({
         user?: User | null,
         language?: string,
       ) => {
+        const langToSave = language ?? detectWordLanguage(term);
         if (user) {
           try {
             const record = await api.searchRecords.saveSearchRecord({
               token: user.token,
               term,
-              language,
+              language: langToSave,
             });
             set((state) => ({
               recordMap: { ...state.recordMap, [term]: record.id },


### PR DESCRIPTION
## Summary
- 自动根据词条检测语言并在保存搜索历史时补齐
- 为历史记录存储逻辑新增语言推断测试

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/store/historyStore.ts src/store/__tests__/historyStore.test.js`
- `npm test` *(失败: Syntax error reading regular expression, Node 内存不足)*
- `mvn -q spotless:apply` *(失败: 无法解析依赖)*
- `mvn -q test` *(失败: 无法解析依赖)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e65b4748332805bf14891573c36