### PR TITLE
feat: centralize service logging with aspect

### DIFF
--- a/backend/src/main/java/com/glancy/backend/config/ServiceLoggingAspect.java
+++ b/backend/src/main/java/com/glancy/backend/config/ServiceLoggingAspect.java
@@ -1,0 +1,44 @@
+package com.glancy.backend.config;
+
+import java.util.Arrays;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * A cross-cutting concern that logs all public methods within the service layer. By centralizing
+ * this logic we keep service classes focused on business behaviour while still providing
+ * consistent observability across the application.
+ */
+@Aspect
+@Component
+public class ServiceLoggingAspect {
+
+  @Around("execution(public * com.glancy.backend.service..*(..))")
+  public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+    long start = System.currentTimeMillis();
+    Object result = joinPoint.proceed();
+    long duration = System.currentTimeMillis() - start;
+
+    Logger logger = LoggerFactory.getLogger(joinPoint.getTarget().getClass());
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    String args = Arrays.toString(joinPoint.getArgs());
+    String returnValue =
+        signature.getReturnType().equals(Void.TYPE) ? "void" : String.valueOf(result);
+
+    logger.info(
+        "Service method {}.{} called with args {} returned {} in {}ms",
+        signature.getDeclaringType().getSimpleName(),
+        signature.getName(),
+        args,
+        returnValue,
+        duration);
+
+    return result;
+  }
+}
+

--- a/backend/src/main/java/com/glancy/backend/service/ContactService.java
+++ b/backend/src/main/java/com/glancy/backend/service/ContactService.java
@@ -4,12 +4,10 @@ import com.glancy.backend.dto.ContactRequest;
 import com.glancy.backend.dto.ContactResponse;
 import com.glancy.backend.entity.ContactMessage;
 import com.glancy.backend.repository.ContactMessageRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Handles persistence of contact messages sent from the front-end contact form. */
