### PR TITLE
feat: handle done event in doubao stream

### DIFF
--- a/backend/src/test/java/com/glancy/backend/llm/stream/DoubaoStreamDecoderTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/stream/DoubaoStreamDecoderTest.java
@@ -108,4 +108,10 @@ class DoubaoStreamDecoderTest {
 
         StepVerifier.create(decoder.decode(chunks)).expectNext("hi").verifyComplete();
     }
+
+    /** 验证单独的 [DONE] 事件能够正常结束流且不抛异常。 */
+    @Test
+    void decodeDoneEvent() {
+        StepVerifier.create(decoder.decode(Flux.just("data: [DONE]\\n\\n"))).verifyComplete();
+    }
 }


### PR DESCRIPTION
## Summary
- handle [DONE] event in Doubao stream by emitting end
- ignore [DONE] in message handler and update tests

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w .`
- `mvn spotless:apply` (fails: Network is unreachable)
- `mvn test` (fails: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68a74dd751f48332af4db859020c656c