### PR TITLE
feat(ui): harmonize theme colors

### DIFF
--- a/website/src/styles/index.css
+++ b/website/src/styles/index.css
@@ -55,16 +55,16 @@
   background-color: var(--sys-bg-dark);
 
   --highlight-color: var(--color-link-dark);
-  --app-bg: #2c2c2c;
+  --app-bg: #3a3a3a;
   --app-color: rgb(255 255 255 / 87%);
-  --chat-window-bg: #333;
+  --chat-window-bg: #3f3f3f;
   --chat-bubble-bg: #444;
   --chat-bubble-user-bg: #2a5be2;
   --body-bg: #1e1e1e;
   --sidebar-bg: #121212;
   --sidebar-color: #fff;
   --input-bg: #2c2c2c;
-  --accent-color: #facc15;
+  --accent-color: var(--brand-color);
   --border-color: var(--sys-border-dark);
   --text-muted: var(--sys-muted);
   --brand-color: var(--brand-color);
@@ -85,16 +85,16 @@
   background-color: var(--sys-bg-light);
 
   --highlight-color: var(--color-link-light);
-  --app-bg: #f5f5f5;
+  --app-bg: #f7f7f7;
   --app-color: #333;
-  --chat-window-bg: #fafafa;
+  --chat-window-bg: #f7f7f7;
   --chat-bubble-bg: #e0e0e0;
   --chat-bubble-user-bg: #d4e5ff;
   --body-bg: #fff;
   --sidebar-bg: #f5f5f5;
   --sidebar-color: #333;
   --input-bg: #fff;
-  --accent-color: #facc15;
+  --accent-color: var(--brand-color);
   --border-color: var(--sys-border-light);
   --text-muted: var(--sys-muted);
   --brand-color: var(--brand-color);
@@ -129,16 +129,16 @@
     background-color: var(--sys-bg-dark);
 
     --highlight-color: var(--color-link-dark);
-    --app-bg: #2c2c2c;
+    --app-bg: #3a3a3a;
     --app-color: rgb(255 255 255 / 87%);
-    --chat-window-bg: #333;
+    --chat-window-bg: #3f3f3f;
     --chat-bubble-bg: #444;
     --chat-bubble-user-bg: #2a5be2;
     --body-bg: #1e1e1e;
     --sidebar-bg: #121212;
     --sidebar-color: #fff;
     --input-bg: #2c2c2c;
-    --accent-color: #facc15;
+    --accent-color: var(--brand-color);
     --border-color: var(--sys-border-dark);
     --text-muted: var(--sys-muted);
     --brand-color: var(--brand-color);
@@ -154,16 +154,16 @@
     background-color: var(--sys-bg-light);
 
     --highlight-color: var(--color-link-light);
-    --app-bg: #f5f5f5;
+    --app-bg: #f7f7f7;
     --app-color: #333;
-    --chat-window-bg: #fafafa;
+    --chat-window-bg: #f7f7f7;
     --chat-bubble-bg: #e0e0e0;
     --chat-bubble-user-bg: #d4e5ff;
     --body-bg: #fff;
     --sidebar-bg: #f5f5f5;
     --sidebar-color: #333;
     --input-bg: #fff;
-    --accent-color: #facc15;
+    --accent-color: var(--brand-color);
     --border-color: var(--sys-border-light);
     --text-muted: var(--sys-muted);
     --brand-color: var(--brand-color);

--- a/website/src/theme/colors.css
+++ b/website/src/theme/colors.css
@@ -16,8 +16,8 @@
   --sys-border-light: #ccc;
   --sys-border-dark: #333;
   --sys-muted: #aaa;
-  --accent-color: #facc15;
-  --brand-color: orange;
+  --accent-color: #10a37f;
+  --brand-color: #10a37f;
 
   /* surface tones */
   --surface-light: #f7f7f7;


### PR DESCRIPTION
## Summary
- brighten app and chat backgrounds for light and dark themes
- align accent and brand colors to a unified green hue

## Testing
- `npx eslint . --fix`
- `npx stylelint "**/*.css" --fix`
- `npx prettier src/theme/colors.css src/styles/index.css -w`
- `mvn spotless:apply` *(fails: dependencies.dependency.version for several artifacts is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bef6bf23648332b2da9ca94a88595c