### PR TITLE
feat: centralize llm client resolution

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/service/LLMClientResolver.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/LLMClientResolver.java
@@ -1,0 +1,40 @@
+package com.glancy.backend.llm.service;
+
+import com.glancy.backend.llm.config.LLMConfig;
+import com.glancy.backend.llm.llm.LLMClient;
+import com.glancy.backend.llm.llm.LLMClientFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class LLMClientResolver {
+
+  private final LLMClientFactory factory;
+  private final LLMConfig config;
+
+  public record Selection(String name, LLMClient client) {}
+
+  public LLMClientResolver(LLMClientFactory factory, LLMConfig config) {
+    this.factory = factory;
+    this.config = config;
+  }
+
+  public Selection resolve(String preferred) {
+    String name = preferred != null ? preferred : config.getDefaultClient();
+    LLMClient client = factory.get(name);
+    if (client != null) {
+      return new Selection(name, client);
+    }
+    log.warn("LLM client '{}' not found, falling back to default", name);
+    String fallback = config.getDefaultClient();
+    client = factory.get(fallback);
+    if (client == null) {
+      throw new IllegalStateException(
+          String.format(
+              "LLM client '%s' not available and default '%s' not configured",
+              name, fallback));
+    }
+    return new Selection(fallback, client);
+  }
+}

--- a/backend/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
@@ -1,11 +1,8 @@
 package com.glancy.backend.llm.service;
 
-import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import reactor.core.publisher.Flux;
 
 public interface WordSearcher {
-  WordResponse search(String term, Language language, String clientName);
-
   Flux<String> streamSearch(String term, Language language, String clientName);
 }

--- a/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
@@ -1,13 +1,9 @@
 package com.glancy.backend.llm.service;
 
-import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.llm.config.LLMConfig;
 import com.glancy.backend.llm.llm.LLMClient;
-import com.glancy.backend.llm.llm.LLMClientFactory;
 import com.glancy.backend.llm.model.ChatMessage;
-import com.glancy.backend.llm.parser.ParsedWord;
-import com.glancy.backend.llm.parser.WordResponseParser;
 import com.glancy.backend.llm.prompt.PromptManager;
 import com.glancy.backend.llm.search.SearchContentManager;
 import java.util.ArrayList;
@@ -20,53 +16,24 @@ import reactor.core.publisher.Flux;
 @Service
 public class WordSearcherImpl implements WordSearcher {
 
-  private final LLMClientFactory clientFactory;
+  private final LLMClientResolver clientResolver;
   private final LLMConfig config;
   private final PromptManager promptManager;
   private final SearchContentManager searchContentManager;
-  private final WordResponseParser parser;
 
   public WordSearcherImpl(
-      LLMClientFactory clientFactory,
+      LLMClientResolver clientResolver,
       LLMConfig config,
       PromptManager promptManager,
-      SearchContentManager searchContentManager,
-      WordResponseParser parser) {
-    this.clientFactory = clientFactory;
+      SearchContentManager searchContentManager) {
+    this.clientResolver = clientResolver;
     this.config = config;
     this.promptManager = promptManager;
     this.searchContentManager = searchContentManager;
-    this.parser = parser;
-  }
-
-  @Override
-  public WordResponse search(String term, Language language, String clientName) {
-    log.info("WordSearcher searching for '{}' using client {}", term, clientName);
-    String cleanInput = searchContentManager.normalize(term);
-    String prompt = promptManager.loadPrompt(config.getPromptPath());
-    String name = clientName != null ? clientName : config.getDefaultClient();
-    LLMClient client = clientFactory.get(name);
-    if (client == null) {
-      log.warn("LLM client '{}' not found, falling back to default", name);
-      String fallback = config.getDefaultClient();
-      client = clientFactory.get(fallback);
-      if (client == null) {
-        throw new IllegalStateException(
-            String.format(
-                "LLM client '%s' not available and default '%s' not configured", name, fallback));
-      }
-      name = fallback;
-    }
-    List<ChatMessage> messages = new ArrayList<>();
-    messages.add(new ChatMessage("system", prompt));
-    messages.add(new ChatMessage("user", cleanInput));
-    String content = client.chat(messages, config.getTemperature());
-    log.info("LLM client '{}' returned content: {}", name, content);
-    ParsedWord parsed = parser.parse(content, term, language);
-    return parsed.parsed();
   }
 
   /** 面向实时场景的搜索接口，直接返回模型的流式输出。 */
+  @Override
   public Flux<String> streamSearch(String term, Language language, String clientName) {
     log.info("WordSearcher streaming for '{}' using client '{}'", term, clientName);
     String cleanInput = searchContentManager.normalize(term);
@@ -78,18 +45,14 @@ public class WordSearcherImpl implements WordSearcher {
         config.getPromptPath(),
         prompt != null ? prompt.length() : 0);
 
-    String name = clientName != null ? clientName : config.getDefaultClient();
-    LLMClient client = clientFactory.get(name);
-    if (client == null) {
-      log.warn("LLM client '{}' not found, falling back to default", name);
-      client = clientFactory.get(config.getDefaultClient());
-    }
+    LLMClientResolver.Selection selection = clientResolver.resolve(clientName);
+    LLMClient client = selection.client();
+    String name = selection.name();
     log.info("Using LLM client '{}'", name);
 
     List<ChatMessage> messages = new ArrayList<>();
     messages.add(new ChatMessage("system", prompt));
     messages.add(new ChatMessage("user", cleanInput));
-    log.info("Using LLM client '{}'", name);
     log.info(
         "Prepared '{}' request messages: roles='{}'",
         messages.size(),

--- a/backend/src/main/java/com/glancy/backend/service/WordService.java
+++ b/backend/src/main/java/com/glancy/backend/service/WordService.java
@@ -81,11 +81,8 @@ public class WordService {
             })
         .orElseGet(
             () -> {
-              log.info("Word '{}' not found locally, searching via LLM", term);
-              WordResponse resp = wordSearcher.search(term, language, model);
-              log.info("LLM search result: {}", resp);
-              saveWord(term, resp, language);
-              return resp;
+              log.info("Word '{}' not found locally, streaming via LLM", term);
+              return performStreamingSearch(term, language, model);
             });
   }
 
@@ -158,6 +155,20 @@ public class WordService {
                 }
               }
             });
