### PR TITLE
refactor: relocate JPA configuration

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,23 +11,21 @@ spring:
     username: glancy_user
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        "[format_sql]": true
   servlet:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
-
-    jpa:
-      hibernate:
-        ddl-auto: update
-      show-sql: true
-      properties:
-        hibernate:
-          dialect: org.hibernate.dialect.MySQLDialect
-          "[format_sql]": true
-    web:
-      resources:
-        add-mappings: false
+  web:
+    resources:
+      add-mappings: false
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- move JPA settings under Spring root

## Testing
- `npx eslint --fix backend/src/main/resources/application.yml` *(fails: ESLint couldn't find config)*
- `npx stylelint --fix backend/src/main/resources/application.yml` *(fails: No configuration provided)*
- `npx prettier -w backend/src/main/resources/application.yml`
- `mvn spotless:apply` *(fails: missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68b85a34822c833293ed1a5f4f222f56