### PR TITLE
refactor: 提升抖宝流式日志级别

### DIFF
--- a/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -64,11 +64,8 @@ public class DoubaoClient implements LLMClient {
         for (ChatMessage m : messages) {
             reqMessages.add(Map.of("role", m.getRole(), "content", m.getContent()));
         }
-        log.debug(
-            "Prepared {} request messages: roles={}",
-            reqMessages.size(),
-            messages.stream().map(ChatMessage::getRole).toList()
-        );
+        List<String> roles = messages.stream().map(ChatMessage::getRole).toList();
+        log.info("Prepared {} request messages with roles {}", reqMessages.size(), roles);
         body.put("messages", reqMessages);
 
         log.info("Request body prepared for Doubao API: {}", body);
@@ -101,7 +98,7 @@ public class DoubaoClient implements LLMClient {
         }
         return resp
             .bodyToFlux(String.class)
-            .doOnNext(raw -> log.debug("SSE event [{}]: {}", extractEventType(raw), raw));
+            .doOnNext(raw -> log.info("SSE event [{}]: {}", extractEventType(raw), raw));
     }
 
     private String extractEventType(String raw) {

--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -35,7 +35,7 @@ public class DoubaoStreamDecoder implements StreamDecoder {
     public Flux<String> decode(Flux<String> rawStream) {
         return splitEvents(rawStream)
             .map(this::toEvent)
-            .doOnNext(evt -> log.debug("Event [{}]: {}", evt.type, evt.data))
+            .doOnNext(evt -> log.info("Event [{}]: {}", evt.type, evt.data))
             .takeUntil(evt -> "end".equals(evt.type))
             .flatMap(evt -> {
                 if (evt.type == null || !handlers.containsKey(evt.type)) {
@@ -101,7 +101,7 @@ public class DoubaoStreamDecoder implements StreamDecoder {
     }
 
     private Flux<String> handleMessage(String json) {
-        log.debug("Handle message event: {}", json);
+        log.info("Handle message event: {}", json);
         if (json == null || json.trim().isEmpty()) {
             log.warn("Empty message event data, ignoring event: raw={}", SensitiveDataUtil.previewText(json));
             return Flux.empty();
@@ -117,6 +117,7 @@ public class DoubaoStreamDecoder implements StreamDecoder {
                 log.warn("Message event missing content: {}", SensitiveDataUtil.previewText(json));
                 return Flux.empty();
             }
+            log.info("Decoded message chunk: {}", SensitiveDataUtil.previewText(content));
             return Flux.just(content);
         } catch (Exception e) {
             log.warn("Failed to decode message event, raw={}", SensitiveDataUtil.previewText(json), e);
@@ -125,7 +126,7 @@ public class DoubaoStreamDecoder implements StreamDecoder {
     }
 
     private Flux<String> handleError(String json) {
-        log.debug("Handle error event: {}", json);
+        log.info("Handle error event: {}", json);
         try {
             JsonNode node = mapper.readTree(json);
             String msg = node.path("message").asText("Stream error");


### PR DESCRIPTION
## Summary
- 提升 DoubaoClient 与解码器日志为 info，并输出流式分片

## Testing
- `npx eslint --fix .`
- `npx stylelint "**/*.{css,scss,vue}" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply` *(失败: Non-resolvable parent POM)*
- `mvn -q test` *(失败: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a129e988332ba457ce49e75bc4b