### PR TITLE
refactor: use HttpServletResponse for word streaming

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/WordController.java
@@ -6,12 +6,13 @@ import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.service.SearchRecordService;
 import com.glancy.backend.service.WordService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,63 +28,98 @@ import reactor.core.publisher.Flux;
 @Slf4j
 public class WordController {
 
-    private final WordService wordService;
-    private final SearchRecordService searchRecordService;
+  private final WordService wordService;
+  private final SearchRecordService searchRecordService;
 
-    public WordController(WordService wordService, SearchRecordService searchRecordService) {
-        this.wordService = wordService;
-        this.searchRecordService = searchRecordService;
-    }
+  public WordController(
+    WordService wordService,
+    SearchRecordService searchRecordService
+  ) {
+    this.wordService = wordService;
+    this.searchRecordService = searchRecordService;
+  }
 
-    /**
-     * Look up a word definition and save the search record.
-     */
-    @GetMapping
-    public ResponseEntity<WordResponse> getWord(
-        @AuthenticatedUser Long userId,
-        @RequestParam String term,
-        @RequestParam Language language,
-        @RequestParam(required = false) String model
-    ) {
-        SearchRecordRequest req = new SearchRecordRequest();
-        req.setTerm(term);
-        req.setLanguage(language);
-        searchRecordService.saveRecord(userId, req);
-        WordResponse resp = wordService.findWordForUser(userId, term, language, model);
-        return ResponseEntity.ok(resp);
-    }
+  /**
+   * Look up a word definition and save the search record.
+   */
+  @GetMapping
+  public ResponseEntity<WordResponse> getWord(
+    @AuthenticatedUser Long userId,
+    @RequestParam String term,
+    @RequestParam Language language,
+    @RequestParam(required = false) String model
+  ) {
+    SearchRecordRequest req = new SearchRecordRequest();
+    req.setTerm(term);
+    req.setLanguage(language);
+    searchRecordService.saveRecord(userId, req);
+    WordResponse resp = wordService.findWordForUser(
+      userId,
+      term,
+      language,
+      model
+    );
+    return ResponseEntity.ok(resp);
+  }
 
-    /**
-     * Retrieve the pronunciation audio for a word.
-     */
-    @GetMapping(value = "/audio", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public ResponseEntity<byte[]> getAudio(@RequestParam String term, @RequestParam Language language) {
-        byte[] data = wordService.getAudio(term, language);
-        return ResponseEntity.ok(data);
-    }
+  /**
+   * Retrieve the pronunciation audio for a word.
+   */
+  @GetMapping(
+    value = "/audio",
+    produces = MediaType.APPLICATION_OCTET_STREAM_VALUE
+  )
+  public ResponseEntity<byte[]> getAudio(
+    @RequestParam String term,
+    @RequestParam Language language
+  ) {
+    byte[] data = wordService.getAudio(term, language);
+    return ResponseEntity.ok(data);
+  }
 
-    /**
-     * Stream word search results via SSE.
-     */
-    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ServerSentEvent<String>> streamWord(
-        @AuthenticatedUser Long userId,
-        @RequestParam String term,
-        @RequestParam Language language,
-        @RequestParam(required = false) String model,
-        ServerHttpResponse response
-    ) {
-        response.getHeaders().setCacheControl(CacheControl.noStore());
-        return wordService
-            .streamWordForUser(userId, term, language, model)
-            .doOnSubscribe(sub -> response.getHeaders().add("X-Accel-Buffering", "no"))
-            .doOnNext(chunk -> log.info("Controller streaming chunk for user {} term '{}': {}", userId, term, chunk))
-            .map(data -> ServerSentEvent.builder(data).build())
-            .doOnCancel(() -> log.info("Streaming canceled for user {} term '{}'", userId, term))
-            .onErrorResume(e -> {
-                log.error("Streaming error for user {} term '{}'", userId, term, e);
-                return Flux.just(ServerSentEvent.<String>builder(e.getMessage()).event("error").build());
-            })
-            .doFinally(sig -> log.info("Streaming finished with signal {} for user {} term '{}'", sig, userId, term));
-    }
+  /**
+   * Stream word search results via SSE.
+   */
+  @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public Flux<ServerSentEvent<String>> streamWord(
+    @AuthenticatedUser Long userId,
+    @RequestParam String term,
+    @RequestParam Language language,
+    @RequestParam(required = false) String model,
+    HttpServletResponse response
+  ) {
+    response.setHeader(
+      HttpHeaders.CACHE_CONTROL,
+      CacheControl.noStore().getHeaderValue()
+    );
+    response.setHeader("X-Accel-Buffering", "no");
+    return wordService
+      .streamWordForUser(userId, term, language, model)
+      .doOnNext(chunk ->
+        log.info(
+          "Controller streaming chunk for user {} term '{}': {}",
+          userId,
+          term,
+          chunk
+        )
+      )
+      .map(data -> ServerSentEvent.builder(data).build())
+      .doOnCancel(() ->
+        log.info("Streaming canceled for user {} term '{}'", userId, term)
+      )
+      .onErrorResume(e -> {
+        log.error("Streaming error for user {} term '{}'", userId, term, e);
+        return Flux.just(
+          ServerSentEvent.<String>builder(e.getMessage()).event("error").build()
+        );
+      })
+      .doFinally(sig ->
+        log.info(
+          "Streaming finished with signal {} for user {} term '{}'",
+          sig,
+          userId,
+          term
+        )
+      );
+  }
 }

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerStreamingTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerStreamingTest.java
@@ -1,7 +1,11 @@
 package com.glancy.backend.controller;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.service.SearchRecordService;
@@ -9,15 +13,13 @@ import com.glancy.backend.service.UserService;
 import com.glancy.backend.service.WordService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
-import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
 
 /**
  * 流式单词查询接口测试。
@@ -26,84 +28,88 @@ import reactor.test.StepVerifier;
  * 2. 模拟 WordService 返回两段数据。
  * 3. 发送请求并验证 SSE 响应序列。
  */
-@WebFluxTest(controllers = WordController.class)
+@WebMvcTest(controllers = WordController.class)
 @Import(
-    {
-        com.glancy.backend.config.security.SecurityConfig.class,
-        com.glancy.backend.config.WebConfig.class,
-        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
-    }
+  {
+    com.glancy.backend.config.security.SecurityConfig.class,
+    com.glancy.backend.config.WebConfig.class,
+    com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
+  }
 )
 class WordControllerStreamingTest {
 
-    @Autowired
-    private WebTestClient webTestClient;
+  @Autowired
+  private MockMvc mockMvc;
 
-    @MockBean
-    private WordService wordService;
+  @MockBean
+  private WordService wordService;
 
-    @MockBean
-    private SearchRecordService searchRecordService;
+  @MockBean
+  private SearchRecordService searchRecordService;
 
-    @MockBean
-    private UserService userService;
+  @MockBean
+  private UserService userService;
 
-    @Test
-    void testStreamWord() {
-        when(wordService.streamWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null))).thenReturn(
-            Flux.just("part1", "part2")
-        );
-        when(userService.authenticateToken("tkn")).thenReturn(1L);
+  @Test
+  void testStreamWord() throws Exception {
+    when(
+      wordService.streamWordForUser(
+        eq(1L),
+        eq("hello"),
+        eq(Language.ENGLISH),
+        eq(null)
+      )
+    ).thenReturn(Flux.just("part1", "part2"));
+    when(userService.authenticateToken("tkn")).thenReturn(1L);
 
-        Flux<String> body = webTestClient
-            .get()
-            .uri(uriBuilder ->
-                uriBuilder
-                    .path("/api/words/stream")
-                    .queryParam("term", "hello")
-                    .queryParam("language", "ENGLISH")
-                    .build()
-            )
-            .header("X-USER-TOKEN", "tkn")
-            .accept(MediaType.TEXT_EVENT_STREAM)
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .returnResult(String.class)
-            .getResponseBody();
+    MvcResult result = mockMvc
+      .perform(
+        get("/api/words/stream")
+          .header("X-USER-TOKEN", "tkn")
+          .param("term", "hello")
+          .param("language", "ENGLISH")
+          .accept(MediaType.TEXT_EVENT_STREAM)
+      )
+      .andExpect(request().asyncStarted())
+      .andReturn();
 
-        StepVerifier.create(body).expectNext("part1", "part2").verifyComplete();
-    }
+    mockMvc
+      .perform(asyncDispatch(result))
+      .andExpect(status().isOk())
+      .andExpect(content().string(containsString("data:part1")))
+      .andExpect(content().string(containsString("data:part2")));
+  }
 
