### PR TITLE
feat: render streamed markdown

### DIFF
--- a/website/glancy-website/src/components/__tests__/MarkdownStream.test.jsx
+++ b/website/glancy-website/src/components/__tests__/MarkdownStream.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import ReactMarkdown from "react-markdown";
+import MarkdownStream from "@/components/ui/MarkdownStream";
+
+/**
+ * 确认 MarkdownStream 使用 renderer 属性正确渲染 Markdown 字符串。
+ */
+test("renders markdown via injected renderer", () => {
+  render(<MarkdownStream text="**bold**" renderer={ReactMarkdown} />);
+  const strong = screen.getByText("bold");
+  expect(strong.tagName).toBe("STRONG");
+});

--- a/website/glancy-website/src/components/ui/MarkdownStream/index.jsx
+++ b/website/glancy-website/src/components/ui/MarkdownStream/index.jsx
@@ -1,0 +1,12 @@
+import ReactMarkdown from "react-markdown";
+
+/**
+ * 渲染 Markdown 流内容的通用组件，默认使用 ReactMarkdown。
+ * 可通过 renderer 属性注入自定义渲染器以便测试或扩展。
+ */
+function MarkdownStream({ text, renderer }) {
+  const Renderer = renderer || ReactMarkdown;
+  return <Renderer className="stream-text">{text}</Renderer>;
+}
+
+export default MarkdownStream;

--- a/website/glancy-website/src/pages/App/App.css
+++ b/website/glancy-website/src/pages/App/App.css
@@ -64,13 +64,21 @@
   width: 100%;
   padding: 16px;
   text-align: left;
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
-  font-family: var(--font-mono, monospace);
   background: var(--app-bg);
   color: var(--app-color);
   border-radius: 8px;
   box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
+  line-height: 1.5;
+}
+
+.stream-text p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.stream-text code {
+  font-family: var(--font-mono, monospace);
 }
 
 .display-content {

--- a/website/glancy-website/src/pages/App/__tests__/streaming.test.jsx
+++ b/website/glancy-website/src/pages/App/__tests__/streaming.test.jsx
@@ -73,9 +73,9 @@ beforeEach(() => {
 });
 
 /**
- * 验证流式内容在 <pre> 标签中逐字呈现，并在完成后恢复默认界面。
+ * 验证流式内容在 Markdown 容器中逐字呈现，并在完成后恢复默认界面。
  */
-test("streams text in pre incrementally", async () => {
+test("streams text with markdown incrementally", async () => {
   useStreamWord.mockImplementation(
     () =>
       async function* () {
@@ -95,8 +95,8 @@ test("streams text in pre incrementally", async () => {
 
   await screen.findByText("f");
   await screen.findByText("fo");
-  const pre = await screen.findByText("foobar");
-  expect(pre.tagName).toBe("PRE");
+  const paragraph = await screen.findByText("foobar");
+  expect(paragraph.tagName).toBe("P");
 
   await waitFor(() => {
     expect(screen.queryByText("foobar")).not.toBeInTheDocument();

--- a/website/glancy-website/src/pages/App/index.jsx
+++ b/website/glancy-website/src/pages/App/index.jsx
@@ -14,6 +14,8 @@ import { useModelStore } from "@/store";
 import ICP from "@/components/ui/ICP";
 import FavoritesView from "./FavoritesView.jsx";
 import { useAppShortcuts } from "@/hooks";
+import ReactMarkdown from "react-markdown";
+import MarkdownStream from "@/components/ui/MarkdownStream";
 
 function App() {
   const [text, setText] = useState("");
@@ -238,11 +240,14 @@ function App() {
           ) : showHistory ? (
             <HistoryDisplay />
           ) : loading ? (
-            <pre className="stream-text">{streamText || "..."}</pre>
+            <MarkdownStream
+              text={streamText || "..."}
+              renderer={ReactMarkdown}
+            />
           ) : entry ? (
             <DictionaryEntry entry={entry} />
           ) : streamText ? (
-            <pre className="stream-text">{streamText}</pre>
+            <MarkdownStream text={streamText} renderer={ReactMarkdown} />
           ) : (
             <div className="display-content">
               <div className="display-term">{placeholder}</div>


### PR DESCRIPTION
## Summary
- render streaming responses with ReactMarkdown
- style markdown output to match app theme
- add MarkdownStream component tests and update streaming tests

## Testing
- `npm run lint`
- `npm run stylelint` *(fails: Missing script "stylelint")*
- `npm run lint:css`
- `npm run format` *(fails: Missing script "format")*
- `npx prettier -w src/pages/App/index.jsx src/pages/App/App.css src/pages/App/__tests__/streaming.test.jsx src/components/ui/MarkdownStream/index.jsx src/components/__tests__/MarkdownStream.test.jsx`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68abef4c0a448332a7fc1db1dcccd0c1