### PR TITLE
refactor: apply theme variables to chat view

### DIFF
--- a/website/glancy-website/src/components/Header/Header.module.css
+++ b/website/glancy-website/src/components/Header/Header.module.css
@@ -72,7 +72,6 @@
   margin-bottom: 0.5rem;
 }
 
-
 .user-menu .avatar {
   width: 32px;
   height: 32px;
@@ -84,7 +83,6 @@
   margin-right: 0.5rem;
   position: relative;
 }
-
 
 .user-menu .pro-tag-small {
   position: absolute;
@@ -120,7 +118,7 @@
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .user-menu li:hover {
+:root[data-theme="dark"] .user-menu li:hover {
   background-color: var(--color-overlay-inverse);
 }
 
@@ -188,7 +186,7 @@
   margin: 0;
   font: inherit;
   cursor: pointer;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   text-decoration: none;
   white-space: nowrap;
 }

--- a/website/glancy-website/src/components/form/AuthForm.module.css
+++ b/website/glancy-website/src/components/form/AuthForm.module.css
@@ -38,7 +38,7 @@
   border: 1px solid var(--border-color);
   background: var(--input-bg);
   color: var(--app-color);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   font-size: 16px;
   margin-bottom: 20px;
 }
@@ -61,23 +61,23 @@
   background: var(--primary-bg);
   color: var(--primary-color);
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   padding: 12px 16px;
   font-size: 16px;
   cursor: pointer;
   margin-bottom: 24px;
 }
 
