### PR TITLE
feat: throttle viewport height updates

### DIFF
--- a/website/glancy-website/src/main.jsx
+++ b/website/glancy-website/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode, Suspense, lazy, useEffect } from "react";
+/* eslint-env browser */
+
+import { StrictMode, Suspense, lazy, useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ErrorBoundary from "./components/ui/ErrorBoundary";
 import "./styles/index.css";
 import Loader from "./components/ui/Loader";
 import AuthWatcher from "./components/AuthWatcher";
+import { rafThrottle } from "./utils/rafThrottle";
 
 const App = lazy(() => import("./pages/App"));
 const Login = lazy(() => import("./pages/auth/Login"));
@@ -16,18 +19,21 @@ import {
   AppProviders,
 } from "@/context";
 
-// eslint-disable-next-line react-refresh/only-export-components
 function ViewportHeightUpdater() {
-  useEffect(() => {
-    const updateVh = () => {
+  useLayoutEffect(() => {
+    const setVh = () => {
       document.documentElement.style.setProperty(
         "--vh",
         `${window.innerHeight}px`,
       );
     };
-    updateVh();
-    window.addEventListener("resize", updateVh);
-    return () => window.removeEventListener("resize", updateVh);
+    const handleResize = rafThrottle(setVh);
+    setVh();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      handleResize.cancel();
+      window.removeEventListener("resize", handleResize);
+    };
   }, []);
   return null;
 }

--- a/website/glancy-website/src/utils/rafThrottle.js
+++ b/website/glancy-website/src/utils/rafThrottle.js
@@ -1,0 +1,31 @@
+/**
+ * Returns a function throttled to the next animation frame.
+ * Useful for reducing invocations of high-frequency events like resize or scroll.
+ * The returned function also provides a `cancel` method to clear any pending frame.
+ * @param {Function} fn - The callback to throttle.
+ * @returns {Function} A throttled version of the callback.
+ */
+/* eslint-env browser */
+
+export function rafThrottle(fn) {
+  let rafId = null;
+
+  function invoke(...args) {
+    rafId = null;
+    fn(...args);
+  }
+
+  function throttled(...args) {
+    if (rafId !== null) return;
+    rafId = requestAnimationFrame(() => invoke(...args));
+  }
+
+  throttled.cancel = () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+
+  return throttled;
+}

--- a/website/glancy-website/tests/rafThrottle.test.mjs
+++ b/website/glancy-website/tests/rafThrottle.test.mjs
@@ -1,0 +1,30 @@
+/* eslint-env node */
+
+import test from "node:test";
+import assert from "node:assert";
+import { rafThrottle } from "../src/utils/rafThrottle.js";
+
+// Polyfill requestAnimationFrame for Node environment
+globalThis.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 0);
+globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
+
+test("rafThrottle collapses rapid calls", async () => {
+  let count = 0;
+  const increment = () => {
+    count += 1;
+  };
+  const throttled = rafThrottle(increment);
+
+  for (let i = 0; i < 100; i += 1) {
+    throttled();
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.strictEqual(count, 1);
+
+  throttled();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.strictEqual(count, 2);
+
+  throttled.cancel();
+});


### PR DESCRIPTION
## Summary
- use requestAnimationFrame to throttle viewport height updates and switch to useLayoutEffect
- add reusable rafThrottle utility and tests for animation frame throttling

## Testing
- `npx prettier website/glancy-website/src/main.jsx website/glancy-website/src/utils/rafThrottle.js website/glancy-website/tests/rafThrottle.test.mjs -w`
- `npx eslint website/glancy-website/src/main.jsx website/glancy-website/src/utils/rafThrottle.js website/glancy-website/tests/rafThrottle.test.mjs --config eslint.run.config.mjs`
- `npx stylelint "**/*.{css,scss}" --fix`
- `mvn -q -f backend/pom.xml spotless:apply` *(fails: Non-resolvable parent POM)*
- `node website/glancy-website/tests/rafThrottle.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68af45df3674833296564a357b23d48e