### PR TITLE
fix: repair failed flyway migrations

### DIFF
--- a/backend/src/main/java/com/glancy/backend/config/FlywayConfig.java
+++ b/backend/src/main/java/com/glancy/backend/config/FlywayConfig.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Ensures failed Flyway migrations do not prevent application startup
+ * by repairing the schema history before running migrations.
+ */
+@Configuration
+public class FlywayConfig {
+
+  /**
+   * Repairs the Flyway schema history before applying pending migrations.
+   *
+   * @return migration strategy invoking {@link Flyway#repair()} then {@link Flyway#migrate()}
+   */
+  @Bean
+  public FlywayMigrationStrategy repairAndMigrateStrategy() {
+    return flyway -> {
+      flyway.repair();
+      flyway.migrate();
+    };
+  }
+}

--- a/backend/src/main/resources/config/application.yml
+++ b/backend/src/main/resources/config/application.yml
@@ -21,17 +21,18 @@ spring:
       max-file-size: 5MB
       max-request-size: 5MB
 
-    jpa:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
       hibernate:
-        ddl-auto: update
-      show-sql: true
-      properties:
-        hibernate:
-          dialect: org.hibernate.dialect.MySQLDialect
-          "[format_sql]": true
-    web:
-      resources:
-        add-mappings: false
+        dialect: org.hibernate.dialect.MySQLDialect
+        "[format_sql]": true
+
+  web:
+    resources:
+      add-mappings: false
 
 management:
   endpoints:
@@ -58,7 +59,6 @@ thirdparty:
   deepseek:
     base-url: https://api.deepseek.com
     api-key: ""
-
   doubao:
     base-url: https://ark.cn-beijing.volces.com
     chat-path: /api/v3/chat/completions

--- a/backend/src/test/java/com/glancy/backend/config/FlywayConfigTest.java
+++ b/backend/src/test/java/com/glancy/backend/config/FlywayConfigTest.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.config;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+/**
+ * 测试逻辑：验证迁移策略会在执行迁移前先修复 Flyway 的历史记录。
+ */
+class FlywayConfigTest {
+
+  @Test
+  void repairAndMigrateStrategyRepairsBeforeMigrating() {
+    Flyway flyway = mock(Flyway.class);
+    InOrder order = inOrder(flyway);
+
+    new FlywayConfig().repairAndMigrateStrategy().migrate(flyway);
+
+    order.verify(flyway).repair();
+    order.verify(flyway).migrate();
+    verifyNoMoreInteractions(flyway);
+  }
+}


### PR DESCRIPTION
## Summary
- repair failed Flyway migrations automatically on startup
- correct Spring configuration indentation for JPA and web resources
- add unit test for Flyway repair strategy

## Testing
- `npx eslint . --fix`
- `npx stylelint "**/*.{css,scss}" --fix`
- `npx prettier -w .`
- `mvn -q -s /tmp/maven-settings.xml -Djava.net.preferIPv4Stack=true spotless:apply` *(failed: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q -s /tmp/maven-settings.xml -Djava.net.preferIPv4Stack=true test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adbd035cb48332b0efcf68125969d0