### PR TITLE
style: replace hardcoded spacing with theme variables

### DIFF
--- a/website/glancy-website/src/components/TopBar/MobileTopBar.module.css
+++ b/website/glancy-website/src/components/TopBar/MobileTopBar.module.css
@@ -8,20 +8,21 @@
   pointer-events: none;
 }
 
+/* 采用全局间距变量保持头部工具栏的一致节奏 */
 .topbar-btn {
   background: none;
   border: none;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   cursor: pointer;
   display: flex;
   align-items: center;
 }
 
 .term-text {
-  margin-left: 4px;
+  margin-left: var(--space-1);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .term-label {
@@ -32,8 +33,7 @@
   height: var(--bar-height);
   display: flex;
   align-items: center;
-  padding: 0 12px;
-  gap: 8px;
+  padding: 0 calc(var(--space-2) + var(--space-1));
+  gap: var(--space-2);
   border-bottom: 1px solid var(--border-color);
 }
-

--- a/website/glancy-website/src/components/TopBar/TopBarCommon.module.css
+++ b/website/glancy-website/src/components/TopBar/TopBarCommon.module.css
@@ -1,13 +1,14 @@
+/* 头部组件统一采用间距变量提升可维护性 */
 .back-btn,
 .more-btn {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
 }
 
 .back-btn {
-  width: 32px;
+  width: var(--space-5);
   text-align: center;
 }
 
@@ -22,7 +23,7 @@
 }
 
 .favorite-toggle {
-  margin-right: 8px;
+  margin-right: var(--space-2);
   background: none;
   border: none;
   cursor: pointer;
@@ -36,12 +37,12 @@
 .more-menu .menu {
   position: absolute;
   right: 0;
-  top: calc(100% + 4px);
+  top: calc(100% + var(--space-1));
   background: var(--app-bg);
   color: var(--app-color);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
-  padding: 4px 0;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) 0;
   width: 100px;
   z-index: 1000;
   display: flex;
@@ -51,11 +52,11 @@
 .more-menu .menu button {
   background: none;
   border: none;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   text-align: left;
   cursor: pointer;
 }
 
 .more-menu .menu .icon {
-  margin-right: 4px;
+  margin-right: var(--space-1);
 }

--- a/website/glancy-website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/glancy-website/src/components/ui/ChatInput/ChatInput.module.css
@@ -1,9 +1,10 @@
+/* 使用全局间距变量保持一致的视觉节奏 */
 .container {
   display: flex;
   align-items: center;
   height: 100%;
   width: 100%;
-  gap: 16px;
+  gap: var(--space-3);
   background: var(--app-bg);
 }
 
@@ -11,7 +12,10 @@
   flex: 1;
   border: none;
   border-radius: var(--radius-lg);
-  padding: 12px 20px;
+
+  /* 内边距组合使用间距变量以避免魔法数 */
+  padding: calc(var(--space-2) + var(--space-1))
+    calc(var(--space-3) + var(--space-1));
   outline: none;
   font-size: 1rem;
   box-shadow: 0 2px 4px var(--shadow-color);
@@ -20,12 +24,12 @@
 .button {
   border: none;
   background: none;
-  padding: 8px;
+  padding: var(--space-2);
   cursor: pointer;
 }
 
 .button + .button {
-  margin-left: 16px;
+  margin-left: var(--space-3);
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- use spacing scale variables in ChatInput and TopBar components
- document spacing choices for future maintainability

## Testing
- `npx prettier website/glancy-website/src/components/ui/ChatInput/ChatInput.module.css website/glancy-website/src/components/TopBar/MobileTopBar.module.css website/glancy-website/src/components/TopBar/TopBarCommon.module.css -w`
- `npx stylelint website/glancy-website/src/components/ui/ChatInput/ChatInput.module.css website/glancy-website/src/components/TopBar/MobileTopBar.module.css website/glancy-website/src/components/TopBar/TopBarCommon.module.css --fix`
- `npx eslint src/components/ui/ChatInput src/components/TopBar --fix`
- `mvn -q spotless:apply` (failed: Non-resolvable parent POM)
- `mvn -q test` (failed: Non-resolvable parent POM)
- `npm test` (failed: JavaScript heap out of memory)


------
https://chatgpt.com/codex/tasks/task_e_68af4db1c9f08332af94c1d4121be586