### PR TITLE
refactor: streamline doubao streaming

### DIFF
--- a/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -15,7 +15,6 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -102,7 +101,7 @@ public class DoubaoClient implements LLMClient {
             );
         }
         return resp
-            .body(BodyExtractors.toFlux(DataBuffer.class))
+            .bodyToFlux(DataBuffer.class)
             .map(buf -> {
                 String raw = buf.toString(StandardCharsets.UTF_8);
                 DataBufferUtils.release(buf);


### PR DESCRIPTION
## Summary
- use bodyToFlux for Netty chunk streaming
- refactor DoubaoStreamDecoder with Reactor bufferUntil
- add SSE chunk streaming test

## Testing
- `npx eslint . --fix` (fails: ESLint couldn't find config)
- `npx stylelint "**/*.{css,scss}" --fix` (fails: npm error canceled)
- `npx prettier -w backend/src/main/java/com/glancy/backend/client/DoubaoClient.java backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java backend/src/test/java/com/glancy/backend/llm/stream/DoubaoStreamDecoderTest.java` (fails: no parser could be inferred)
- `./mvnw spotless:apply` (fails: Network is unreachable)
- `./mvnw -q test` (fails: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68a870390d3c8332bc6d61bced18455a