### PR TITLE
feat(streaming): add chunk callback

### DIFF
--- a/website/glancy-website/src/api/words.js
+++ b/website/glancy-website/src/api/words.js
@@ -39,7 +39,15 @@ export function createWordsApi(request = apiRequest) {
    * 日志格式:
    *   console.info("[streamWord] <阶段>", { userId, term, chunk?, error? })
    */
-  async function* streamWord({ userId, term, language, model, token, signal }) {
+  async function* streamWord({
+    userId,
+    term,
+    language,
+    model,
+    token,
+    signal,
+    onChunk,
+  }) {
     const params = new URLSearchParams({ userId, term, language });
     if (model) params.append("model", model);
     const url = `${API_PATHS.words}/stream?${params.toString()}`;
@@ -70,6 +78,7 @@ export function createWordsApi(request = apiRequest) {
         if (data === "[DONE]") break;
         if (data) {
           console.info("[streamWord] chunk", { ...logCtx, chunk: data });
+          if (onChunk) onChunk(data);
           yield data;
         }
       }

--- a/website/glancy-website/src/hooks/useStreamWord.js
+++ b/website/glancy-website/src/hooks/useStreamWord.js
@@ -23,8 +23,10 @@ export function useStreamWord() {
         model: clientNameFromModel(model),
         token: user.token,
         signal,
+        onChunk: (chunk) => {
+          console.info("[streamWordWithHandling] chunk", { ...logCtx, chunk });
+        },
       })) {
-        console.info("[streamWordWithHandling] chunk", { ...logCtx, chunk });
         yield { chunk, language };
       }
       console.info("[streamWordWithHandling] end", logCtx);


### PR DESCRIPTION
## Summary
- support optional onChunk callback in word streaming API
- pass chunk callback through useStreamWord hook

## Testing
- `npx eslint src/api/words.js src/hooks/useStreamWord.js --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/api/words.js src/hooks/useStreamWord.js`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM due to network is unreachable)*
- `npm test src/api/__tests__/words.stream.test.js src/pages/App/__tests__/streaming.test.jsx` *(fails: Syntax error reading regular expression in words.stream.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a8780298d4833283f8005e045765ed