### PR TITLE
feat: add multiline chat input

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -1,20 +1,22 @@
 .container {
   display: flex;
-  align-items: center;
-  height: 100%;
+  align-items: flex-end;
   width: 100%;
   gap: 16px;
   background: var(--app-bg);
 }
 
-.input {
+.textarea {
   flex: 1;
   border: none;
   border-radius: var(--radius-xl);
   padding: 12px 20px;
   outline: none;
   font-size: 1rem;
+  line-height: 1.5;
   box-shadow: 0 2px 4px var(--shadow-color);
+  resize: none;
+  overflow: hidden;
 }
 
 .button {

--- a/website/src/components/ui/ChatInput/index.jsx
+++ b/website/src/components/ui/ChatInput/index.jsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef } from "react";
 import ThemeIcon from "@/components/ui/Icon";
 import styles from "./ChatInput.module.css";
 
@@ -15,8 +16,30 @@ function ChatInput({
   placeholder,
   sendLabel = "Send",
   voiceLabel = "Voice",
+  rows = 1,
+  maxRows = 5,
 }) {
   const isEmpty = value.trim() === "";
+  const localRef = useRef(null);
+  const textareaRef = inputRef || localRef;
+
+  const autoResize = useCallback(
+    (el) => {
+      const lineHeight = parseFloat(
+        window.getComputedStyle(el).lineHeight || "20",
+      );
+      const maxHeight = lineHeight * maxRows;
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    },
+    [maxRows],
+  );
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      autoResize(textareaRef.current);
+    }
+  }, [autoResize, value, textareaRef]);
 
   const handleClick = (e) => {
     if (isEmpty && onVoice) {
@@ -25,15 +48,20 @@ function ChatInput({
     }
   };
 
+  const handleChange = (e) => {
+    autoResize(e.target);
+    onChange?.(e);
+  };
+
   return (
     <form className={styles.container} onSubmit={onSubmit}>
-      <input
-        ref={inputRef}
-        type="text"
+      <textarea
+        ref={textareaRef}
+        rows={rows}
         placeholder={placeholder}
         value={value}
-        onChange={onChange}
-        className={styles.input}
+        onChange={handleChange}
+        className={styles.textarea}
       />
       <button
         type={isEmpty ? "button" : "submit"}

--- a/website/src/pages/App/__tests__/streaming.test.jsx
+++ b/website/src/pages/App/__tests__/streaming.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { jest } from "@jest/globals";
-jest.mock("remark-gfm", () => () => {});
+jest.unstable_mockModule("remark-gfm", () => ({ default: () => {} }));
 
 // simplify layout and nested components for isolated testing
 jest.unstable_mockModule("@/components/Layout", () => ({
@@ -35,7 +35,12 @@ jest.unstable_mockModule("@/pages/App/FavoritesView.jsx", () => ({
 jest.unstable_mockModule("@/components/ui/ChatInput", () => ({
   default: ({ value, onChange, onSubmit, placeholder }) => (
     <form onSubmit={onSubmit}>
-      <input value={value} onChange={onChange} placeholder={placeholder} />
+      <textarea
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        rows={1}
+      />
     </form>
   ),
 }));
@@ -97,7 +102,7 @@ test("streams text with markdown and preserves final output", async () => {
   render(<App />);
 
   const input = screen.getByPlaceholderText("input");
-  fireEvent.change(input, { target: { value: "hello" } });
+  fireEvent.change(input, { target: { value: "hello\nworld" } });
   fireEvent.submit(input.closest("form"));
 
   await screen.findByText("f");
@@ -126,7 +131,7 @@ test("renders dictionary entry after streaming completes", async () => {
   render(<App />);
 
   const input = screen.getByPlaceholderText("input");
-  fireEvent.change(input, { target: { value: "hello" } });
+  fireEvent.change(input, { target: { value: "hello\nworld" } });
   fireEvent.submit(input.closest("form"));
 
   const entry = await screen.findByTestId("entry");

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -237,6 +237,7 @@ function App() {
             onSubmit={handleSend}
             onVoice={handleVoice}
             placeholder={t.inputPlaceholder}
+            maxRows={5}
           />
         }
       >

--- a/website/src/pages/chat/ChatView.jsx
+++ b/website/src/pages/chat/ChatView.jsx
@@ -57,6 +57,7 @@ export default function ChatView({ streamFn = streamChatMessage }) {
         onVoice={handleVoice}
         placeholder={t.chatPlaceholder}
         sendLabel={t.sendButton}
+        maxRows={5}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- replace single-line chat input with auto-expanding textarea
- align textarea and send button across different heights
- cover multi-line message submission in tests

## Testing
- `npx prettier -w src/components/ui/ChatInput/index.jsx src/components/ui/ChatInput/ChatInput.module.css src/pages/chat/ChatView.jsx src/pages/App/index.jsx src/pages/App/__tests__/streaming.test.jsx`
- `npx eslint src/components/ui/ChatInput/index.jsx src/pages/chat/ChatView.jsx src/pages/App/index.jsx src/pages/App/__tests__/streaming.test.jsx --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npm test src/pages/App/__tests__/streaming.test.jsx`
- `mvn -q spotless:apply` *(fails: No plugin found for prefix 'spotless')*
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bed8489e9c8332bca38c955a184986