### PR TITLE
feat: 为 maven-compiler-plugin 启用参数名保留

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -194,6 +194,7 @@
                                 <configuration>
                                         <source>17</source>
                                         <target>17</target>
+                                        <parameters>true</parameters>
                                         <annotationProcessorPaths>
                                                 <path>
                                                         <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
- 在 `maven-compiler-plugin` 中开启 `parameters` 以保留方法参数名

## Testing
- `npx eslint backend --fix` *(fails: ESLint couldn't find an eslint.config)*
- `printf '' | npx stylelint --stdin --stdin-filename dummy.css --fix` *(fails: No configuration provided)*
- `npx prettier -w backend/pom.xml` *(fails: No parser could be inferred for file)*
- `mvn spotless:apply` *(fails: dependencies.dependency.version ... is missing)*
- `mvn test` *(fails: dependencies.dependency.version ... is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b84edbf7b08332abbcc27a15495bb6