### PR TITLE
feat: improve controller logging robustness

### DIFF
--- a/backend/src/main/java/com/glancy/backend/config/logging/ControllerLoggingAspect.java
+++ b/backend/src/main/java/com/glancy/backend/config/logging/ControllerLoggingAspect.java
@@ -2,12 +2,15 @@ package com.glancy.backend.config.logging;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.IntStream;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.stereotype.Component;
 
 /**
@@ -19,15 +22,28 @@ public class ControllerLoggingAspect {
 
     private static final Logger log = LoggerFactory.getLogger(ControllerLoggingAspect.class);
 
+    private final ParameterNameDiscoverer parameterNameDiscoverer =
+            new DefaultParameterNameDiscoverer();
+
     @Around("within(@org.springframework.web.bind.annotation.RestController *)")
     public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         String method = signature.getDeclaringType().getSimpleName() + "." + signature.getName();
-        String[] paramNames = signature.getParameterNames();
         Object[] args = joinPoint.getArgs();
+        String[] paramNames = resolveParameterNames(signature, args);
         Map<String, Object> params = new LinkedHashMap<>();
-        for (int i = 0; i < paramNames.length; i++) {
-            params.put(paramNames[i], args[i]);
+        if (args != null) {
+            int nameLength = paramNames != null ? paramNames.length : 0;
+            if (paramNames != null && nameLength != args.length) {
+                log.debug(
+                        "Parameter name count {} does not match argument count {}",
+                        nameLength,
+                        args.length);
+            }
+            for (int i = 0; i < args.length; i++) {
+                String name = (i < nameLength) ? paramNames[i] : "arg" + i;
+                params.put(name, args[i]);
+            }
         }
         log.info("controller.entry method={} params={}", method, params);
         try {
@@ -38,5 +54,18 @@ public class ControllerLoggingAspect {
             log.error("controller.error method={} message={}", method, ex.getMessage(), ex);
             throw ex;
         }
+    }
+
+    private String[] resolveParameterNames(MethodSignature signature, Object[] args) {
+        String[] names = signature.getParameterNames();
+        if (names == null) {
+            names = parameterNameDiscoverer.getParameterNames(signature.getMethod());
+        }
+        if (names == null && args != null) {
+            names = IntStream.range(0, args.length)
+                    .mapToObj(i -> "arg" + i)
+                    .toArray(String[]::new);
+        }
+        return names;
     }
 }


### PR DESCRIPTION
## Summary
- enhance ControllerLoggingAspect with resilient parameter name discovery
- guard against null or mismatched arguments when logging controller calls

## Testing
- `npx eslint --fix .`
- `npx stylelint --fix "**/*.{css,scss,vue}"`
- `npx prettier -w .`
- `mvn spotless:apply` *(fails: 'dependencies.dependency.version' for org.springframework.boot:spring-boot-starter-web:jar is missing)*
- `mvn test` *(fails: 'dependencies.dependency.version' for org.springframework.boot:spring-boot-starter-web:jar is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b84eda5d6c8332a1f8ac5ff53b5c61