### PR TITLE
feat: stop SSE stream on done marker

### DIFF
--- a/website/glancy-website/src/api/words.js
+++ b/website/glancy-website/src/api/words.js
@@ -60,6 +60,7 @@ export function createWordsApi(request = apiRequest) {
           console.info("[streamWord] error", { ...logCtx, error: data });
           throw new Error(data);
         }
+        if (data === "[DONE]") break;
         if (data) {
           console.info("[streamWord] chunk", { ...logCtx, chunk: data });
           yield data;


### PR DESCRIPTION
## Summary
- stop yielding words when `[DONE]` is received during SSE streaming
- test words stream halts without emitting `[DONE]`

## Testing
- `npx eslint --fix src/api/words.js src/api/__tests__/words.stream.test.js`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/api/words.js src/api/__tests__/words.stream.test.js`
- `NODE_OPTIONS='--experimental-vm-modules' npx jest src/api/__tests__/words.stream.test.js --runInBand` *(fails: Syntax error reading regular expression)*
- `./mvnw -q spotless:apply` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a74deaf1448332bef40adce4da178e