### PR TITLE
规范 SSE 换行处理并新增 CRLF 测试

### DIFF
--- a/website/glancy-website/src/utils/sse.js
+++ b/website/glancy-website/src/utils/sse.js
@@ -12,7 +12,7 @@ export async function* parseSse(stream) {
       if (done) break;
       const chunk = decoder.decode(value, { stream: true });
       log("chunk", preview(chunk));
-      buffer += chunk;
+      buffer = normalizeNewlines(buffer + chunk);
       while (true) {
         const separatorIndex = buffer.indexOf("\n\n");
         if (separatorIndex === -1) break;
@@ -37,6 +37,7 @@ export async function* parseSse(stream) {
         }
       }
     }
+    buffer = normalizeNewlines(buffer);
     if (buffer.trim()) {
       const event = { event: "message", data: "" };
       for (const line of buffer.split(/\r?\n/)) {
@@ -58,6 +59,10 @@ export async function* parseSse(stream) {
   } finally {
     reader.releaseLock();
   }
+}
+
+function normalizeNewlines(str) {
+  return str.replace(/\r\n?/g, "\n");
 }
 
 function preview(str, len = 100) {

--- a/website/glancy-website/src/utils/sse.test.js
+++ b/website/glancy-website/src/utils/sse.test.js
@@ -1,5 +1,13 @@
+import { TextEncoder, TextDecoder } from "node:util";
+import { ReadableStream } from "node:stream/web";
 import { parseSse } from "./sse.js";
 
+// Jest 环境下需要手动挂载 TextDecoder
+global.TextDecoder = TextDecoder;
+
+/**
+ * 验证 parseSse 在一次性输入中能够解析多个事件
+ */
 test("parseSse yields events", async () => {
   const encoder = new TextEncoder();
   const sse =
@@ -20,5 +28,29 @@ test("parseSse yields events", async () => {
     { event: "message", data: "one" },
     { event: "error", data: "boom" },
     { event: "message", data: "multi\nline" },
+  ]);
+});
+
+/**
+ * 验证 parseSse 在带有 CRLF 的分片数据流中逐事件产出
+ */
+test("parseSse handles chunked CRLF events", async () => {
+  const encoder = new TextEncoder();
+  const chunks = ["data: one\r\n", "\r\n", "data: two\r", "\n\r\n"]; // 分片模拟跨 chunk 的 CRLF
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const part of chunks) {
+        controller.enqueue(encoder.encode(part));
+      }
+      controller.close();
+    },
+  });
+  const events = [];
+  for await (const evt of parseSse(stream)) {
+    events.push(evt);
+  }
+  expect(events).toEqual([
+    { event: "message", data: "one" },
+    { event: "message", data: "two" },
   ]);
 });


### PR DESCRIPTION
## Summary
- 规范化 SSE 解析逻辑，将 CRLF 统一转换为 LF 并正确识别事件分隔
- 补充带 CRLF 的分片解析测试

## Testing
- `npm --prefix website/glancy-website test src/utils/sse.test.js`
- `mvn -q -f backend/pom.xml spotless:apply` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a74de009248332aa648ea5a13790f5