### PR TITLE
refactor: migrate word store to ts

### DIFF
--- a/website/glancy-website/src/api/words.js
+++ b/website/glancy-website/src/api/words.js
@@ -2,7 +2,7 @@ import { API_PATHS } from "@/config/api.js";
 import { apiRequest } from "./client.js";
 import { useApi } from "@/hooks";
 import { createCachedFetcher, parseSse, clientNameFromModel } from "@/utils";
-import { useWordStore } from "@/store/wordStore.js";
+import { useWordStore } from "@/store/wordStore";
 
 export const WORD_CACHE_VERSION = "md1";
 

--- a/website/glancy-website/src/hooks/__tests__/useStreamWord.test.js
+++ b/website/glancy-website/src/hooks/__tests__/useStreamWord.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import DictionaryEntry from "@/components/ui/DictionaryEntry";
 import { useStreamWord } from "@/hooks/useStreamWord";
-import { useWordStore } from "@/store/wordStore.js";
+import { useWordStore } from "@/store/wordStore";
 
 const streamWordMock = jest.fn();
 const apiMock = { words: { streamWord: streamWordMock } };

--- a/website/glancy-website/src/hooks/useStreamWord.js
+++ b/website/glancy-website/src/hooks/useStreamWord.js
@@ -1,7 +1,7 @@
 import { useApi } from "@/hooks/useApi.js";
 import { detectWordLanguage, clientNameFromModel } from "@/utils";
 import { wordCacheKey } from "@/api/words.js";
