### PR TITLE
feat: allow manual backend deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
     paths:
-      - 'backend/**'
+      - "backend/**"
+  workflow_dispatch: {}
 
 jobs:
   build-and-deploy:
@@ -16,8 +17,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
       - name: Code style check
         run: ./mvnw -B spotless:check checkstyle:check
         working-directory: backend
@@ -32,10 +33,10 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
           timeout: 2m
-          source: backend/target/glancy-backend.jar   # ← 源仍在 backend/target/
+          source: backend/target/glancy-backend.jar # ← 源仍在 backend/target/
           target: ${{ secrets.BACKEND_DEPLOY_PATH }}/target/
           overwrite: true
-          strip_components: 2                         # ← 关键：剥掉 backend/ 与 target/
+          strip_components: 2 # ← 关键：剥掉 backend/ 与 target/
           debug: true
 
       - name: Upload service unit


### PR DESCRIPTION
## Summary
- 支持在 GitHub Actions 中手动触发后端部署

## Testing
- `npx eslint --fix .` *(失败：Cannot use import statement outside a module)*
- `sh .codex-stylelint.sh`
- `npx prettier -w .github/workflows/deploy-backend.yml`
- `cd backend && ./mvnw spotless:apply` *(失败：Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afe18a5ec48332b1cf929df884a381