### PR TITLE
feat: 引入 Flyway 并添加 words 表 markdown 列迁移

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -76,6 +76,15 @@
                         <scope>runtime</scope>
                 </dependency>
                 <dependency>
+                        <groupId>org.flywaydb</groupId>
+                        <artifactId>flyway-core</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.flywaydb</groupId>
+                        <artifactId>flyway-mysql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
                         <groupId>org.projectlombok</groupId>
                         <artifactId>lombok</artifactId>
                         <version>1.18.32</version>

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -5,6 +5,9 @@ spring:
         password: ${DB_PASSWORD}
         driver-class-name: com.mysql.cj.jdbc.Driver
 
+    flyway:
+        baseline-on-migrate: true
+
     jpa:
         hibernate:
             ddl-auto: update

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,6 +12,9 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  flyway:
+    baseline-on-migrate: true
+
   servlet:
     multipart:
       max-file-size: 5MB

--- a/backend/src/main/resources/db/migration/V1__add_markdown_column.sql
+++ b/backend/src/main/resources/db/migration/V1__add_markdown_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE words ADD COLUMN markdown TEXT;
+UPDATE words SET markdown = '' WHERE markdown IS NULL;

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,6 +4,8 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+  flyway:
+    enabled: false
   servlet:
     multipart:
       max-file-size: 5MB


### PR DESCRIPTION
## Summary
- 引入 Flyway 迁移框架
- 新增 words 表 markdown 列的数据库迁移脚本
- 在主配置与本地配置启用 Flyway，测试环境关闭

## Testing
- `npm --prefix website/glancy-website ci`
- `npx eslint . --fix`
- `npx stylelint "**/*.{css,scss}" --fix`
- `npx prettier -w .`
- `mvn -s /tmp/settings.xml -f backend/pom.xml spotless:apply` *(失败: 网络无法访问 Maven 仓库)*
- `mvn -s /tmp/settings.xml -f backend/pom.xml test` *(失败: 网络无法访问 Maven 仓库)*

------
https://chatgpt.com/codex/tasks/task_e_68aca565dde08332a6542158b452efb2