### PR TITLE
refactor: 引入 PromptManager 统一管理 DeepSeek 固定 prompt

### DIFF
--- a/backend/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/backend/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -35,7 +35,8 @@ class DeepSeekClientTest {
             restTemplate,
             "http://mock",
             "key",
-            new com.glancy.backend.llm.parser.JacksonWordResponseParser());
+            new com.glancy.backend.llm.parser.JacksonWordResponseParser(),
+            new com.glancy.backend.llm.prompt.PromptManagerImpl());
   }
 
   /** 测试 fetchDefinitionWithAuth 接口 */


### PR DESCRIPTION
## Summary
- 通过在 `DeepSeekClient` 构造函数注入 `PromptManager`，统一加载中英互译提示词
- 更新 `DeepSeekClientTest` 适配 `PromptManager` 依赖

## Testing
- `npx eslint --fix .` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx stylelint "**/*.{css,scss,less}" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68af2c4b9d9c833285301547477c40ef