### PR TITLE
修复 Maven 格式化流程中的 npm 403 错误

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -153,13 +153,9 @@
                                 <version>2.43.0</version>
                                 <configuration>
                                         <java>
-                                                <prettier>
-                                                       <devDependencies>
-                                                               <prettier>${prettier.version}</prettier>
-                                                               <prettier-plugin-java>${prettier-plugin-java.version}</prettier-plugin-java>
-                                                       </devDependencies>
-                                                        <configFile>${project.basedir}/spotless-config.json</configFile>
-                                                </prettier>
+                                                <googleJavaFormat>
+                                                        <style>GOOGLE</style>
+                                                </googleJavaFormat>
                                         </java>
                                         <format>
                                                 <name>yaml</name>
@@ -167,13 +163,9 @@
                                                         <include>**/*.yml</include>
                                                         <include>**/*.yaml</include>
                                                 </includes>
-                                                <prettier>
-                                                        <devDependencies>
-                                                                <prettier>${prettier.version}</prettier>
-                                                        </devDependencies>
-                                                        <parser>yaml</parser>
-                                                        <configFile>${project.basedir}/spotless-config.json</configFile>
-                                                </prettier>
+                                                <trimTrailingWhitespace/>
+                                                <endWithNewline/>
+                                                <indentWithSpaces/>
                                         </format>
                                 </configuration>
                         </plugin>

--- a/backend/spotless-config.json
+++ b/backend/spotless-config.json
@@ -1,7 +1,0 @@
-{
-    "printWidth": 120,
-    "tabWidth": 4,
-    "useTabs": false,
-    "plugins": ["prettier-plugin-java"]
-}
-


### PR DESCRIPTION
## 概要
- 使用 `google-java-format` 替代基于 Prettier 的 Spotless 配置，去除对 npm 包的依赖
- 移除无用的 `spotless-config.json`

## 测试
- `npx eslint . --fix` *(失败：缺少配置文件)*
- `npm_config_yes=true npx stylelint "**/*.{css,scss}" --fix` *(失败：缺少 stylelint-config-standard)*
- `npm_config_yes=true npx prettier -w backend/AGENTS.md`
- `mvn -q spotless:apply` *(失败：无法解析 Spring Boot parent POM，网络不可达)*

------
https://chatgpt.com/codex/tasks/task_e_68adb1e72de08332bb6b30a124ff8478