### PR TITLE
feat: 引入 Inter 字体并扩展排版尺寸

### DIFF
--- a/website/src/theme/typography.css
+++ b/website/src/theme/typography.css
@@ -1,28 +1,68 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap");
+
 :root {
-  --font-family-base: system-ui, avenir, helvetica, arial, sans-serif;
+  --font-family-base:
+    "Inter", system-ui, -apple-system, blinkmacsystemfont, "Segoe UI",
+    helvetica, arial, sans-serif;
+  --line-height-base: 1.6;
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
   --text-base: 1rem;
   --text-lg: 1.125rem;
   --text-xl: 1.25rem;
   --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
   --font-light: 300;
   --font-normal: 400;
   --font-medium: 500;
   --font-bold: 700;
 }
 
-body {
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-family-base);
+  line-height: var(--line-height-base);
 }
 
-.text-xs { font-size: var(--text-xs); }
-.text-sm { font-size: var(--text-sm); }
-.text-base { font-size: var(--text-base); }
-.text-lg { font-size: var(--text-lg); }
-.text-xl { font-size: var(--text-xl); }
-.text-2xl { font-size: var(--text-2xl); }
-.font-light { font-weight: var(--font-light); }
-.font-normal { font-weight: var(--font-normal); }
-.font-medium { font-weight: var(--font-medium); }
-.font-bold { font-weight: var(--font-bold); }
+.text-xs {
+  font-size: var(--text-xs);
+}
+.text-sm {
+  font-size: var(--text-sm);
+}
+.text-base {
+  font-size: var(--text-base);
+}
+.text-lg {
+  font-size: var(--text-lg);
+}
+.text-xl {
+  font-size: var(--text-xl);
+}
+.text-2xl {
+  font-size: var(--text-2xl);
+}
+.text-3xl {
+  font-size: var(--text-3xl);
+}
+.text-4xl {
+  font-size: var(--text-4xl);
+}
+.font-light {
+  font-weight: var(--font-light);
+}
+.font-normal {
+  font-weight: var(--font-normal);
+}
+.font-medium {
+  font-weight: var(--font-medium);
+}
+.font-bold {
+  font-weight: var(--font-bold);
+}


### PR DESCRIPTION
## Summary
- 引入 Inter 等高端无衬线字体作为基础字体，并扩展文本尺寸变量以适配宽屏布局
- 统一 body 与标题的行距与字体配置，提升排版一致性与可读性

## Testing
- `npx eslint src/theme/typography.css --fix`
- `npx stylelint src/theme/typography.css --fix`
- `npx prettier src/theme/typography.css -w`
- `./mvnw spotless:apply` *(failed: Network is unreachable)*
- `npm test` *(failed: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bef6c6294c83328ca6395f78ad82c8