### PR TITLE
feat: add migration job and container startup db check

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -8,7 +8,26 @@ on:
       - "backend/**"
 
 jobs:
+  migration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - name: Run database migrations
+        run: |
+          mvn -B -pl backend flyway:migrate
+          status=$?
+          if [ $status -ne 0 ]; then
+            echo "Flyway migration failed with exit code $status"
+            exit $status
+          fi
   build-and-deploy:
+    needs: migration
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/backend/scripts/start-container.sh
+++ b/backend/scripts/start-container.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { echo "[$(date '+%F %T')] $*" >&2; }
+
+APP_HOME=$(cd "$(dirname "$0")/.." && pwd)
+
+readonly DB_HOST=${DB_HOST:-localhost}
+readonly DB_PORT=${DB_PORT:-3306}
+readonly DB_NAME=${DB_NAME:-glancy_db}
+readonly DB_USER=${DB_USER:-glancy_user}
+readonly DB_PASSWORD=${DB_PASSWORD:-}
+
+mvn_info_args=(-f "${APP_HOME}/pom.xml" -q flyway:info \
+  -Dflyway.url="jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}" \
+  -Dflyway.user="${DB_USER}")
+if [[ -n "${DB_PASSWORD}" ]]; then
+  mvn_info_args+=( -Dflyway.password="${DB_PASSWORD}" )
+fi
+
+info_output=$(mvn "${mvn_info_args[@]}")
+if echo "${info_output}" | grep -q "Pending"; then
+  log "数据库迁移未同步至最新版本，请先执行迁移。"
+  exit 1
+fi
+
+exec java -jar "${APP_HOME}/target/glancy-backend.jar"


### PR DESCRIPTION
## Summary
- add migration job executing flyway migrations prior to deploy
- add container startup script that verifies schema version before launching backend

## Testing
- `ESLINT_USE_FLAT_CONFIG=true npx eslint --fix .` (fails: SyntaxError: Cannot use import statement outside a module)
- `npx stylelint "**/*.{css,scss}" --fix`
- `npx prettier -w .`
- `mvn spotless:apply` (fails: Non-resolvable parent POM ... Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68af4d72349c83329d9d583e923b47e4