### PR TITLE
refactor: 内联 SVG 图标并支持主题色

### DIFF
--- a/website/src/assets/icons.js
+++ b/website/src/assets/icons.js
@@ -3,25 +3,25 @@
  * Aggregates all SVG assets within the assets directory.
  */
 
-const modules = import.meta.glob('./**/*.svg', {
+const modules = import.meta.glob("./**/*.svg", {
+  as: "raw",
   eager: true,
-  import: 'default',
-})
+});
 
-const icons = {}
+const icons = {};
 
 for (const [path, mod] of Object.entries(modules)) {
-  const filename = path.split('/').pop().replace('.svg', '')
+  const filename = path.split("/").pop().replace(".svg", "");
 
-  if (filename.endsWith('-light')) {
-    const name = filename.replace('-light', '')
-    icons[name] = { ...(icons[name] || {}), light: mod }
-  } else if (filename.endsWith('-dark')) {
-    const name = filename.replace('-dark', '')
-    icons[name] = { ...(icons[name] || {}), dark: mod }
+  if (filename.endsWith("-light")) {
+    const name = filename.replace("-light", "");
+    icons[name] = { ...(icons[name] || {}), light: mod };
+  } else if (filename.endsWith("-dark")) {
+    const name = filename.replace("-dark", "");
+    icons[name] = { ...(icons[name] || {}), dark: mod };
   } else {
-    icons[filename] = { ...(icons[filename] || {}), single: mod }
+    icons[filename] = { ...(icons[filename] || {}), single: mod };
   }
 }
 
-export default icons
+export default icons;

--- a/website/src/components/ui/Icon/index.jsx
+++ b/website/src/components/ui/Icon/index.jsx
@@ -1,25 +1,58 @@
-import React from 'react'
-import { useTheme } from '@/context'
-import ICONS from '@/assets/icons.js'
+import React from "react";
+import { useTheme } from "@/context";
+import ICONS from "@/assets/icons.js";
 
-// ICONS shape: { [name]: { light?: url, dark?: url, single?: url } }
+export const DEFAULT_ICON_SIZE = 24;
+export const DEFAULT_ICON_COLOR = "#4A4A4A";
 
-export function ThemeIcon({ name, alt, ...props }) {
-  const { resolvedTheme } = useTheme()
-  const theme = resolvedTheme === 'dark' ? 'dark' : 'light'
-  const src = ICONS[name]?.[theme] || ICONS[name]?.single
-  if (!src) return null
-  return <img src={src} alt={alt || name} {...props} />
+const processSvg = (raw) =>
+  raw
+    .replace(/(width|height)="[^"]*"/g, "")
+    .replace("<svg", '<svg width="100%" height="100%"')
+    .replace(/stroke-width="[^"]*"/g, 'stroke-width="2"')
+    .replace(/stroke="[^"]*"/g, 'stroke="currentColor"')
+    .replace(/fill="(?!none)[^"]*"/g, 'fill="currentColor"');
+
+export function ThemeIcon({
+  name,
+  alt,
+  color = DEFAULT_ICON_COLOR,
+  size = DEFAULT_ICON_SIZE,
+  style,
+  ...props
+}) {
+  const { resolvedTheme } = useTheme();
+  const theme = resolvedTheme === "dark" ? "dark" : "light";
+  const raw = ICONS[name]?.[theme] || ICONS[name]?.single;
+  if (!raw) return null;
+  const svg = processSvg(raw);
+  return (
+    <span
+      role="img"
+      aria-label={alt || name}
+      style={{
+        color,
+        width: size,
+        height: size,
+        display: "inline-block",
+        ...style,
+      }}
+      dangerouslySetInnerHTML={{ __html: svg }}
+      {...props}
+    />
+  );
 }
 
-export const EllipsisVerticalIcon = (props) => (
-  <ThemeIcon name="ellipsis-vertical" alt="ellipsis" {...props} />
-)
-export const StarSolidIcon = (props) => (
-  <ThemeIcon name="star-solid" alt="star" {...props} />
-)
-export const TrashIcon = (props) => (
-  <ThemeIcon name="trash" alt="trash" {...props} />
-)
+const defaultProps = { size: DEFAULT_ICON_SIZE, color: DEFAULT_ICON_COLOR };
 
-export default ThemeIcon
+export const EllipsisVerticalIcon = (props) => (
+  <ThemeIcon name="ellipsis-vertical" {...defaultProps} {...props} />
+);
+export const StarSolidIcon = (props) => (
+  <ThemeIcon name="star-solid" {...defaultProps} {...props} />
+);
+export const TrashIcon = (props) => (
+  <ThemeIcon name="trash" {...defaultProps} {...props} />
+);
+
+export default ThemeIcon;


### PR DESCRIPTION
## 摘要
- 使用 `import.meta.glob` 原始内容收集 SVG 图标
- Icon 组件支持 `currentColor` 并提供默认尺寸与颜色
- 对常用图标暴露统一的 24px 尺寸与 `#4A4A4A` 默认色

## 测试
- `npx prettier -w src/assets/icons.js src/components/ui/Icon/index.jsx`
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npm test` *(失败: Syntax error reading regular expression)*
- `mvn -q -f backend/pom.xml spotless:apply` *(失败: dependencies.dependency.version is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bef6cfbeb4833287fc0158d4762859