### PR TITLE
fix: robust doubao sse parsing

### DIFF
--- a/backend/src/test/java/com/glancy/backend/llm/stream/DoubaoStreamDecoderTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/stream/DoubaoStreamDecoderTest.java
@@ -93,4 +93,19 @@ class DoubaoStreamDecoderTest {
 
         logger.detachAppender(appender);
     }
+
+    /**
+     * 验证跨 chunk 的事件能够被正确拼接解析。
+     */
+    @Test
+    void decodeChunkedEvent() {
+        Flux<String> chunks = Flux.just(
+            "event: message\n",
+            "data: {\"choices\":[{\"delta\":{\"messages\":[{\"content\":\"hi\"}]}}]}\n\n",
+            "event: end\n",
+            "data: {\"code\":0}\n\n"
+        );
+
+        StepVerifier.create(decoder.decode(chunks)).expectNext("hi").verifyComplete();
+    }
 }


### PR DESCRIPTION
## Summary
- handle fragmented SSE events from Doubao by buffering and splitting on blank lines
- add regression test covering chunked Doubao responses

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w .`
- `mvn spotless:apply` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to aliyun)*
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to aliyun)*

------
https://chatgpt.com/codex/tasks/task_e_68a7344005c08332a6e5c1765bff8365