### PR TITLE
fix: 锁定视口高度并使侧边栏独立滚动

### DIFF
--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -6,6 +6,10 @@
   padding: 20px;
   display: flex;
   flex-direction: column;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  overflow-y: auto;
 }
 
 .sidebar-brand {

--- a/website/src/styles/index.css
+++ b/website/src/styles/index.css
@@ -190,11 +190,12 @@ a:hover {
 body {
   margin: 0;
   min-width: 320px;
-  min-height: var(--vh);
+  height: var(--vh);
+  overflow: hidden;
 }
 
 #root {
-  min-height: var(--vh);
+  height: var(--vh);
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- 将 body/#root 的 `min-height` 改为 `height` 并在 body 上禁用溢出，固定视口高度
- 为桌面端侧边栏添加 `position: sticky`、`top: 0`、`align-self: start` 与 `overflow-y: auto`，独立于主体滚动

## Testing
- `npx prettier -w src/styles/index.css src/pages/App/App.css`
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npm test` *(failed: Syntax error reading regular expression & JS heap OOM)*
- `./mvnw spotless:apply` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68beee52194c8332b36d734532067cd9