+  }
+
+  private WordResponse performStreamingSearch(
+      String term, Language language, String model) {
+    String content =
+        wordSearcher
+            .streamSearch(term, language, model)
+            .collectList()
+            .map(list -> String.join("", list))
+            .block();
+    ParsedWord parsed = parser.parse(content, term, language);
+    WordResponse resp = parsed.parsed();
+    saveWord(term, resp, language);
+    return resp;
   }
 
   private String serialize(Word word) throws JsonProcessingException {

--- a/backend/src/test/java/com/glancy/backend/llm/service/LLMClientResolverTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/service/LLMClientResolverTest.java
@@ -1,0 +1,43 @@
+package com.glancy.backend.llm.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.glancy.backend.llm.config.LLMConfig;
+import com.glancy.backend.llm.llm.LLMClient;
+import com.glancy.backend.llm.llm.LLMClientFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LLMClientResolverTest {
+
+  private LLMClientFactory factory;
+  private LLMConfig config;
+  private LLMClient defaultClient;
+
+  @BeforeEach
+  void setUp() {
+    factory = mock(LLMClientFactory.class);
+    config = new LLMConfig();
+    config.setDefaultClient("deepseek");
+    defaultClient = mock(LLMClient.class);
+  }
+
+  @Test
+  void fallsBackToDefaultWhenClientMissing() {
+    when(factory.get("invalid")).thenReturn(null);
+    when(factory.get("deepseek")).thenReturn(defaultClient);
+    LLMClientResolver resolver = new LLMClientResolver(factory, config);
+    LLMClientResolver.Selection sel = resolver.resolve("invalid");
+    assertSame(defaultClient, sel.client());
+    assertEquals("deepseek", sel.name());
+  }
+
+  @Test
+  void throwsWhenDefaultMissing() {
+    when(factory.get("invalid")).thenReturn(null);
+    when(factory.get("deepseek")).thenReturn(null);
+    LLMClientResolver resolver = new LLMClientResolver(factory, config);
+    assertThrows(IllegalStateException.class, () -> resolver.resolve("invalid"));
+  }
+}


### PR DESCRIPTION
## Summary
- remove blocking search method and expose only streamSearch
- add LLMClientResolver to manage client selection and fallback
- refactor WordService to rely on streaming search
- cover client resolution with new unit tests

## Testing
- `npx eslint --fix .` *(fails: Cannot find package '@eslint/js')*
- `npx stylelint "**/*.{css,scss,less}" --fix` *(fails: canceled)*
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68adc0e323148332adc3aa6c29da1d1b