### PR TITLE
Ensure sequential Doubao SSE processing

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
+++ b/backend/src/main/java/com/glancy/backend/llm/stream/DoubaoStreamDecoder.java
@@ -34,7 +34,8 @@ public class DoubaoStreamDecoder implements StreamDecoder {
             .map(this::toEvent)
             .doOnNext(evt -> log.info("Event [{}]: {}", evt.type, evt.data))
             .takeUntil(evt -> "end".equals(evt.type))
-            .flatMap(evt ->
+            // 使用 concatMap 确保事件按接收顺序依次处理
+            .concatMap(evt ->
                 handlers.containsKey(evt.type) ? handlers.get(evt.type).apply(evt.data.toString()) : Flux.empty()
             );
     }


### PR DESCRIPTION
## Summary
- use `concatMap` in `DoubaoStreamDecoder` so events are emitted in receive order

## Testing
- `mvn spotless:apply` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.2.5 from aliyun repository)*
- `mvn test -Dtest=DoubaoStreamDecoderTest,ChatControllerIT` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.2.5 from aliyun repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a8780ed60883328a48dcbfc8862d27