### PR TITLE
fix: forward doubao stream to client

### DIFF
--- a/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -4,14 +4,18 @@ import com.glancy.backend.config.DoubaoProperties;
 import com.glancy.backend.llm.llm.LLMClient;
 import com.glancy.backend.llm.model.ChatMessage;
 import com.glancy.backend.llm.stream.StreamDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -97,7 +101,12 @@ public class DoubaoClient implements LLMClient {
             );
         }
         return resp
-            .bodyToFlux(String.class)
+            .body(BodyExtractors.toFlux(DataBuffer.class))
+            .map(buf -> {
+                String raw = buf.toString(StandardCharsets.UTF_8);
+                DataBufferUtils.release(buf);
+                return raw;
+            })
             .doOnNext(raw -> log.info("SSE event [{}]: {}", extractEventType(raw), raw));
     }
 


### PR DESCRIPTION
## Summary
- stream Doubao SSE using raw DataBuffer so chunks reach client

## Testing
- `npx --yes eslint . --fix`
- `npx --yes --prefix website/glancy-website stylelint "**/*.{css,scss}" --fix`
- `npx --yes --prefix website/glancy-website prettier -w .`
- `npx --yes prettier -w backend/src/main/java/com/glancy/backend/client/DoubaoClient.java` *(fail: No parser could be inferred)*
- `cd backend && mvn -q spotless:apply` *(fail: Non-resolvable parent POM)*
- `cd backend && mvn -q test` *(fail: Non-resolvable parent POM)*
- `npm --prefix website/glancy-website test` *(fail: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a745a460248332ac1ff2afa971a5ee