### PR TITLE
refactor: centralize sse parsing

### DIFF
--- a/website/glancy-website/src/utils/index.js
+++ b/website/glancy-website/src/utils/index.js
@@ -9,3 +9,4 @@ export { validateEmail, validatePhone, validateAccount } from "./validators.js";
 export { audioManager } from "./audioManager.js";
 export { decodeTtsAudio } from "./audio.js";
 export { createCachedFetcher } from "./cache.js";
+export { parseSse } from "./sse.js";

--- a/website/glancy-website/src/utils/sse.js
+++ b/website/glancy-website/src/utils/sse.js
@@ -1,0 +1,52 @@
+export async function* parseSse(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      while (true) {
+        const separatorIndex = buffer.indexOf("\n\n");
+        if (separatorIndex === -1) break;
+        const rawEvent = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+        const event = { event: "message", data: "" };
+        for (const line of rawEvent.split(/\r?\n/)) {
+          const colonIndex = line.indexOf(":");
+          if (colonIndex === -1) continue;
+          const field = line.slice(0, colonIndex);
+          const valuePart = line.slice(colonIndex + 1).trimStart();
+          if (field === "event") {
+            event.event = valuePart;
+          } else if (field === "data") {
+            event.data += event.data ? `\n${valuePart}` : valuePart;
+          }
+        }
+        if (event.data || event.event !== "message") {
+          yield event;
+        }
+      }
+    }
+    if (buffer.trim()) {
+      const event = { event: "message", data: "" };
+      for (const line of buffer.split(/\r?\n/)) {
+        const colonIndex = line.indexOf(":");
+        if (colonIndex === -1) continue;
+        const field = line.slice(0, colonIndex);
+        const valuePart = line.slice(colonIndex + 1).trimStart();
+        if (field === "event") {
+          event.event = valuePart;
+        } else if (field === "data") {
+          event.data += event.data ? `\n${valuePart}` : valuePart;
+        }
+      }
+      if (event.data) {
+        yield event;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/website/glancy-website/src/utils/sse.test.js
+++ b/website/glancy-website/src/utils/sse.test.js
@@ -1,0 +1,24 @@
+import { parseSse } from "./sse.js";
+
+test("parseSse yields events", async () => {
+  const encoder = new TextEncoder();
+  const sse =
+    "data: one\n\n" +
+    "event: error\ndata: boom\n\n" +
+    "data: multi\ndata: line\n\n";
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(sse));
+      controller.close();
+    },
+  });
+  const events = [];
+  for await (const evt of parseSse(stream)) {
+    events.push(evt);
+  }
+  expect(events).toEqual([
+    { event: "message", data: "one" },
+    { event: "error", data: "boom" },
+    { event: "message", data: "multi\nline" },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add reusable `parseSse` utility for streaming event parsing
- use `parseSse` in word and chat APIs
- cover parser with unit test

## Testing
- `npx eslint --fix src/api/words.js src/api/chat.js src/utils/index.js src/utils/sse.js src/utils/sse.test.js`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/api/words.js src/api/chat.js src/utils/index.js src/utils/sse.js src/utils/sse.test.js`
- `npm test` *(fails: Syntax error reading regular expression)*
- `./mvnw spotless:apply` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a73e97e4948332b1684b4055b75d32