### PR TITLE
优化词汇流式缓存处理与测试

### DIFF
--- a/website/glancy-website/src/hooks/__tests__/useStreamWord.test.js
+++ b/website/glancy-website/src/hooks/__tests__/useStreamWord.test.js
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import DictionaryEntry from "@/components/ui/DictionaryEntry";
+import { useStreamWord } from "@/hooks/useStreamWord";
+import { useWordStore } from "@/store/wordStore.js";
+
+const streamWordMock = jest.fn();
+const apiMock = { words: { streamWord: streamWordMock } };
+jest.mock("@/hooks/useApi.js", () => ({
+  useApi: () => apiMock,
+}));
+
+beforeEach(() => {
+  streamWordMock.mockReset();
+  useWordStore.getState().clear();
+});
+
+/**
+ * 测试逻辑:
+ *  1. 模拟 API 返回纯 JSON 结果。
+ *  2. 调用流式函数并等待完成。
+ *  3. 断言缓存内容不含 markdown 且渲染释义。
+ */
+test("cache JSON entry and render definitions", async () => {
+  const jsonEntry = JSON.parse(
+    '{ "词条": "test", "发音解释": [{ "释义": [{ "定义": "**bold**" }] }] }',
+  );
+
+  streamWordMock.mockImplementation(async function* () {
+    yield JSON.stringify(jsonEntry);
+  });
+
+  const streamWordWithHandling = useStreamWord();
+  for await (const _ of streamWordWithHandling({
+    user: { id: "u", token: "t" },
+    term: "test",
+    model: "m",
+    signal: new AbortController().signal,
+  })) {
+    // consume generator
+  }
+
+  const entries = useWordStore.getState().entries;
+  const cached = entries[Object.keys(entries)[0]];
+  expect(cached).toEqual(jsonEntry);
+  expect(cached.markdown).toBeUndefined();
+
+  render(<DictionaryEntry entry={cached} />);
+  const strong = screen.getByText("bold");
+  expect(strong.tagName).toBe("STRONG");
+});
+
+/**
+ * 测试逻辑:
+ *  1. 模拟 API 返回纯 Markdown 内容。
+ *  2. 调用流式函数并等待完成。
+ *  3. 断言缓存含 markdown 字段且能渲染。
+ */
+test("cache markdown entry and render", async () => {
+  streamWordMock.mockImplementation(async function* () {
+    yield "# Title";
+  });
+
+  const streamWordWithHandling = useStreamWord();
+  for await (const _ of streamWordWithHandling({
+    user: { id: "u", token: "t" },
+    term: "test",
+    model: "m",
+    signal: new AbortController().signal,
+  })) {
+    // consume generator
+  }
+
+  const entries = useWordStore.getState().entries;
+  const cached = entries[Object.keys(entries)[0]];
+  expect(cached.markdown).toBe("# Title");
+
+  render(<DictionaryEntry entry={cached} />);
+  const heading = screen.getByText("Title");
+  expect(heading.tagName).toBe("H1");
+});

--- a/website/glancy-website/src/hooks/useStreamWord.js
+++ b/website/glancy-website/src/hooks/useStreamWord.js
@@ -41,9 +41,9 @@ export function useStreamWord() {
       }
       let entry;
       try {
-        entry = JSON.parse(acc);
-        if (entry && typeof entry === "object") {
-          entry.markdown = entry.markdown ?? acc;
+        const parsed = JSON.parse(acc);
+        if (parsed && typeof parsed === "object") {
+          entry = parsed;
         } else {
           entry = { markdown: acc };
         }


### PR DESCRIPTION
## Summary
- 移除解析成功时的 Markdown 回退，只在解析失败或响应自带字段时缓存 Markdown
- 新增 useStreamWord 测试，覆盖纯 JSON 与纯 Markdown 缓存路径

## Testing
- `npx prettier -w src/hooks/useStreamWord.js src/hooks/__tests__/useStreamWord.test.js`
- `npx eslint src/hooks/useStreamWord.js src/hooks/__tests__/useStreamWord.test.js --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npm test src/hooks/__tests__/useStreamWord.test.js` *(failed: Syntax error reading regular expression)*
- `./mvnw spotless:apply` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac97d9d3f48332ac1e5599a3e6a12a