### PR TITLE
优化词汇流式获取与展示

### DIFF
--- a/website/glancy-website/src/api/words.js
+++ b/website/glancy-website/src/api/words.js
@@ -43,11 +43,18 @@ export function createWordsApi(request = apiRequest) {
     const params = new URLSearchParams({ userId, term, language });
     if (model) params.append("model", model);
     const url = `${API_PATHS.words}/stream?${params.toString()}`;
-    const headers = token ? { "X-USER-TOKEN": token } : {};
+    const headers = {
+      Accept: "text/event-stream",
+      ...(token ? { "X-USER-TOKEN": token } : {}),
+    };
     const logCtx = { userId, term };
     let response;
     try {
-      response = await fetch(url, { headers, signal });
+      response = await fetch(url, {
+        headers,
+        cache: "no-store",
+        signal,
+      });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
     } catch (err) {
       console.info("[streamWord] error", { ...logCtx, error: err });

--- a/website/glancy-website/src/pages/App/App.css
+++ b/website/glancy-website/src/pages/App/App.css
@@ -60,6 +60,19 @@
   text-align: center;
 }
 
+.stream-text {
+  width: 100%;
+  padding: 16px;
+  text-align: left;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono, monospace);
+  background: var(--app-bg);
+  color: var(--app-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
+}
+
 .display-content {
   display: flex;
   flex-direction: column;

--- a/website/glancy-website/src/pages/App/index.jsx
+++ b/website/glancy-website/src/pages/App/index.jsx
@@ -6,7 +6,6 @@ import { useTheme } from "@/context";
 import DictionaryEntry from "@/components/ui/DictionaryEntry";
 import { useLanguage } from "@/context";
 import { useStreamWord, useSpeechInput } from "@/hooks";
-import ReactMarkdown from "react-markdown";
 import "./App.css";
 import ChatInput from "@/components/ui/ChatInput";
 import Layout from "@/components/Layout";
@@ -239,11 +238,11 @@ function App() {
           ) : showHistory ? (
             <HistoryDisplay />
           ) : loading ? (
-            <pre>{streamText || "..."}</pre>
+            <pre className="stream-text">{streamText || "..."}</pre>
           ) : entry ? (
             <DictionaryEntry entry={entry} />
           ) : streamText ? (
-            <ReactMarkdown>{streamText}</ReactMarkdown>
+            <pre className="stream-text">{streamText}</pre>
           ) : (
             <div className="display-content">
               <div className="display-term">{placeholder}</div>


### PR DESCRIPTION
## Summary
- fetch SSE headers and disable caching to reduce proxy buffering
- render streaming text via lightweight `<pre>` with refined styles

## Testing
- `npx prettier -w src/api/words.js src/pages/App/index.jsx src/pages/App/App.css`
- `npx eslint src/api/words.js src/pages/App/index.jsx --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npm test` *(failed: JavaScript heap out of memory)*
- `npm test src/pages/App/__tests__/streaming.test.jsx`
- `./mvnw -q spotless:apply` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a750fc853c8332b43390fa8e624835