-@Slf4j
 @Service
 public class ContactService {
 
@@ -22,7 +20,6 @@ public class ContactService {
   /** Save an incoming contact message. */
   @Transactional
   public ContactResponse submit(ContactRequest request) {
-    log.info("Submitting contact message from {}", request.getEmail());
     ContactMessage message = new ContactMessage();
     message.setName(request.getName());
     message.setEmail(request.getEmail());

--- a/backend/src/main/java/com/glancy/backend/service/FaqService.java
+++ b/backend/src/main/java/com/glancy/backend/service/FaqService.java
@@ -7,7 +7,6 @@ import com.glancy.backend.mapper.FaqMapper;
 import com.glancy.backend.repository.FaqRepository;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
  * Business logic for FAQ management. Allows admins to create and retrieve frequently asked
  * questions.
  */
-@Slf4j
 @Service
 public class FaqService {
 
@@ -30,7 +28,6 @@ public class FaqService {
   /** Persist a new FAQ entry. */
   @Transactional
   public FaqResponse createFaq(FaqRequest request) {
-    log.info("Creating FAQ: {}", request.getQuestion());
     Faq faq = new Faq();
     faq.setQuestion(request.getQuestion());
     faq.setAnswer(request.getAnswer());
@@ -41,7 +38,6 @@ public class FaqService {
   /** Retrieve all stored FAQ entries. */
   @Transactional(readOnly = true)
   public List<FaqResponse> getAllFaqs() {
-    log.info("Retrieving all FAQs");
     return faqRepository.findAll().stream().map(faqMapper::toResponse).collect(Collectors.toList());
   }
 }

--- a/backend/src/main/java/com/glancy/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/glancy/backend/service/NotificationService.java
@@ -10,7 +10,6 @@ import com.glancy.backend.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
  * Business logic around creating and listing notifications that may either be global announcements
  * or user specific.
  */
-@Slf4j
 @Service
 public class NotificationService {
 
@@ -34,7 +32,6 @@ public class NotificationService {
   /** Create a system level notification for all users. */
   @Transactional
   public NotificationResponse createSystemNotification(NotificationRequest request) {
-    log.info("Creating system notification: {}", request.getMessage());
     Notification notification = new Notification();
     notification.setMessage(request.getMessage());
     notification.setSystemLevel(true);
@@ -45,7 +42,6 @@ public class NotificationService {
   /** Create a notification for a single user. */
   @Transactional
   public NotificationResponse createUserNotification(Long userId, NotificationRequest request) {
-    log.info("Creating notification for user {}: {}", userId, request.getMessage());
     User user =
         userRepository.findById(userId).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     Notification notification = new Notification();
@@ -59,7 +55,6 @@ public class NotificationService {
   /** Combine system notifications with those addressed to the given user. */
   @Transactional(readOnly = true)
   public List<NotificationResponse> getNotificationsForUser(Long userId) {
-    log.info("Fetching notifications for user {}", userId);
     List<Notification> result = new ArrayList<>();
     result.addAll(notificationRepository.findBySystemLevelTrueOrderByCreatedAtDesc());
     result.addAll(notificationRepository.findByUserIdOrderByCreatedAtDesc(userId));

--- a/backend/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
+++ b/backend/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
@@ -57,7 +57,6 @@ public class OssAvatarStorage implements AvatarStorage {
     } else {
       url = generatePresignedUrl(objectName);
     }
-    log.info("Avatar stored as {}. URL returned: {}", objectName, url);
     return url;
   }
 
@@ -91,7 +90,6 @@ public class OssAvatarStorage implements AvatarStorage {
     }
     URL url = ossClient.generatePresignedUrl(req);
     String result = url.toString();
-    log.info("Generated presigned URL: {}", result);
     return result;
   }
 

--- a/backend/src/main/java/com/glancy/backend/service/UserPreferenceService.java
+++ b/backend/src/main/java/com/glancy/backend/service/UserPreferenceService.java
@@ -8,12 +8,10 @@ import com.glancy.backend.entity.UserPreference;
 import com.glancy.backend.exception.ResourceNotFoundException;
 import com.glancy.backend.repository.UserPreferenceRepository;
 import com.glancy.backend.repository.UserRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Stores and retrieves per-user settings such as theme and preferred languages. */
-@Slf4j
 @Service
 public class UserPreferenceService {
 
@@ -46,7 +44,6 @@ public class UserPreferenceService {
   /** Save UI and language preferences for a user. */
   @Transactional
   public UserPreferenceResponse savePreference(Long userId, UserPreferenceRequest req) {
-    log.info("Saving preferences for user {}", userId);
     User user =
         userRepository.findById(userId).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     UserPreference pref =
@@ -63,7 +60,6 @@ public class UserPreferenceService {
   /** Retrieve preferences previously saved for the user. */
   @Transactional(readOnly = true)
   public UserPreferenceResponse getPreference(Long userId) {
-    log.info("Fetching preferences for user {}", userId);
     UserPreference pref =
         userPreferenceRepository
             .findByUserId(userId)

--- a/backend/src/main/java/com/glancy/backend/service/UserProfileService.java
+++ b/backend/src/main/java/com/glancy/backend/service/UserProfileService.java
@@ -7,12 +7,10 @@ import com.glancy.backend.entity.UserProfile;
 import com.glancy.backend.exception.ResourceNotFoundException;
 import com.glancy.backend.repository.UserProfileRepository;
 import com.glancy.backend.repository.UserRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Manage optional personal details for users. */
-@Slf4j
 @Service
 public class UserProfileService {
 
@@ -36,7 +34,6 @@ public class UserProfileService {
   @Transactional
   public void initProfile(Long userId) {
     if (userProfileRepository.findByUserId(userId).isEmpty()) {
-      log.info("Initializing default profile for user {}", userId);
       userProfileRepository.save(createDefaultProfile(userId));
     }
   }
@@ -44,7 +41,6 @@ public class UserProfileService {
   /** Save the profile for a user. */
   @Transactional
   public UserProfileResponse saveProfile(Long userId, UserProfileRequest req) {
-    log.info("Saving profile for user {}", userId);
     User user =
         userRepository.findById(userId).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     UserProfile profile = userProfileRepository.findByUserId(userId).orElseGet(UserProfile::new);
@@ -61,7 +57,6 @@ public class UserProfileService {
   /** Fetch profile for a user. */
   @Transactional(readOnly = true)
   public UserProfileResponse getProfile(Long userId) {
-    log.info("Fetching profile for user {}", userId);
     UserProfile profile =
         userProfileRepository.findByUserId(userId).orElseGet(() -> createDefaultProfile(userId));
     return toResponse(profile);

--- a/backend/src/main/java/com/glancy/backend/service/UserService.java
+++ b/backend/src/main/java/com/glancy/backend/service/UserService.java
@@ -59,7 +59,6 @@ public class UserService {
   /** Register a new user ensuring username and email uniqueness. */
   @Transactional
   public UserResponse register(UserRegistrationRequest req) {
-    log.info("Registering user {}", req.getUsername());
     if (userRepository.findByUsernameAndDeletedFalse(req.getUsername()).isPresent()) {
       log.warn("Username {} already exists", req.getUsername());
       throw new DuplicateResourceException("用户名已存在");
@@ -87,7 +86,6 @@ public class UserService {
   /** Logically delete a user account. */
   @Transactional
   public void deleteUser(Long id) {
-    log.info("Deleting user {}", id);
     User user =
         userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     user.setDeleted(true);
@@ -97,7 +95,6 @@ public class UserService {
   /** Retrieve a user by id, regardless of deletion flag. */
   @Transactional(readOnly = true)
   public User getUserRaw(Long id) {
-    log.info("Fetching user {}", id);
     return userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
   }
 
@@ -164,7 +161,6 @@ public class UserService {
         break;
     }
 
-    log.info("Attempting login for {}", identifier);
 
     if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
       log.warn("Password mismatch for user {}", user.getUsername());
@@ -191,7 +187,6 @@ public class UserService {
     user.setLoginToken(token);
     userRepository.save(user);
 
-    log.info("User {} logged in", user.getId());
     return new LoginResponse(
         user.getId(),
         user.getUsername(),
@@ -206,7 +201,6 @@ public class UserService {
   @Transactional
   public ThirdPartyAccountResponse bindThirdPartyAccount(
       Long userId, ThirdPartyAccountRequest req) {
-    log.info("Binding {} account for user {}", req.getProvider(), userId);
     User user =
         userRepository
             .findById(userId)
@@ -283,7 +277,6 @@ public class UserService {
   /** Retrieve only the avatar URL of a user. */
   @Transactional(readOnly = true)
   public AvatarResponse getAvatar(Long userId) {
-    log.info("Fetching avatar for user {}", userId);
     User user =
         userRepository.findById(userId).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     return new AvatarResponse(user.getAvatar());
@@ -292,13 +285,11 @@ public class UserService {
   /** Update the avatar URL for the specified user. */
   @Transactional
   public AvatarResponse updateAvatar(Long userId, String avatar) {
-    log.info("Updating avatar for user {}", userId);
     User user =
         userRepository.findById(userId).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     String previousAvatar = user.getAvatar();
     user.setAvatar(avatar);
     User saved = userRepository.save(user);
-    log.info("Avatar updated for user {} from {} to {}", userId, previousAvatar, saved.getAvatar());
     return new AvatarResponse(saved.getAvatar());
   }
 
@@ -317,7 +308,6 @@ public class UserService {
   /** Update the username for the specified user. */
   @Transactional
   public UsernameResponse updateUsername(Long userId, String username) {
-    log.info("Updating username for user {}", userId);
     userRepository
         .findByUsernameAndDeletedFalse(username)
         .ifPresent(
@@ -334,7 +324,6 @@ public class UserService {
   /** Set a user as member. */
   @Transactional
   public void activateMembership(Long userId) {
-    log.info("Activating membership for user {}", userId);
     User user =
         userRepository.findById(userId).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     user.setMember(true);
@@ -344,7 +333,6 @@ public class UserService {
   /** Remove member status from a user. */
   @Transactional
   public void removeMembership(Long userId) {
-    log.info("Removing membership for user {}", userId);
     User user =
         userRepository.findById(userId).orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
     user.setMember(false);

--- a/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/client/VolcengineTtsClient.java
@@ -146,7 +146,6 @@ public class VolcengineTtsClient {
     sanitized.put("uid", sanitize("uid", uid));
     Object lang = ((Map<?, ?>) payload.get("audio")).get("explicit_language");
     sanitized.put("lang", sanitize("lang", lang));
-    log.info("Resolved TTS parameters {}", sanitized);
   }
 
   private Object sanitize(String key, Object value) {

--- a/backend/src/main/java/com/glancy/backend/service/tts/config/TtsConfigManager.java
+++ b/backend/src/main/java/com/glancy/backend/service/tts/config/TtsConfigManager.java
@@ -75,7 +75,6 @@ public class TtsConfigManager implements Closeable {
       TtsConfig cfg = mapper.readValue(in, TtsConfig.class);
       validate(cfg);
       snapshot.set(cfg);
-      log.info("Loaded TTS config from classpath");
     } catch (Exception ex) {
       log.error("Failed to load classpath TTS config", ex);
     }
@@ -86,7 +85,6 @@ public class TtsConfigManager implements Closeable {
       TtsConfig cfg = mapper.readValue(in, TtsConfig.class);
       validate(cfg);
       snapshot.set(cfg);
-      log.info("Loaded TTS config from {}", path.toAbsolutePath());
     } catch (Exception ex) {
       log.warn("Failed to reload TTS config from {}", path.toAbsolutePath(), ex);
     }
@@ -119,7 +117,6 @@ public class TtsConfigManager implements Closeable {
                 return t;
               });
       watchExecutor.submit(() -> watchLoop(dir, path));
-      log.info("Watching {} for TTS config changes", path.toAbsolutePath());
     } catch (IOException | RuntimeException ex) {
       log.warn("Failed to watch TTS config file", ex);
     }
@@ -132,7 +129,6 @@ public class TtsConfigManager implements Closeable {
         for (WatchEvent<?> event : key.pollEvents()) {
           Path changed = dir.resolve((Path) event.context());
           if (Files.isRegularFile(changed) && changed.getFileName().equals(path.getFileName())) {
-            log.info("Detected TTS config change");
             reload();
           }
         }

--- a/backend/src/test/java/com/glancy/backend/config/ServiceLoggingAspectTest.java
+++ b/backend/src/test/java/com/glancy/backend/config/ServiceLoggingAspectTest.java
@@ -1,0 +1,45 @@
+package com.glancy.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.glancy.backend.service.EchoService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+/** Tests for {@link ServiceLoggingAspect}. */
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(classes = ServiceLoggingAspectTest.TestConfig.class)
+class ServiceLoggingAspectTest {
+
+  @Autowired private EchoService echoService;
+
+  @Test
+  void logsMethodNameParametersAndReturnValue(CapturedOutput output) {
+    String result = echoService.echo("alice");
+    assertThat(result).isEqualTo("echo: alice");
+    assertThat(output.getOut())
+        .contains("EchoService.echo")
+        .contains("args=[alice]")
+        .contains("returned echo: alice")
+        .contains("ms");
+  }
+
+  @SpringBootConfiguration
+  @EnableAutoConfiguration
+  @Import(ServiceLoggingAspect.class)
+  static class TestConfig {
+    @Bean
+    EchoService echoService() {
+      return new EchoService();
+    }
+  }
+}
+

--- a/backend/src/test/java/com/glancy/backend/service/EchoService.java
+++ b/backend/src/test/java/com/glancy/backend/service/EchoService.java
@@ -1,0 +1,12 @@
+package com.glancy.backend.service;
+
+import org.springframework.stereotype.Service;
+
+/** Simple service for aspect testing. */
+@Service
+public class EchoService {
+  public String echo(String name) {
+    return "echo: " + name;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ServiceLoggingAspect to log service method name, arguments, return value and duration
- remove manual info logging from service layer
- cover aspect with test verifying log format

## Testing
- `npx eslint --fix .` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx stylelint "**/*.{css,scss}" --fix`
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68af2bb4bfdc83329fc771ebbc383ab6