### PR TITLE
feat: support JSON dictionary entries

### DIFF
--- a/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
+++ b/website/glancy-website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
@@ -3,11 +3,25 @@ import { TtsButton, PronounceableWord } from "@/components";
 import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
 import styles from "./DictionaryEntry.module.css";
 
+function tryParseJson(text) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
 function DictionaryEntry({ entry }) {
   const { t, lang } = useLanguage();
   if (!entry) return null;
 
   if (entry.markdown) {
+    const parsed = tryParseJson(entry.markdown);
+    if (parsed) {
+      return <DictionaryEntry entry={parsed} />;
+    }
     return (
       <article className={styles["dictionary-entry"]}>
         <MarkdownRenderer>{entry.markdown}</MarkdownRenderer>

--- a/website/glancy-website/src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx
+++ b/website/glancy-website/src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx
@@ -25,13 +25,28 @@ jest.mock("@/components", () => ({
 }));
 
 /**
- * 确认当存在 markdown 字段时优先渲染其内容。
+ * 确认当存在 markdown 字段且为 Markdown 文本时优先渲染。
  */
 test("renders top-level markdown when present", () => {
   const entry = { markdown: "# Title" };
   render(<DictionaryEntry entry={entry} />);
   const heading = screen.getByText("Title");
   expect(heading.tagName).toBe("H1");
+});
+
+/**
+ * 确认当 markdown 字段为 JSON 字符串时解析并渲染结构化内容。
+ */
+test("renders structured data from JSON markdown", () => {
+  const entry = {
+    markdown: JSON.stringify({
+      词条: "test",
+      发音解释: [{ 释义: [{ 定义: "**bold**" }] }],
+    }),
+  };
+  render(<DictionaryEntry entry={entry} />);
+  const strong = screen.getByText("bold");
+  expect(strong.tagName).toBe("STRONG");
 });
 
 /**


### PR DESCRIPTION
## Summary
- render structured fields when `entry.markdown` contains JSON
- test dictionary entries parsing markdown or JSON

## Testing
- `npx eslint --fix src/components/ui/DictionaryEntry/DictionaryEntry.jsx src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/components/ui/DictionaryEntry/DictionaryEntry.jsx src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx`
- `npm test` (fails: Syntax error reading regular expression)
- `npx jest src/components/ui/DictionaryEntry/__tests__/DictionaryEntry.test.jsx --runInBand` (fails: Cannot use import statement outside a module)
- `mvn -q spotless:apply` (fails: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68ac97da17608332b26b638aad52a229