### PR TITLE
fix: ensure markdown column migration

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -6,7 +6,8 @@ spring:
         driver-class-name: com.mysql.cj.jdbc.Driver
 
     flyway:
-        baseline-on-migrate: true
+        # Disable baselining to allow migration scripts to run
+        baseline-on-migrate: false
 
     jpa:
         hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,7 +13,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   flyway:
-    baseline-on-migrate: true
+    # Disable baselining to ensure all migrations are executed
+    baseline-on-migrate: false
 
   servlet:
     multipart:

--- a/backend/src/main/resources/db/migration/V2__ensure_markdown_column.sql
+++ b/backend/src/main/resources/db/migration/V2__ensure_markdown_column.sql
@@ -1,0 +1,5 @@
+-- Ensure markdown column exists for existing deployments
+ALTER TABLE words
+    ADD COLUMN IF NOT EXISTS markdown TEXT;
+
+UPDATE words SET markdown = '' WHERE markdown IS NULL;


### PR DESCRIPTION
## Summary
- disable Flyway baselining so migrations execute
- add migration ensuring `markdown` column exists in `words`

## Testing
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM ... maven.aliyun.com unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM ... maven.aliyun.com unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aca915d6208332b4563a968a590995