-:root[data-theme='dark'] .auth-primary-btn {
+:root[data-theme="dark"] .auth-primary-btn {
   color: var(--primary-color);
 }
 
-:root[data-theme='system'] .auth-primary-btn {
+:root[data-theme="system"] .auth-primary-btn {
   color: var(--primary-color);
 }
 
 @media (prefers-color-scheme: dark) {
-  :root[data-theme='system'] .auth-primary-btn {
+  :root[data-theme="system"] .auth-primary-btn {
     color: var(--primary-color);
   }
 }
@@ -101,7 +101,7 @@
 
 .divider::before,
 .divider::after {
-  content: '';
+  content: "";
   flex: 1;
   height: 1px;
   background: var(--border-color);
@@ -122,7 +122,7 @@
   width: 100%;
   background: var(--input-bg);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   padding: 12px 16px;
   margin-bottom: 12px;
   cursor: pointer;
@@ -138,16 +138,16 @@
   height: 24px;
 }
 
-:root[data-theme='dark'] .oauth-buttons img {
+:root[data-theme="dark"] .oauth-buttons img {
   filter: invert(1);
 }
 
-:root[data-theme='system'] .oauth-buttons img {
+:root[data-theme="system"] .oauth-buttons img {
   filter: none;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root[data-theme='system'] .oauth-buttons img {
+  :root[data-theme="system"] .oauth-buttons img {
     filter: invert(1);
   }
 }
@@ -166,13 +166,12 @@
   justify-content: center;
   background: var(--input-bg);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   padding: 12px;
   width: 48px;
   height: 48px;
   cursor: pointer;
 }
-
 
 .password-row {
   display: flex;
@@ -192,7 +191,7 @@
   border: 1px solid var(--border-color);
   background: var(--input-bg);
   color: var(--app-color);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   font-size: 14px;
   width: 96px;
   cursor: pointer;
@@ -203,16 +202,16 @@
   cursor: not-allowed;
 }
 
-:root[data-theme='dark'] .login-options img {
+:root[data-theme="dark"] .login-options img {
   filter: invert(1);
 }
 
-:root[data-theme='system'] .login-options img {
+:root[data-theme="system"] .login-options img {
   filter: none;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root[data-theme='system'] .login-options img {
+  :root[data-theme="system"] .login-options img {
     filter: invert(1);
   }
 }
@@ -234,7 +233,6 @@
   margin: 0 4px;
 }
 
-
 .auth-close {
   position: absolute;
   top: 20px;
@@ -243,4 +241,3 @@
   color: var(--text-muted);
   font-size: 24px;
 }
-

--- a/website/glancy-website/src/components/form/Form.module.css
+++ b/website/glancy-website/src/components/form/Form.module.css
@@ -18,7 +18,7 @@
   border: 1px solid var(--border-color);
   background: var(--input-bg);
   color: var(--app-color);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
 }
 
 .select:focus {

--- a/website/glancy-website/src/components/form/PhoneInput.module.css
+++ b/website/glancy-website/src/components/form/PhoneInput.module.css
@@ -13,7 +13,7 @@
   border: 1px solid var(--border-color);
   background: var(--input-bg);
   color: var(--app-color);
-  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  border-radius: var(--radius-xl) 0 0 var(--radius-xl);
   cursor: pointer;
   user-select: none;
   min-width: 80px;
@@ -26,7 +26,7 @@
   border-left: none;
   background: var(--input-bg);
   color: var(--app-color);
-  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  border-radius: 0 var(--radius-xl) var(--radius-xl) 0;
   padding: 12px 16px;
   height: 48px;
   line-height: 24px;

--- a/website/glancy-website/src/components/modals/LogoutConfirmModal.module.css
+++ b/website/glancy-website/src/components/modals/LogoutConfirmModal.module.css
@@ -1,4 +1,4 @@
-@import url('./ModalContent.module.css');
+@import url("./ModalContent.module.css");
 
 .logout-modal {
   width: 320px;
@@ -27,7 +27,7 @@
   background: var(--highlight-color);
   color: var(--primary-bg);
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   padding: 0.5rem 1rem;
   cursor: pointer;
   width: 100%;
@@ -37,7 +37,7 @@
   background: none;
   border: 1px solid var(--border-color);
   color: var(--app-color);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   padding: 0.5rem 1rem;
   cursor: pointer;
   width: 100%;

--- a/website/glancy-website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/glancy-website/src/components/ui/ChatInput/ChatInput.module.css
@@ -10,7 +10,7 @@
 .input {
   flex: 1;
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   padding: 12px 20px;
   outline: none;
   font-size: 1rem;

--- a/website/glancy-website/src/components/ui/ErrorBoundary/ErrorBoundary.module.css
+++ b/website/glancy-website/src/components/ui/ErrorBoundary/ErrorBoundary.module.css
@@ -4,6 +4,6 @@
   text-align: center;
   background: var(--app-bg);
   color: var(--app-color);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px var(--shadow-color);
 }

--- a/website/glancy-website/src/pages/chat/ChatView.module.css
+++ b/website/glancy-website/src/pages/chat/ChatView.module.css
@@ -17,19 +17,19 @@
 .message {
   max-width: 70%;
   padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 2px 4px var(--shadow-color);
   line-height: 1.5;
 }
 
 .user {
   align-self: flex-end;
-  background: #fff;
+  background: var(--chat-bubble-user-bg);
 }
 
 .assistant {
   align-self: flex-start;
-  background: var(--theme-color, #f5f5f5);
+  background: var(--chat-bubble-bg);
 }
 
 .form {
@@ -40,17 +40,17 @@
 .input {
   flex: 1;
   padding: 0.5rem 0.75rem;
-  border: 1px solid #ccc;
-  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
 }
 
 .button {
-  padding: 0.5rem 1rem;
-  border: none;
-  background: var(--theme-color, #4f46e5);
-  color: #fff;
-  border-radius: 0.5rem;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  padding: var(--btn-padding);
+  border: var(--btn-border);
+  background: var(--accent-color);
+  color: var(--color-text-inverse);
+  border-radius: var(--radius-md);
+  box-shadow: 0 2px 4px var(--shadow-color);
   cursor: pointer;
 }
 

--- a/website/glancy-website/src/pages/profile/Profile.module.css
+++ b/website/glancy-website/src/pages/profile/Profile.module.css
@@ -9,7 +9,7 @@
 .avatar-area {
   width: 100px;
   height: 100px;
-  border-radius: 20px;
+  border-radius: var(--radius-xl);
   overflow: hidden;
   margin-bottom: 8px;
   position: relative;
@@ -42,7 +42,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0 0 20px 20px;
+  border-radius: 0 0 var(--radius-xl) var(--radius-xl);
   font-size: 0.8rem;
   opacity: 0;
   transition: opacity 0.3s;
@@ -52,7 +52,6 @@
 .avatar-area:hover .avatar-hint {
   opacity: 1;
 }
-
 
 .username-input {
   font-size: 1.2rem;
@@ -93,7 +92,7 @@
   color: var(--primary-color);
   border: none;
   padding: 6px 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .save-btn:hover {
@@ -105,7 +104,7 @@
   border: 1px solid var(--primary-bg);
   color: var(--primary-bg);
   padding: 6px 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .cancel-btn:hover {
@@ -118,4 +117,3 @@
   flex: 1;
   text-align: left;
 }
-

--- a/website/glancy-website/src/pages/profile/index.jsx
+++ b/website/glancy-website/src/pages/profile/index.jsx
@@ -99,7 +99,11 @@ function Profile({ onCancel }) {
           {avatar && typeof avatar === "string" ? (
             <img src={avatar} alt="avatar" />
           ) : (
-            <Avatar width={100} height={100} style={{ borderRadius: "20px" }} />
+            <Avatar
+              width={100}
+              height={100}
+              style={{ borderRadius: "var(--radius-xl)" }}
+            />
           )}
           <span className={styles["avatar-hint"]}>{t.avatarHint}</span>
           <input

--- a/website/glancy-website/src/theme/variables.css
+++ b/website/glancy-website/src/theme/variables.css
@@ -2,7 +2,8 @@
   --bar-height: 60px;
   --radius-sm: 4px;
   --radius-md: 8px;
-  --radius-lg: 20px;
+  --radius-lg: 12px;
+  --radius-xl: 20px;
   --btn-padding: 0.6em 1.2em;
   --btn-border: 1px solid transparent;
   --user-menu-width: 180px;


### PR DESCRIPTION
## Summary
- replace chat view hardcoded colors, shadows and radii with theme tokens
- add xl radius token and align related components
- unify profile avatar styling with theme variables

## Testing
- `npx prettier -w src/theme/variables.css src/pages/chat/ChatView.module.css src/components/ui/ErrorBoundary/ErrorBoundary.module.css src/components/form/Form.module.css src/components/modals/LogoutConfirmModal.module.css src/components/form/AuthForm.module.css src/components/form/PhoneInput.module.css src/components/Header/Header.module.css src/components/ui/ChatInput/ChatInput.module.css src/pages/profile/Profile.module.css src/pages/profile/index.jsx`
- `npx stylelint src/theme/variables.css src/pages/chat/ChatView.module.css src/components/ui/ErrorBoundary/ErrorBoundary.module.css src/components/form/Form.module.css src/components/modals/LogoutConfirmModal.module.css src/components/form/AuthForm.module.css src/components/form/PhoneInput.module.css src/components/Header/Header.module.css src/components/ui/ChatInput/ChatInput.module.css src/pages/profile/Profile.module.css --fix`
- `npx eslint --fix src/pages/profile/index.jsx src/pages/chat/ChatView.jsx`
- `npm test` (failed: Syntax error reading regular expression)
- `mvn -q -f backend/pom.xml spotless:apply` (failed: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68afe7f273dc8332a749febf69534179