### PR TITLE
refactor: modularize backend configuration

### DIFF
--- a/backend/src/main/resources/config/application.yml
+++ b/backend/src/main/resources/config/application.yml
@@ -11,12 +11,10 @@ spring:
     username: glancy_user
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
   servlet:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
-
   jpa:
     hibernate:
       ddl-auto: none
@@ -25,59 +23,23 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         "[format_sql]": true
-
   web:
     resources:
       add-mappings: false
-
+  config:
+    import:
+      - classpath:config/search.yml
+      - classpath:config/llm.yml
+      - classpath:config/thirdparty.yml
+      - classpath:config/oss.yml
+      - classpath:config/tts.yml
 management:
   endpoints:
     web:
       exposure:
         include: health,info
-
   logging:
     level:
       "[org.springframework.security]": DEBUG
       "[com.glancy.backend]": DEBUG
       "[org.springframework.web]": INFO
-
-search:
-  limit:
-    nonMember: 10
-
-llm:
-  default-client: deepseek
-  temperature: 0.7
-  prompt-path: prompts/english_to_chinese.txt
-
-thirdparty:
-  deepseek:
-    base-url: https://api.deepseek.com
-    api-key: ""
-  doubao:
-    base-url: https://ark.cn-beijing.volces.com
-    chat-path: /api/v3/chat/completions
-    api-key: ""
-oss:
-  endpoint: https://oss-cn-beijing.aliyuncs.com
-  bucket: glancy-avatar-bucket
-  avatar-dir: avatars/
-  public-read: true
-  signed-url-expiration-minutes: 10080
-  verify-location: true
-  access-key-id: ${OSS_ACCESS_KEY_ID:}
-  access-key-secret: ${OSS_ACCESS_KEY_SECRET:}
-  security-token: ${OSS_SECURITY_TOKEN:}
-
-tts:
-  volcengine:
-    # Credentials and routing for Volcengine TTS service.
-    app-id: ${VOLCENGINE_APP_ID:}
-    # Access token issued by Volcengine for authentication.
-    access-token: ${VOLCENGINE_ACCESS_TOKEN:}
-    cluster: volcano_tts
-    # Base URL of Volcengine TTS endpoint. Override for staging or mocks.
-    api-url: https://openspeech.bytedance.com/api/v1/tts
-    # Interval for proactive health checks to Volcengine TTS.
-    health-interval: PT10M

--- a/backend/src/main/resources/config/llm.yml
+++ b/backend/src/main/resources/config/llm.yml
@@ -1,0 +1,4 @@
+llm:
+  default-client: deepseek
+  temperature: 0.7
+  prompt-path: prompts/english_to_chinese.txt

--- a/backend/src/main/resources/config/oss.yml
+++ b/backend/src/main/resources/config/oss.yml
@@ -1,0 +1,10 @@
+oss:
+  endpoint: https://oss-cn-beijing.aliyuncs.com
+  bucket: glancy-avatar-bucket
+  avatar-dir: avatars/
+  public-read: true
+  signed-url-expiration-minutes: 10080
+  verify-location: true
+  access-key-id: ${OSS_ACCESS_KEY_ID:}
+  access-key-secret: ${OSS_ACCESS_KEY_SECRET:}
+  security-token: ${OSS_SECURITY_TOKEN:}

--- a/backend/src/main/resources/config/search.yml
+++ b/backend/src/main/resources/config/search.yml
@@ -1,0 +1,3 @@
+search:
+  limit:
+    nonMember: 10

--- a/backend/src/main/resources/config/thirdparty.yml
+++ b/backend/src/main/resources/config/thirdparty.yml
@@ -1,0 +1,8 @@
+thirdparty:
+  deepseek:
+    base-url: https://api.deepseek.com
+    api-key: ""
+  doubao:
+    base-url: https://ark.cn-beijing.volces.com
+    chat-path: /api/v3/chat/completions
+    api-key: ""

