### PR TITLE
feat: integrate ChatInput with i18n in ChatView

### DIFF
--- a/website/src/components/ui/ChatInput/index.jsx
+++ b/website/src/components/ui/ChatInput/index.jsx
@@ -1,20 +1,29 @@
-import ThemeIcon from '@/components/ui/Icon'
-import styles from './ChatInput.module.css'
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./ChatInput.module.css";
 
 /**
  * Chat input field with dual submit/voice behaviour.
  * When the field is empty the button acts as a voice trigger
  * instead of submitting the form.
  */
-function ChatInput({ value, onChange, onSubmit, onVoice, inputRef, placeholder }) {
-  const isEmpty = value.trim() === ''
+function ChatInput({
+  value,
+  onChange,
+  onSubmit,
+  onVoice,
+  inputRef,
+  placeholder,
+  sendLabel = "Send",
+  voiceLabel = "Voice",
+}) {
+  const isEmpty = value.trim() === "";
 
   const handleClick = (e) => {
     if (isEmpty && onVoice) {
-      e.preventDefault()
-      onVoice()
+      e.preventDefault();
+      onVoice();
     }
-  }
+  };
 
   return (
     <form className={styles.container} onSubmit={onSubmit}>
@@ -27,18 +36,27 @@ function ChatInput({ value, onChange, onSubmit, onVoice, inputRef, placeholder }
         className={styles.input}
       />
       <button
-        type={isEmpty ? 'button' : 'submit'}
+        type={isEmpty ? "button" : "submit"}
         className={styles.button}
         onClick={handleClick}
+        aria-label={isEmpty ? voiceLabel : sendLabel}
       >
         {isEmpty ? (
-          <ThemeIcon name="voice-button" alt="voice" className={styles.icon} />
+          <ThemeIcon
+            name="voice-button"
+            alt={voiceLabel}
+            className={styles.icon}
+          />
         ) : (
-          <ThemeIcon name="send-button" alt="send" className={styles.icon} />
+          <ThemeIcon
+            name="send-button"
+            alt={sendLabel}
+            className={styles.icon}
+          />
         )}
       </button>
     </form>
-  )
+  );
 }
 
-export default ChatInput
+export default ChatInput;

--- a/website/src/pages/chat/ChatView.jsx
+++ b/website/src/pages/chat/ChatView.jsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
+import ChatInput from "@/components/ui/ChatInput";
 import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
 import { streamChatMessage } from "@/api/chat.js";
+import { useLanguage } from "@/context";
 import styles from "./ChatView.module.css";
 
 export default function ChatView({ streamFn = streamChatMessage }) {
+  const { t } = useLanguage();
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
 
@@ -31,6 +34,10 @@ export default function ChatView({ streamFn = streamChatMessage }) {
     }
   };
 
+  const handleVoice = () => {
+    /* Voice input integration hook */
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.history}>
@@ -43,21 +50,14 @@ export default function ChatView({ streamFn = streamChatMessage }) {
           </div>
         ))}
       </div>
-      <form className={styles.form} onSubmit={handleSubmit}>
-        <input
-          className={styles.input}
-          placeholder="输入消息"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-        />
-        <button
-          className={styles.button}
-          type="submit"
-          disabled={!input.trim()}
-        >
-          发送
-        </button>
-      </form>
+      <ChatInput
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onSubmit={handleSubmit}
+        onVoice={handleVoice}
+        placeholder={t.chatPlaceholder}
+        sendLabel={t.sendButton}
+      />
     </div>
   );
 }

--- a/website/src/pages/chat/ChatView.module.css
+++ b/website/src/pages/chat/ChatView.module.css
@@ -31,30 +31,3 @@
   align-self: flex-start;
   background: var(--chat-bubble-bg);
 }
-
-.form {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.input {
-  flex: 1;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-}
-
-.button {
-  padding: var(--btn-padding);
-  border: var(--btn-border);
-  background: var(--accent-color);
-  color: var(--color-text-inverse);
-  border-radius: var(--radius-md);
-  box-shadow: 0 2px 4px var(--shadow-color);
-  cursor: pointer;
-}
-
-.button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}

--- a/website/src/pages/chat/__tests__/ChatView.test.jsx
+++ b/website/src/pages/chat/__tests__/ChatView.test.jsx
@@ -1,18 +1,25 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 jest.mock("remark-gfm", () => () => {});
+jest.mock("@/context", () => ({
+  useLanguage: () => ({
+    t: { chatPlaceholder: "输入消息...", sendButton: "发送" },
+  }),
+}));
 import ChatView from "@/pages/chat/ChatView";
 
 /**
- * 验证 ChatView 使用 MarkdownRenderer 渲染消息。
+ * 验证 ChatView 使用国际化文案并渲染 Markdown。
  */
-test("renders streamed markdown", async () => {
+test("renders streamed markdown with i18n texts", async () => {
   async function* streamFn() {
     yield "**bold**";
   }
   render(<ChatView streamFn={() => streamFn()} />);
-  const input = screen.getByPlaceholderText("输入消息");
+  const input = screen.getByPlaceholderText("输入消息...");
+  expect(screen.getByLabelText("Voice")).toBeInTheDocument();
   fireEvent.change(input, { target: { value: "hi" } });
-  fireEvent.submit(input.closest("form"));
+  const sendButton = screen.getByLabelText("发送");
+  fireEvent.click(sendButton);
   const strong = await screen.findByText("bold");
   expect(strong.tagName).toBe("STRONG");
 });


### PR DESCRIPTION
## Summary
- replace inline chat form with reusable `ChatInput`
- localize placeholder and send button via `useLanguage`
- extend `ChatInput` with accessible labels and add ChatView tests

## Testing
- `npx prettier -w src/components/ui/ChatInput/index.jsx src/pages/chat/ChatView.jsx src/pages/chat/ChatView.module.css src/pages/chat/__tests__/ChatView.test.jsx`
- `npx eslint src/components/ui/ChatInput/index.jsx src/pages/chat/ChatView.jsx src/pages/chat/__tests__/ChatView.test.jsx --fix`
- `npx stylelint "src/pages/chat/ChatView.module.css" --fix`
- `npm test` *(fails: ReferenceError: require is not defined; Syntax error reading regular expression)*
- `mvn -q spotless:apply` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c94105d08332aaa0a7d12bde9cd0