### PR TITLE
feat: 自定义 Flyway 迁移配置并新增测试

### DIFF
--- a/backend/src/main/java/com/glancy/backend/config/FlywayConfig.java
+++ b/backend/src/main/java/com/glancy/backend/config/FlywayConfig.java
@@ -1,0 +1,63 @@
+package com.glancy.backend.config;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.flywaydb.core.api.FlywayException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 自定义 Flyway 迁移配置。
+ *
+ * <p>通过数据库锁保证只有一个实例执行迁移，同时彻底禁止 {@code clean} 操作。
+ */
+@Configuration
+public class FlywayConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(FlywayConfig.class);
+
+  /** 禁用 Flyway 的 clean 操作，避免误删数据。 */
+  @Bean
+  FlywayConfigurationCustomizer disableFlywayClean() {
+    log.warn("Flyway clean 操作已被禁用，如需重置数据库请手动执行");
+    return configuration -> configuration.cleanDisabled(true);
+  }
+
+  /**
+   * 使用基于数据库的简单锁保证只有一个实例执行迁移。
+   *
+   * @param dataSource 数据源
+   * @return 迁移策略
+   */
+  @Bean
+  FlywayMigrationStrategy migrationStrategy(DataSource dataSource) {
+    return flyway -> {
+      try (Connection connection = dataSource.getConnection();
+          Statement statement = connection.createStatement()) {
+        connection.setAutoCommit(false);
+        statement.execute("CREATE TABLE IF NOT EXISTS flyway_lock (id INT PRIMARY KEY)");
+        try {
+          statement.executeUpdate("INSERT INTO flyway_lock (id) VALUES (1)");
+        } catch (SQLException ignored) {
+          // 记录已存在，无需处理
+        }
+        try (PreparedStatement ps =
+            connection.prepareStatement(
+                "SELECT id FROM flyway_lock WHERE id = 1 FOR UPDATE")) {
+          ps.executeQuery();
+          flyway.migrate();
+          connection.commit();
+        }
+      } catch (SQLException ex) {
+        throw new FlywayException("数据库迁移失败", ex);
+      }
+    };
+  }
+}

--- a/backend/src/test/java/com/glancy/backend/config/FlywayConfigTest.java
+++ b/backend/src/test/java/com/glancy/backend/config/FlywayConfigTest.java
@@ -1,0 +1,37 @@
+package com.glancy.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/** Tests for {@link FlywayConfig}. */
+@SpringBootTest
+class FlywayConfigTest {
+
+  @Autowired private Flyway flyway;
+
+  @Autowired private DataSource dataSource;
+
+  /** 验证 Flyway clean 被禁用且历史表存在。 */
+  @Test
+  void disablesCleanAndCreatesHistoryTable() throws Exception {
+    assertThat(flyway.getConfiguration().isCleanDisabled()).isTrue();
+    assertThatThrownBy(() -> flyway.clean()).isInstanceOf(FlywayException.class);
+    try (Connection connection = dataSource.getConnection()) {
+      DatabaseMetaData metaData = connection.getMetaData();
+      try (ResultSet tables =
+          metaData.getTables(null, null, "flyway_schema_history".toUpperCase(), null)) {
+        assertThat(tables.next()).isTrue();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 自定义 Flyway 迁移策略，使用数据库锁并禁止 clean
- 添加 Flyway 配置测试，校验 clean 禁用和历史表存在

## Testing
- `npx eslint . --fix` (fails: Cannot use import statement outside a module)
- `npx stylelint "**/*.{css,scss}" --fix`
- `npx prettier -w .`
- `mvn -q -f backend/pom.xml spotless:apply` (fails: Non-resolvable parent POM)
- `mvn -q -f backend/pom.xml test` (fails: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68af4d713b70833282fb6f226d87be7c