--- a/backend/src/main/resources/config/tts.yml
+++ b/backend/src/main/resources/config/tts.yml
@@ -1,0 +1,11 @@
+tts:
+  volcengine:
+    # Credentials and routing for Volcengine TTS service.
+    app-id: ${VOLCENGINE_APP_ID:}
+    # Access token issued by Volcengine for authentication.
+    access-token: ${VOLCENGINE_ACCESS_TOKEN:}
+    cluster: volcano_tts
+    # Base URL of Volcengine TTS endpoint. Override for staging or mocks.
+    api-url: https://openspeech.bytedance.com/api/v1/tts
+    # Interval for proactive health checks to Volcengine TTS.
+    health-interval: PT10M

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -14,35 +14,12 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
-
   logging:
     level:
       "[org.hibernate.SQL]": debug
       "[org.hibernate.orm.schema]": debug
-
-oss:
-  endpoint: https://oss-cn-beijing.aliyuncs.com
-  bucket: glancy-avatar-bucket
-  avatar-dir: avatars/
-  public-read: true
-  signed-url-expiration-minutes: 60
-  verify-location: true
-  access-key-id:
-  access-key-secret:
-
-llm:
-  default-client: deepseek
-  temperature: 0.7
-  prompt-path: prompts/english_to_chinese.txt
-
-tts:
-  volcengine:
-    # Credentials and routing for Volcengine TTS service during tests.
-    app-id:
-    # Access token issued by Volcengine for authentication.
-    access-token: ${VOLCENGINE_ACCESS_TOKEN:}
-    cluster: volcano_tts
-    # Base URL used during tests; points to mock server or real endpoint.
-    api-url: https://openspeech.bytedance.com/api/v1/tts
-    # Interval for proactive health checks during tests.
-    health-interval: PT1M
+  config:
+    import:
+      - classpath:config/oss.yml
+      - classpath:config/llm.yml
+      - classpath:config/tts.yml

--- a/backend/src/test/resources/config/llm.yml
+++ b/backend/src/test/resources/config/llm.yml
@@ -1,0 +1,4 @@
+llm:
+  default-client: deepseek
+  temperature: 0.7
+  prompt-path: prompts/english_to_chinese.txt

--- a/backend/src/test/resources/config/oss.yml
+++ b/backend/src/test/resources/config/oss.yml
@@ -1,0 +1,10 @@
+oss:
+  endpoint: https://oss-cn-beijing.aliyuncs.com
+  bucket: glancy-avatar-bucket
+  avatar-dir: avatars/
+  public-read: true
+  signed-url-expiration-minutes: 60
+  verify-location: true
+  access-key-id:
+  access-key-secret:
+  security-token:

--- a/backend/src/test/resources/config/tts.yml
+++ b/backend/src/test/resources/config/tts.yml
@@ -1,0 +1,11 @@
+tts:
+  volcengine:
+    # Credentials and routing for Volcengine TTS service during tests.
+    app-id:
+    # Access token issued by Volcengine for authentication.
+    access-token: ${VOLCENGINE_ACCESS_TOKEN:}
+    cluster: volcano_tts
+    # Base URL used during tests; points to mock server or real endpoint.
+    api-url: https://openspeech.bytedance.com/api/v1/tts
+    # Interval for proactive health checks during tests.
+    health-interval: PT1M


### PR DESCRIPTION
## Summary
- modularize backend application config into domain-specific YAML files
- update tests to use modular config structure

## Testing
- `npx eslint . --fix` *(fails: ESLint couldn't find an eslint.config file)*
- `npx stylelint "backend/src/main/resources/config/*.yml" --fix` *(terminated: command produced no output)*
- `npx prettier -w backend/src/main/resources/config/application.yml backend/src/main/resources/config/search.yml backend/src/main/resources/config/llm.yml backend/src/main/resources/config/thirdparty.yml backend/src/main/resources/config/oss.yml backend/src/main/resources/config/tts.yml backend/src/test/resources/application.yml backend/src/test/resources/config/llm.yml backend/src/test/resources/config/oss.yml backend/src/test/resources/config/tts.yml`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ae98a4a73c83328b772e25232c2868