-import { useWordStore } from "@/store/wordStore.js";
+import { useWordStore } from "@/store/wordStore";
 
 /**
  * 提供基于 SSE 的词汇查询流式接口，并输出统一格式日志。

--- a/website/glancy-website/src/store/favoritesStore.ts
+++ b/website/glancy-website/src/store/favoritesStore.ts
@@ -1,24 +1,24 @@
-import { createPersistentStore } from './createPersistentStore.ts'
-import { pickState } from './persistUtils.ts'
+import { createPersistentStore } from "./createPersistentStore";
+import { pickState } from "./persistUtils";
 
 interface FavoritesState {
-  favorites: string[]
-  toggleFavorite: (term: string) => void
+  favorites: string[];
+  toggleFavorite: (term: string) => void;
 }
 
 export const useFavoritesStore = createPersistentStore<FavoritesState>({
-  key: 'favorites',
+  key: "favorites",
   initializer: (set, get) => ({
     favorites: [],
     toggleFavorite: (term: string) => {
-      const list = get().favorites
+      const list = get().favorites;
       const updated = list.includes(term)
         ? list.filter((t) => t !== term)
-        : [...list, term]
-      set({ favorites: updated })
-    }
+        : [...list, term];
+      set({ favorites: updated });
+    },
   }),
   persistOptions: {
-    partialize: pickState(['favorites'])
-  }
-})
+    partialize: pickState(["favorites"]),
+  },
+});

--- a/website/glancy-website/src/store/historyStore.ts
+++ b/website/glancy-website/src/store/historyStore.ts
@@ -1,7 +1,7 @@
 import api from "@/api/index.js";
-import { createPersistentStore } from "./createPersistentStore.ts";
-import { pickState } from "./persistUtils.ts";
-import type { User } from "./userStore.ts";
+import { createPersistentStore } from "./createPersistentStore";
+import { pickState } from "./persistUtils";
+import type { User } from "./userStore";
 import { detectWordLanguage } from "@/utils";
 
 interface HistoryState {

--- a/website/glancy-website/src/store/index.ts
+++ b/website/glancy-website/src/store/index.ts
@@ -1,7 +1,7 @@
-export { useFavoritesStore } from "./favoritesStore.ts";
-export { useHistoryStore } from "./historyStore.ts";
-export { useModelStore } from "./modelStore.ts";
-export { useUserStore } from "./userStore.ts";
-export { useVoiceStore } from "./voiceStore.ts";
-export { useWordStore } from "./wordStore.js";
-export type { User } from "./userStore.ts";
+export { useFavoritesStore } from "./favoritesStore";
+export { useHistoryStore } from "./historyStore";
+export { useModelStore } from "./modelStore";
+export { useUserStore } from "./userStore";
+export { useVoiceStore } from "./voiceStore";
+export { useWordStore } from "./wordStore";
+export type { User } from "./userStore";

--- a/website/glancy-website/src/store/modelStore.ts
+++ b/website/glancy-website/src/store/modelStore.ts
@@ -1,20 +1,20 @@
-import { createPersistentStore } from './createPersistentStore.ts'
-import { pickState } from './persistUtils.ts'
+import { createPersistentStore } from "./createPersistentStore";
+import { pickState } from "./persistUtils";
 
 interface ModelState {
-  model: string
-  setModel: (value: string) => void
+  model: string;
+  setModel: (value: string) => void;
 }
 
 export const useModelStore = createPersistentStore<ModelState>({
-  key: 'dictionaryModel',
+  key: "dictionaryModel",
   initializer: (set) => ({
-    model: 'DEEPSEEK',
+    model: "DEEPSEEK",
     setModel: (value: string) => {
-      set({ model: value })
-    }
+      set({ model: value });
+    },
   }),
   persistOptions: {
-    partialize: pickState(['model'])
-  }
-})
+    partialize: pickState(["model"]),
+  },
+});

--- a/website/glancy-website/src/store/userStore.ts
+++ b/website/glancy-website/src/store/userStore.ts
@@ -1,31 +1,31 @@
-import { createPersistentStore } from './createPersistentStore.ts'
-import { pickState } from './persistUtils.ts'
+import { createPersistentStore } from "./createPersistentStore";
+import { pickState } from "./persistUtils";
 
 export interface User {
-  id: string
-  token: string
-  avatar?: string
-  [key: string]: unknown
+  id: string;
+  token: string;
+  avatar?: string;
+  [key: string]: unknown;
 }
 
 interface UserState {
-  user: User | null
-  setUser: (user: User) => void
-  clearUser: () => void
+  user: User | null;
+  setUser: (user: User) => void;
+  clearUser: () => void;
 }
 
 export const useUserStore = createPersistentStore<UserState>({
-  key: 'user',
+  key: "user",
   initializer: (set) => ({
     user: null,
     setUser: (user: User) => {
-      set({ user })
+      set({ user });
     },
     clearUser: () => {
-      set({ user: null })
-    }
+      set({ user: null });
+    },
   }),
   persistOptions: {
-    partialize: pickState(['user'])
-  }
-})
+    partialize: pickState(["user"]),
+  },
+});

--- a/website/glancy-website/src/store/voiceStore.ts
+++ b/website/glancy-website/src/store/voiceStore.ts
@@ -1,14 +1,14 @@
-import { createPersistentStore } from './createPersistentStore.ts'
-import { pickState } from './persistUtils.ts'
+import { createPersistentStore } from "./createPersistentStore";
+import { pickState } from "./persistUtils";
 
 interface VoiceState {
-  voices: Record<string, string>
-  setVoice: (lang: string, voiceId: string) => void
-  getVoice: (lang: string) => string | undefined
+  voices: Record<string, string>;
+  setVoice: (lang: string, voiceId: string) => void;
+  getVoice: (lang: string) => string | undefined;
 }
 
 export const useVoiceStore = createPersistentStore<VoiceState>({
-  key: 'ttsVoicePrefs',
+  key: "ttsVoicePrefs",
   initializer: (set, get) => ({
     voices: {},
     setVoice: (lang: string, voiceId: string) =>
@@ -16,6 +16,6 @@ export const useVoiceStore = createPersistentStore<VoiceState>({
     getVoice: (lang: string) => get().voices[lang],
   }),
   persistOptions: {
-    partialize: pickState(['voices']),
+    partialize: pickState(["voices"]),
   },
-})
+});

--- a/website/glancy-website/src/store/wordStore.ts
+++ b/website/glancy-website/src/store/wordStore.ts
@@ -1,0 +1,28 @@
+import { createPersistentStore } from "./createPersistentStore";
+import { pickState } from "./persistUtils";
+
+export interface WordEntry {
+  markdown?: string;
+  [key: string]: unknown;
+}
+
+interface WordStoreState {
+  entries: Record<string, WordEntry>;
+  setEntry: (key: string, entry: WordEntry) => void;
+  getEntry: (key: string) => WordEntry | undefined;
+  clear: () => void;
+}
+
+export const useWordStore = createPersistentStore<WordStoreState>({
+  key: "wordCache",
+  initializer: (set, get) => ({
+    entries: {},
+    setEntry: (key, entry) =>
+      set((state) => ({ entries: { ...state.entries, [key]: entry } })),
+    getEntry: (key) => get().entries[key],
+    clear: () => set({ entries: {} }),
+  }),
+  persistOptions: {
+    partialize: pickState(["entries"]),
+  },
+});

--- a/website/glancy-website/tsconfig.json
+++ b/website/glancy-website/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
     "isolatedModules": true,
     "noEmit": true,
     "allowJs": true,


### PR DESCRIPTION
## Summary
- migrate word store to TypeScript with explicit state and entry types
- drop .ts extensions from internal store imports and consumers
- forbid TS extension imports via tsconfig

## Testing
- `npx eslint -c website/glancy-website/eslint.config.js website/glancy-website/src/api/words.js website/glancy-website/src/hooks/useStreamWord.js website/glancy-website/src/hooks/__tests__/useStreamWord.test.js --fix`
- `npx stylelint "website/glancy-website/src/**/*.css" --fix --formatter verbose`
- `npx prettier -w website/glancy-website/src/api/words.js website/glancy-website/src/hooks/useStreamWord.js website/glancy-website/src/hooks/__tests__/useStreamWord.test.js website/glancy-website/src/store/index.ts website/glancy-website/src/store/wordStore.ts website/glancy-website/src/store/favoritesStore.ts website/glancy-website/src/store/historyStore.ts website/glancy-website/src/store/modelStore.ts website/glancy-website/src/store/userStore.ts website/glancy-website/src/store/voiceStore.ts website/glancy-website/tsconfig.json`
- `mvn -q -f backend/pom.xml spotless:apply` (fails: Non-resolvable parent POM)
- `npm test` (fails: Syntax error reading regular expression, OOM)

------
https://chatgpt.com/codex/tasks/task_e_68af4daf929883329f6fdb2e79b80f7e