### PR TITLE
feat: enhance item menu accessibility

### DIFF
--- a/website/src/components/ui/ItemMenu/ItemMenu.jsx
+++ b/website/src/components/ui/ItemMenu/ItemMenu.jsx
@@ -1,59 +1,86 @@
-import ThemeIcon from '@/components/ui/Icon'
-import { useOutsideToggle } from '@/hooks'
-import { withStopPropagation } from '@/utils/stopPropagation.js'
-import styles from './ItemMenu.module.css'
+import { useRef } from "react";
+import ThemeIcon from "@/components/ui/Icon";
+import { useOutsideToggle } from "@/hooks";
+import useMenuNavigation from "@/hooks/useMenuNavigation.js";
+import { withStopPropagation } from "@/utils/stopPropagation.js";
+import styles from "./ItemMenu.module.css";
 
 function ItemMenu({ onFavorite, onDelete, favoriteLabel, deleteLabel }) {
-  const { open, setOpen, ref } = useOutsideToggle(false)
+  const { open, setOpen, ref: wrapperRef } = useOutsideToggle(false);
+  const triggerRef = useRef(null);
+  const menuRef = useRef(null);
+
+  useMenuNavigation(open, menuRef, triggerRef, setOpen);
+
+  const handleTriggerKeyDown = (e) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      setOpen(true);
+      requestAnimationFrame(() => {
+        const items = menuRef.current?.querySelectorAll('[role="menuitem"]');
+        if (!items || items.length === 0) return;
+        const index = e.key === "ArrowUp" ? items.length - 1 : 0;
+        items[index]?.querySelector("button, [href], [tabindex]")?.focus();
+      });
+    }
+  };
 
   return (
-    <div className={styles.wrapper} ref={ref}>
+    <div className={styles.wrapper} ref={wrapperRef}>
       <button
         type="button"
         className={styles.action}
+        aria-haspopup="true"
+        aria-expanded={open}
         onClick={withStopPropagation(() => {
-          setOpen(!open)
+          setOpen(!open);
         })}
+        onKeyDown={handleTriggerKeyDown}
+        ref={triggerRef}
       >
         <ThemeIcon name="ellipsis-vertical" width={16} height={16} />
       </button>
       {open && (
-        <div className={styles.menu}>
-          <button
-            type="button"
-            onClick={withStopPropagation(() => {
-              onFavorite()
-              setOpen(false)
-            })}
-          >
-            <ThemeIcon
-              name="star-solid"
-              width={16}
-              height={16}
-              className={styles.icon}
-            />{' '}
-            {favoriteLabel}
-          </button>
-          <button
-            type="button"
-            className={styles['delete-btn']}
-            onClick={withStopPropagation(() => {
-              onDelete()
-              setOpen(false)
-            })}
-          >
-            <ThemeIcon
-              name="trash"
-              width={16}
-              height={16}
-              className={styles.icon}
-            />{' '}
-            {deleteLabel}
-          </button>
-        </div>
+        <ul className={styles.menu} role="menu" ref={menuRef}>
+          <li role="menuitem">
+            <button
+              type="button"
+              onClick={withStopPropagation(() => {
+                onFavorite();
+                setOpen(false);
+              })}
+            >
+              <ThemeIcon
+                name="star-solid"
+                width={16}
+                height={16}
+                className={styles.icon}
+              />{" "}
+              {favoriteLabel}
+            </button>
+          </li>
+          <li role="menuitem">
+            <button
+              type="button"
+              className={styles["delete-btn"]}
+              onClick={withStopPropagation(() => {
+                onDelete();
+                setOpen(false);
+              })}
+            >
+              <ThemeIcon
+                name="trash"
+                width={16}
+                height={16}
+                className={styles.icon}
+              />{" "}
+              {deleteLabel}
+            </button>
+          </li>
+        </ul>
       )}
     </div>
-  )
+  );
 }
 
-export default ItemMenu
+export default ItemMenu;

--- a/website/src/components/ui/ItemMenu/ItemMenu.module.css
+++ b/website/src/components/ui/ItemMenu/ItemMenu.module.css
@@ -38,6 +38,12 @@
   background: var(--color-overlay-inverse);
 }
 
+.menu button:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+  background: var(--color-overlay-inverse);
+}
+
 .delete-btn {
   color: var(--color-danger);
 }

--- a/website/src/hooks/index.js
+++ b/website/src/hooks/index.js
@@ -7,3 +7,4 @@ export { default as useEscapeKey } from "./useEscapeKey.js";
 export { default as useMediaQuery } from "./useMediaQuery.js";
 export { default as useOutsideToggle } from "./useOutsideToggle.js";
 export { default as useSpeechInput } from "./useSpeechInput.js";
+export { default as useMenuNavigation } from "./useMenuNavigation.js";

--- a/website/src/hooks/useMenuNavigation.js
+++ b/website/src/hooks/useMenuNavigation.js
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+
+/**
+ * Menu keyboard navigation and accessibility management.
+ * Focuses first item on open and supports Arrow/Escape keys.
+ * @param {boolean} open - menu open state
+ * @param {React.RefObject<HTMLElement>} menuRef - ref to menu element
+ * @param {React.RefObject<HTMLElement>} triggerRef - ref to trigger button
+ * @param {Function} setOpen - state setter to control menu visibility
+ */
+export default function useMenuNavigation(open, menuRef, triggerRef, setOpen) {
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const menuEl = menuRef.current;
+    if (!menuEl) return undefined;
+
+    const items = Array.from(menuEl.querySelectorAll('[role="menuitem"]'));
+    if (!items.length) return undefined;
+
+    const getFocusable = (item) =>
+      item.querySelector("button, [href], [tabindex]");
+
+    getFocusable(items[0])?.focus();
+
+    const handleKeyDown = (e) => {
+      const currentItem = e.target.closest('[role="menuitem"]');
+      const index = items.indexOf(currentItem);
+      switch (e.key) {
+        case "Escape":
+          setOpen(false);
+          triggerRef.current?.focus();
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          getFocusable(items[(index + 1) % items.length])?.focus();
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          getFocusable(
+            items[(index - 1 + items.length) % items.length],
+          )?.focus();
+          break;
+        default:
+          break;
+      }
+    };
+
+    menuEl.addEventListener("keydown", handleKeyDown);
+    return () => menuEl.removeEventListener("keydown", handleKeyDown);
+  }, [open, menuRef, triggerRef, setOpen]);
+}


### PR DESCRIPTION
## Summary
- refactor item menu to use semantic list roles and ARIA attributes
- add keyboard navigation hook for menus
- improve focus outline for high contrast

## Testing
- `npx eslint --fix src/components/ui/ItemMenu/ItemMenu.jsx src/hooks/useMenuNavigation.js src/hooks/index.js`
- `npx stylelint --fix src/components/ui/ItemMenu/ItemMenu.module.css`
- `npx prettier -w src/components/ui/ItemMenu/ItemMenu.jsx src/hooks/useMenuNavigation.js src/hooks/index.js src/components/ui/ItemMenu/ItemMenu.module.css`
- `mvn -q -e spotless:apply` *(fails: No plugin found for prefix 'spotless')*
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bed850c30883328dd4b283bcd8b901