### PR TITLE
feat: cache streamed markdown for words

### DIFF
--- a/website/glancy-website/src/api/__tests__/words.cache.e2e.test.js
+++ b/website/glancy-website/src/api/__tests__/words.cache.e2e.test.js
@@ -1,0 +1,41 @@
+import { jest } from "@jest/globals";
+
+const streamWordMock = jest.fn(async function* () {
+  yield "**hello**";
+});
+
+jest.unstable_mockModule("@/hooks/useApi.js", () => ({
+  useApi: () => ({ words: { streamWord: streamWordMock } }),
+}));
+
+const { createWordsApi } = await import("@/api/words.js");
+const { useStreamWord } = await import("@/hooks");
+const { useWordStore } = await import("@/store");
+
+const request = jest.fn();
+const api = createWordsApi(request);
+
+beforeEach(() => {
+  useWordStore.getState().clear();
+  request.mockClear();
+});
+
+/**
+ * 首次流式查询后将 Markdown 写入缓存，二次直接读取时无需网络请求。
+ */
+test("streams then reads markdown from cache", async () => {
+  const stream = useStreamWord();
+  const user = { id: "u", token: "t" };
+  for await (const _ of stream({ user, term: "hello" })) {
+    // consume stream
+  }
+
+  const result = await api.fetchWord({
+    userId: "u",
+    term: "hello",
+    language: "ENGLISH",
+  });
+
+  expect(result.markdown).toBe("**hello**");
+  expect(request).not.toHaveBeenCalled();
+});

--- a/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
+++ b/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
@@ -7,6 +7,14 @@ function DictionaryEntry({ entry }) {
   const { t, lang } = useLanguage();
   if (!entry) return null;
 
+  if (entry.markdown) {
+    return (
+      <article className={styles["dictionary-entry"]}>
+        <MarkdownRenderer>{entry.markdown}</MarkdownRenderer>
+      </article>
+    );
+  }
+
   // new format detected by the presence of Chinese keys
   const isNew = Object.prototype.hasOwnProperty.call(entry, "发音解释");
 

--- a/website/glancy-website/src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx
+++ b/website/glancy-website/src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx
@@ -25,9 +25,19 @@ jest.mock("@/components", () => ({
 }));
 
 /**
- * 确认 DictionaryEntry 能解析释义中的 Markdown。
+ * 确认当存在 markdown 字段时优先渲染其内容。
  */
-test("renders markdown in definitions", () => {
+test("renders top-level markdown when present", () => {
+  const entry = { markdown: "# Title" };
+  render(<DictionaryEntry entry={entry} />);
+  const heading = screen.getByText("Title");
+  expect(heading.tagName).toBe("H1");
+});
+
+/**
+ * 没有 markdown 字段时回退到 definitions 渲染。
+ */
+test("falls back to definitions", () => {
   const entry = {
     词条: "test",
     发音解释: [{ 释义: [{ 定义: "**bold**" }] }],

--- a/website/glancy-website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
+++ b/website/glancy-website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
  * 可作为统一的 Markdown 渲染入口，便于未来扩展。
  */
 function MarkdownRenderer({ children, ...props }) {
+  if (!children) return null;
   return (
     <ReactMarkdown remarkPlugins={[remarkGfm]} {...props}>
       {children}

--- a/website/glancy-website/src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx
+++ b/website/glancy-website/src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx
@@ -10,3 +10,8 @@ test("renders GFM syntax", () => {
   const del = screen.getByText("gone");
   expect(del.tagName).toBe("DEL");
 });
+
+test("returns null for empty content", () => {
+  const { container } = render(<MarkdownRenderer>{""}</MarkdownRenderer>);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/website/glancy-website/src/store/index.ts
+++ b/website/glancy-website/src/store/index.ts
@@ -1,6 +1,7 @@
-export { useFavoritesStore } from './favoritesStore.ts'
-export { useHistoryStore } from './historyStore.ts'
-export { useModelStore } from './modelStore.ts'
-export { useUserStore } from './userStore.ts'
-export { useVoiceStore } from './voiceStore.ts'
-export type { User } from './userStore.ts'
+export { useFavoritesStore } from "./favoritesStore.ts";
+export { useHistoryStore } from "./historyStore.ts";
+export { useModelStore } from "./modelStore.ts";
+export { useUserStore } from "./userStore.ts";
+export { useVoiceStore } from "./voiceStore.ts";
+export { useWordStore } from "./wordStore.js";
+export type { User } from "./userStore.ts";

--- a/website/glancy-website/src/store/wordStore.js
+++ b/website/glancy-website/src/store/wordStore.js
@@ -1,0 +1,16 @@
+import { createPersistentStore } from "./createPersistentStore.ts";
+import { pickState } from "./persistUtils.ts";
+
+export const useWordStore = createPersistentStore({
+  key: "wordCache",
+  initializer: (set, get) => ({
+    entries: {},
+    setEntry: (key, entry) =>
+      set((state) => ({ entries: { ...state.entries, [key]: entry } })),
+    getEntry: (key) => get().entries[key],
+    clear: () => set({ entries: {} }),
+  }),
+  persistOptions: {
+    partialize: pickState(["entries"]),
+  },
+});


### PR DESCRIPTION
## Summary
- cache dictionary lookups with versioned keys and preserve markdown field
- render word markdown when available and store streamed results locally
- add test for caching streamed markdown

## Testing
- `npx prettier -w website/glancy-website/src/api/words.js website/glancy-website/src/hooks/useStreamWord.js website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx website/glancy-website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx website/glancy-website/src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx website/glancy-website/src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx website/glancy-website/src/store/wordStore.ts website/glancy-website/src/store/index.ts website/glancy-website/src/api/__tests__/words.cache.e2e.test.js`
- `npm --prefix website/glancy-website run lint -- --fix src/api/words.js src/hooks/useStreamWord.js src/components/ui/DictionaryEntry/DictionaryEntry.jsx src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx src/store/wordStore.ts src/store/index.ts src/api/__tests__/words.cache.e2e.test.js`
- `npm --prefix website/glancy-website run lint:css -- --fix`
- `mvn -q spotless:apply` (fails: No plugin found for prefix 'spotless')
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npm --prefix website/glancy-website test` (fails: ReferenceError: require is not defined; FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed)
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npm --prefix website/glancy-website test -- src/api/__tests__/words.cache.e2e.test.js`
- `mvn -q -f backend/pom.xml test` (fails: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68ac8a14f24c8332bb2ef24ceb82582a