### PR TITLE
feat: support sse error handling

### DIFF
--- a/backend/src/test/java/com/glancy/backend/exception/GlobalExceptionHandlerSseTest.java
+++ b/backend/src/test/java/com/glancy/backend/exception/GlobalExceptionHandlerSseTest.java
@@ -1,0 +1,47 @@
+package com.glancy.backend.exception;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 测试全局异常处理在 SSE 请求下的返回。
+ * 流程：
+ * 1. 发送 Accept 为 text/event-stream 的请求。
+ * 2. 控制器抛出 ResourceNotFoundException。
+ * 3. 验证响应为 SSE 格式错误事件。
+ */
+@WebMvcTest(controllers = GlobalExceptionHandlerSseTest.DummyController.class)
+@Import(GlobalExceptionHandler.class)
+class GlobalExceptionHandlerSseTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @RestController
+    @RequestMapping("/dummy")
+    static class DummyController {
+        @GetMapping("/boom")
+        String boom() {
+            throw new ResourceNotFoundException("missing");
+        }
+    }
+
+    @Test
+    void returnsSseErrorWhenAcceptEventStream() throws Exception {
+        mvc
+            .perform(get("/dummy/boom").accept(MediaType.TEXT_EVENT_STREAM))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
+            .andExpect(content().string("event: error\ndata: {\"message\":\"missing\"}\n\n"));
+    }
+}


### PR DESCRIPTION
## Summary
- handle Accept: text/event-stream requests by formatting errors as SSE
- ensure all exception handlers return JSON by default
- test GlobalExceptionHandler SSE branch

## Testing
- `npx eslint . --fix` *(fails: ESLint couldn't find an eslint.config file)*
- `npx stylelint "**/*.{css,scss}" --fix` *(fails: Need to install the following packages: stylelint)*
- `npx prettier -w .`
- `./mvnw spotless:apply` *(fails: Network is unreachable)*
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a87cb9c5988332b1089e437e3b905d