### PR TITLE
feat: enhance top bar back buttons

### DIFF
--- a/website/src/assets/icons/arrow-left-dark.svg
+++ b/website/src/assets/icons/arrow-left-dark.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke-width="1.5"
+  stroke="white"
+  aria-hidden="true"
+>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M15.75 19.5L8.25 12l7.5-7.5"
+  />
+</svg>

--- a/website/src/assets/icons/arrow-left-light.svg
+++ b/website/src/assets/icons/arrow-left-light.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke-width="1.5"
+  stroke="#121212"
+  aria-hidden="true"
+>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M15.75 19.5L8.25 12l7.5-7.5"
+  />
+</svg>

--- a/website/src/components/TopBar/DesktopTopBar.jsx
+++ b/website/src/components/TopBar/DesktopTopBar.jsx
@@ -1,10 +1,12 @@
-import styles from './DesktopTopBar.module.css'
-import common from './TopBarCommon.module.css'
-import TopBarActions from './TopBarActions.jsx'
-import { TtsButton } from '@/components'
+import styles from "./DesktopTopBar.module.css";
+import common from "./TopBarCommon.module.css";
+import TopBarActions from "./TopBarActions.jsx";
+import { TtsButton } from "@/components";
+import ThemeIcon from "@/components/ui/Icon";
+import { useLanguage } from "@/context";
 
 function DesktopTopBar({
-  term = '',
+  term = "",
   lang,
   showBack = false,
   onBack,
@@ -12,18 +14,26 @@ function DesktopTopBar({
   onToggleFavorite,
   canFavorite = false,
 }) {
+  const { t } = useLanguage();
 
   return (
-    <header className={styles['desktop-topbar']}>
+    <header className={styles["desktop-topbar"]}>
       <button
         type="button"
-        className={`${common['back-btn']} ${showBack ? styles.visible : styles.hidden}`}
+        className={`${common["back-btn"]} ${showBack ? styles.visible : styles.hidden}`}
         onClick={onBack}
+        aria-label={t.back}
       >
-        ←
+        <ThemeIcon
+          name="arrow-left"
+          alt=""
+          width={24}
+          height={24}
+          aria-hidden="true"
+        />
       </button>
-      <div className={`${common['term-text']} ${styles['term-text']}`}>
-        <span className={styles['term-label']}>{term}</span>
+      <div className={`${common["term-text"]} ${styles["term-text"]}`}>
+        <span className={styles["term-label"]}>{term}</span>
         {term && <TtsButton text={term} lang={lang} size={20} />}
       </div>
       <TopBarActions
@@ -32,7 +42,7 @@ function DesktopTopBar({
         canFavorite={canFavorite}
       />
     </header>
-  )
+  );
 }
 
-export default DesktopTopBar
+export default DesktopTopBar;

--- a/website/src/components/TopBar/MobileTopBar.jsx
+++ b/website/src/components/TopBar/MobileTopBar.jsx
@@ -1,12 +1,13 @@
-import ThemeIcon from '@/components/ui/Icon'
-import TopBarActions from './TopBarActions.jsx'
-import common from './TopBarCommon.module.css'
-import styles from './MobileTopBar.module.css'
-import { getBrandText } from '@/utils'
-import { TtsButton } from '@/components'
+import ThemeIcon from "@/components/ui/Icon";
+import TopBarActions from "./TopBarActions.jsx";
+import common from "./TopBarCommon.module.css";
+import styles from "./MobileTopBar.module.css";
+import { getBrandText } from "@/utils";
+import { TtsButton } from "@/components";
+import { useLanguage } from "@/context";
 
 function MobileTopBar({
-  term = '',
+  term = "",
   lang,
   showBack = false,
   onBack,
@@ -15,22 +16,30 @@ function MobileTopBar({
   canFavorite = false,
   onOpenSidebar,
 }) {
-  const brandText = getBrandText(lang)
+  const brandText = getBrandText(lang);
+  const { t } = useLanguage();
 
   return (
-    <header className={styles['mobile-topbar']}>
-      <button className={styles['topbar-btn']} onClick={onOpenSidebar}>
+    <header className={styles["mobile-topbar"]}>
+      <button className={styles["topbar-btn"]} onClick={onOpenSidebar}>
         <ThemeIcon name="glancy-web" alt={brandText} width={24} height={24} />
       </button>
       <button
         type="button"
-        className={`${common['back-btn']} ${showBack ? styles.visible : styles.hidden}`}
+        className={`${common["back-btn"]} ${showBack ? styles.visible : styles.hidden}`}
         onClick={onBack}
+        aria-label={t.back}
       >
-        ←
+        <ThemeIcon
+          name="arrow-left"
+          alt=""
+          width={24}
+          height={24}
+          aria-hidden="true"
+        />
       </button>
-      <div className={`${common['term-text']} ${styles['term-text']}`}>
-        <span className={styles['term-label']}>{term || brandText}</span>
+      <div className={`${common["term-text"]} ${styles["term-text"]}`}>
+        <span className={styles["term-label"]}>{term || brandText}</span>
         {term && <TtsButton text={term} lang={lang} size={20} />}
       </div>
       <TopBarActions
@@ -39,7 +48,7 @@ function MobileTopBar({
         canFavorite={canFavorite}
       />
     </header>
-  )
+  );
 }
 
-export default MobileTopBar
+export default MobileTopBar;

--- a/website/src/components/TopBar/TopBarCommon.module.css
+++ b/website/src/components/TopBar/TopBarCommon.module.css
@@ -3,12 +3,20 @@
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0 8px;
 }
 
 .back-btn {
   width: 32px;
-  text-align: center;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 4px;
+}
+
+.more-btn {
+  padding: 0 8px;
 }
 
 .term-text {

--- a/website/src/components/TopBar/__tests__/DesktopTopBar.test.jsx
+++ b/website/src/components/TopBar/__tests__/DesktopTopBar.test.jsx
@@ -1,36 +1,46 @@
 /* eslint-env jest */
-import React from 'react'
-import { render } from '@testing-library/react'
-import { jest } from '@jest/globals'
+import React from "react";
+import { render } from "@testing-library/react";
+import { jest } from "@jest/globals";
 
 // mock TtsButton to isolate top bar behaviour
-const TtsButton = jest.fn(() => <div data-testid="tts" />)
+const TtsButton = jest.fn(() => <div data-testid="tts" />);
 
-jest.unstable_mockModule('@/components', () => ({ TtsButton }))
+jest.unstable_mockModule("@/components", () => ({ TtsButton }));
 
-const { default: DesktopTopBar } = await import('@/components/TopBar/DesktopTopBar.jsx')
+const { default: DesktopTopBar } = await import(
+  "@/components/TopBar/DesktopTopBar.jsx"
+);
 
-describe('DesktopTopBar', () => {
+describe("DesktopTopBar", () => {
   afterEach(() => {
-    TtsButton.mockClear()
-  })
+    TtsButton.mockClear();
+  });
 
   /**
    * Renders play button when a term is provided.
    */
-  test('renders tts button for term', () => {
-    render(<DesktopTopBar term="hello" lang="en" />)
+  test("renders tts button for term", () => {
+    render(<DesktopTopBar term="hello" lang="en" />);
     expect(TtsButton).toHaveBeenCalledWith(
-      expect.objectContaining({ text: 'hello', lang: 'en', size: 20 }),
-      {}
-    )
-  })
+      expect.objectContaining({ text: "hello", lang: "en", size: 20 }),
+      {},
+    );
+  });
 
   /**
    * Omits play button when term is empty.
    */
-  test('hides tts button without term', () => {
-    render(<DesktopTopBar term="" lang="en" />)
-    expect(TtsButton).not.toHaveBeenCalled()
-  })
-})
+  test("hides tts button without term", () => {
+    render(<DesktopTopBar term="" lang="en" />);
+    expect(TtsButton).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Applies accessible label on back button.
+   */
+  test("back button has aria-label", () => {
+    const { getByLabelText } = render(<DesktopTopBar showBack />);
+    expect(getByLabelText("返回")).toBeInTheDocument();
+  });
+});

--- a/website/src/components/TopBar/__tests__/MobileTopBar.test.jsx
+++ b/website/src/components/TopBar/__tests__/MobileTopBar.test.jsx
@@ -1,36 +1,48 @@
 /* eslint-env jest */
-import React from 'react'
-import { render } from '@testing-library/react'
-import { jest } from '@jest/globals'
+import React from "react";
+import { render } from "@testing-library/react";
+import { jest } from "@jest/globals";
 
 // mock TtsButton to isolate top bar behaviour
-const TtsButton = jest.fn(() => <div data-testid="tts" />)
+const TtsButton = jest.fn(() => <div data-testid="tts" />);
 
-jest.unstable_mockModule('@/components', () => ({ TtsButton }))
+jest.unstable_mockModule("@/components", () => ({ TtsButton }));
 
-const { default: MobileTopBar } = await import('@/components/TopBar/MobileTopBar.jsx')
+const { default: MobileTopBar } = await import(
+  "@/components/TopBar/MobileTopBar.jsx"
+);
 
-describe('MobileTopBar', () => {
+describe("MobileTopBar", () => {
   afterEach(() => {
-    TtsButton.mockClear()
-  })
+    TtsButton.mockClear();
+  });
 
   /**
    * Renders play button when a term is provided.
    */
-  test('renders tts button for term', () => {
-    render(<MobileTopBar term="world" lang="en" />)
+  test("renders tts button for term", () => {
+    render(<MobileTopBar term="world" lang="en" />);
     expect(TtsButton).toHaveBeenCalledWith(
-      expect.objectContaining({ text: 'world', lang: 'en', size: 20 }),
-      {}
-    )
-  })
+      expect.objectContaining({ text: "world", lang: "en", size: 20 }),
+      {},
+    );
+  });
 
   /**
    * Omits play button when term is empty.
    */
-  test('hides tts button without term', () => {
-    render(<MobileTopBar term="" lang="en" />)
-    expect(TtsButton).not.toHaveBeenCalled()
-  })
-})
+  test("hides tts button without term", () => {
+    render(<MobileTopBar term="" lang="en" />);
+    expect(TtsButton).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Applies accessible label on back button.
+   */
+  test("back button has aria-label", () => {
+    const { getByLabelText } = render(
+      <MobileTopBar showBack onOpenSidebar={() => {}} />,
+    );
+    expect(getByLabelText("返回")).toBeInTheDocument();
+  });
+});

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -37,6 +37,7 @@ export default {
   notifications: "Notifications",
   markRead: "Mark read",
   contactTitle: "Contact Us",
+  back: "Back",
   name: "Name",
   email: "Email",
   phone: "Phone",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -37,6 +37,7 @@ export default {
   notifications: "通知",
   markRead: "标为已读",
   contactTitle: "联系我们",
+  back: "返回",
   name: "姓名",
   email: "邮箱",
   phone: "手机号",


### PR DESCRIPTION
## Summary
- replace text arrows with themed icons in top bars
- add accessible labels sourced from i18n
- align back button styles with design system

## Testing
- `npx prettier -w src/components/TopBar/DesktopTopBar.jsx src/components/TopBar/MobileTopBar.jsx src/components/TopBar/TopBarCommon.module.css src/i18n/common/en.js src/i18n/common/zh.js src/components/TopBar/__tests__/DesktopTopBar.test.jsx src/components/TopBar/__tests__/MobileTopBar.test.jsx`
- `npx prettier -w src/assets/icons/arrow-left-light.svg src/assets/icons/arrow-left-dark.svg --parser html`
- `npx eslint src/components/TopBar/DesktopTopBar.jsx src/components/TopBar/MobileTopBar.jsx src/components/TopBar/__tests__/DesktopTopBar.test.jsx src/components/TopBar/__tests__/MobileTopBar.test.jsx src/i18n/common/en.js src/i18n/common/zh.js --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npm test` *(fails: ReferenceError and JS heap out of memory)*
- `./mvnw -q spotless:apply` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c93f8df8833288143aa41e03aa80