### PR TITLE
refactor: centralize client url utils

### DIFF
--- a/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/backend/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -1,5 +1,9 @@
 package com.glancy.backend.client;
 
+import static com.glancy.backend.util.ClientUtils.ensureLeadingSlash;
+import static com.glancy.backend.util.ClientUtils.maskKey;
+import static com.glancy.backend.util.ClientUtils.trimTrailingSlash;
+
 import com.glancy.backend.config.DoubaoProperties;
 import com.glancy.backend.llm.llm.LLMClient;
 import com.glancy.backend.llm.model.ChatMessage;
@@ -119,25 +123,4 @@ public class DoubaoClient implements LLMClient {
     return "message";
   }
 
-  private String trimTrailingSlash(String url) {
-    if (url == null || url.isBlank()) {
-      return "";
-    }
-    return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
-  }
-
-  private String ensureLeadingSlash(String path) {
-    if (path == null || path.isBlank()) {
-      return "";
-    }
-    return path.startsWith("/") ? path : "/" + path;
-  }
-
-  private String maskKey(String key) {
-    if (key.length() <= 8) {
-      return "****";
-    }
-    int end = key.length() - 4;
-    return key.substring(0, 4) + "****" + key.substring(end);
-  }
 }

--- a/backend/src/main/java/com/glancy/backend/util/ClientUtils.java
+++ b/backend/src/main/java/com/glancy/backend/util/ClientUtils.java
@@ -1,0 +1,34 @@
+package com.glancy.backend.util;
+
+import org.springframework.util.StringUtils;
+
+/** Utility methods for client configuration normalization. */
+public final class ClientUtils {
+
+  private ClientUtils() {}
+
+  /** Removes a trailing slash from the given URL, if present. */
+  public static String trimTrailingSlash(String url) {
+    if (!StringUtils.hasText(url)) {
+      return "";
+    }
+    return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+  }
+
+  /** Ensures the path starts with a leading slash. */
+  public static String ensureLeadingSlash(String path) {
+    if (!StringUtils.hasText(path)) {
+      return "";
+    }
+    return path.startsWith("/") ? path : "/" + path;
+  }
+
+  /** Masks an API key for safe logging. */
+  public static String maskKey(String key) {
+    if (!StringUtils.hasText(key) || key.length() <= 8) {
+      return "****";
+    }
+    int end = key.length() - 4;
+    return key.substring(0, 4) + "****" + key.substring(end);
+  }
+}


### PR DESCRIPTION
## Summary
- factor common URL and key helpers into new `ClientUtils`
- refactor Doubao, DeepSeek, and DeepSeekStream clients to use `ClientUtils`

## Testing
- `npx eslint . --fix` *(fails: Cannot use import statement outside a module)*
- `npx stylelint "**/*.{css,scss}" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af2c2cdf1883329bd61641f40dbf70