-    /**
-     * 测试流式接口在服务抛出错误时能够返回错误事件。
-     */
-    @Test
-    void testStreamWordError() {
-        when(wordService.streamWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null))).thenReturn(
-            Flux.error(new IllegalStateException("boom"))
-        );
-        when(userService.authenticateToken("tkn")).thenReturn(1L);
+  /**
+   * 测试流式接口在服务抛出错误时能够返回错误事件。
+   */
+  @Test
+  void testStreamWordError() throws Exception {
+    when(
+      wordService.streamWordForUser(
+        eq(1L),
+        eq("hello"),
+        eq(Language.ENGLISH),
+        eq(null)
+      )
+    ).thenReturn(Flux.error(new IllegalStateException("boom")));
+    when(userService.authenticateToken("tkn")).thenReturn(1L);
 
-        Flux<ServerSentEvent<String>> body = webTestClient
-            .get()
-            .uri(uriBuilder ->
-                uriBuilder
-                    .path("/api/words/stream")
-                    .queryParam("term", "hello")
-                    .queryParam("language", "ENGLISH")
-                    .build()
-            )
-            .header("X-USER-TOKEN", "tkn")
-            .accept(MediaType.TEXT_EVENT_STREAM)
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .returnResult(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
-            .getResponseBody();
+    MvcResult result = mockMvc
+      .perform(
+        get("/api/words/stream")
+          .header("X-USER-TOKEN", "tkn")
+          .param("term", "hello")
+          .param("language", "ENGLISH")
+          .accept(MediaType.TEXT_EVENT_STREAM)
+      )
+      .andExpect(request().asyncStarted())
+      .andReturn();
 
-        StepVerifier.create(body)
-            .expectNextMatches(evt -> "error".equals(evt.event()) && "boom".equals(evt.data()))
-            .verifyComplete();
-    }
+    mockMvc
+      .perform(asyncDispatch(result))
+      .andExpect(status().isOk())
+      .andExpect(content().string(containsString("event:error")))
+      .andExpect(content().string(containsString("data:boom")));
+  }
 }


### PR DESCRIPTION
## Summary
- refactor word streaming to use HttpServletResponse and explicit cache headers
- adapt WordController streaming tests to MockMvc

## Testing
- `npx eslint --fix .`
- `npx stylelint "**/*.{css,scss,less,sass}" --fix`
- `npx prettier -w --plugin=prettier-plugin-java --parser=java ../../backend/src/main/java/com/glancy/backend/controller/WordController.java ../../backend/src/test/java/com/glancy/backend/controller/WordControllerStreamingTest.java`
- `npm test` *(fails: Syntax error reading regular expression & JavaScript heap out of memory)*
- `mvn spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a87cb7dc448332960f247918bd4733