### PR TITLE
feat(theme): extend spacing utilities for larger gaps

### DIFF
--- a/website/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
+++ b/website/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
@@ -8,13 +8,16 @@ function HistoryDisplay() {
   if (!history.length) {
     return (
       <div className="display-content">
-        <div className="display-term">{t.noHistory}</div>
+        <div className="display-term mb-6">{t.noHistory}</div>
       </div>
     );
   }
 
   return (
-    <div className="display-content" style={{ maxHeight: 400, overflowY: "auto", width: "100%" }}>
+    <div
+      className="display-content"
+      style={{ maxHeight: 400, overflowY: "auto", width: "100%" }}
+    >
       <ul className={styles["history-grid-display"]}>
         {history.map((item, idx) => (
           <li key={idx}>{item}</li>

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -56,7 +56,6 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  padding: 20px;
   overflow-y: auto;
   overscroll-behavior: contain;
   font-size: 2rem;
@@ -92,10 +91,6 @@
   flex: 1;
   align-items: center;
   justify-content: center;
-}
-
-.display-term {
-  margin-bottom: 1rem;
 }
 
 @media (width <= 600px) {

--- a/website/src/pages/App/FavoritesView.jsx
+++ b/website/src/pages/App/FavoritesView.jsx
@@ -1,12 +1,17 @@
-import ListItem from '@/components/ui/ListItem'
+import ListItem from "@/components/ui/ListItem";
 
-function FavoritesView({ favorites = [], onSelect, onUnfavorite, emptyMessage }) {
+function FavoritesView({
+  favorites = [],
+  onSelect,
+  onUnfavorite,
+  emptyMessage,
+}) {
   if (!favorites.length) {
     return (
       <div className="display-content">
-        <div className="display-term">{emptyMessage}</div>
+        <div className="display-term mb-6">{emptyMessage}</div>
       </div>
-    )
+    );
   }
 
   return (
@@ -18,23 +23,23 @@ function FavoritesView({ favorites = [], onSelect, onUnfavorite, emptyMessage })
           text={w}
           textClassName="favorite-term"
           onClick={() => onSelect?.(w)}
-          actions={(
+          actions={
             <button
               type="button"
               aria-label="unfavorite"
               className="unfavorite-btn"
               onClick={(e) => {
-                e.stopPropagation()
-                onUnfavorite?.(w)
+                e.stopPropagation();
+                onUnfavorite?.(w);
               }}
             >
               ○
             </button>
-          )}
+          }
         />
       ))}
     </ul>
-  )
+  );
 }
 
-export default FavoritesView
+export default FavoritesView;

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -244,7 +244,7 @@ function App() {
           </div>
         }
       >
-        <div className="display">
+        <div className="display p-6">
           {showFavorites ? (
             <FavoritesView
               favorites={favorites}
@@ -266,7 +266,7 @@ function App() {
             <MarkdownStream text={streamText} />
           ) : (
             <div className="display-content">
-              <div className="display-term">{placeholder}</div>
+              <div className="display-term mb-6">{placeholder}</div>
             </div>
           )}
         </div>

--- a/website/src/theme/spacing.css
+++ b/website/src/theme/spacing.css
@@ -4,42 +4,140 @@
   --space-3: 16px;
   --space-4: 24px;
   --space-5: 32px;
+  --space-6: 40px;
+  --space-7: 56px;
 }
 
 /* margin utilities */
-.m-1 { margin: var(--space-1); }
-.m-2 { margin: var(--space-2); }
-.m-3 { margin: var(--space-3); }
-.m-4 { margin: var(--space-4); }
-.m-5 { margin: var(--space-5); }
+.m-1 {
+  margin: var(--space-1);
+}
+.m-2 {
+  margin: var(--space-2);
+}
+.m-3 {
+  margin: var(--space-3);
+}
+.m-4 {
+  margin: var(--space-4);
+}
+.m-5 {
+  margin: var(--space-5);
+}
+.m-6 {
+  margin: var(--space-6);
+}
+.m-7 {
+  margin: var(--space-7);
+}
 
-.mt-1 { margin-top: var(--space-1); }
-.mt-2 { margin-top: var(--space-2); }
-.mt-3 { margin-top: var(--space-3); }
-.mt-4 { margin-top: var(--space-4); }
-.mt-5 { margin-top: var(--space-5); }
+.mt-1 {
+  margin-top: var(--space-1);
+}
+.mt-2 {
+  margin-top: var(--space-2);
+}
+.mt-3 {
+  margin-top: var(--space-3);
+}
+.mt-4 {
+  margin-top: var(--space-4);
+}
+.mt-5 {
+  margin-top: var(--space-5);
+}
+.mt-6 {
+  margin-top: var(--space-6);
+}
+.mt-7 {
+  margin-top: var(--space-7);
+}
 
-.mb-1 { margin-bottom: var(--space-1); }
-.mb-2 { margin-bottom: var(--space-2); }
-.mb-3 { margin-bottom: var(--space-3); }
-.mb-4 { margin-bottom: var(--space-4); }
-.mb-5 { margin-bottom: var(--space-5); }
+.mb-1 {
+  margin-bottom: var(--space-1);
+}
+.mb-2 {
+  margin-bottom: var(--space-2);
+}
+.mb-3 {
+  margin-bottom: var(--space-3);
+}
+.mb-4 {
+  margin-bottom: var(--space-4);
+}
+.mb-5 {
+  margin-bottom: var(--space-5);
+}
+.mb-6 {
+  margin-bottom: var(--space-6);
+}
+.mb-7 {
+  margin-bottom: var(--space-7);
+}
 
 /* padding utilities */
-.p-1 { padding: var(--space-1); }
-.p-2 { padding: var(--space-2); }
-.p-3 { padding: var(--space-3); }
-.p-4 { padding: var(--space-4); }
-.p-5 { padding: var(--space-5); }
+.p-1 {
+  padding: var(--space-1);
+}
+.p-2 {
+  padding: var(--space-2);
+}
+.p-3 {
+  padding: var(--space-3);
+}
+.p-4 {
+  padding: var(--space-4);
+}
+.p-5 {
+  padding: var(--space-5);
+}
+.p-6 {
+  padding: var(--space-6);
+}
+.p-7 {
+  padding: var(--space-7);
+}
 
-.pt-1 { padding-top: var(--space-1); }
-.pt-2 { padding-top: var(--space-2); }
-.pt-3 { padding-top: var(--space-3); }
-.pt-4 { padding-top: var(--space-4); }
-.pt-5 { padding-top: var(--space-5); }
+.pt-1 {
+  padding-top: var(--space-1);
+}
+.pt-2 {
+  padding-top: var(--space-2);
+}
+.pt-3 {
+  padding-top: var(--space-3);
+}
+.pt-4 {
+  padding-top: var(--space-4);
+}
+.pt-5 {
+  padding-top: var(--space-5);
+}
+.pt-6 {
+  padding-top: var(--space-6);
+}
+.pt-7 {
+  padding-top: var(--space-7);
+}
 
-.pb-1 { padding-bottom: var(--space-1); }
-.pb-2 { padding-bottom: var(--space-2); }
-.pb-3 { padding-bottom: var(--space-3); }
-.pb-4 { padding-bottom: var(--space-4); }
-.pb-5 { padding-bottom: var(--space-5); }
+.pb-1 {
+  padding-bottom: var(--space-1);
+}
+.pb-2 {
+  padding-bottom: var(--space-2);
+}
+.pb-3 {
+  padding-bottom: var(--space-3);
+}
+.pb-4 {
+  padding-bottom: var(--space-4);
+}
+.pb-5 {
+  padding-bottom: var(--space-5);
+}
+.pb-6 {
+  padding-bottom: var(--space-6);
+}
+.pb-7 {
+  padding-bottom: var(--space-7);
+}


### PR DESCRIPTION
## Summary
- add `--space-6`/`--space-7` spacing tokens and corresponding margin/padding utilities
- apply new `p-6` and `mb-6` utilities across core display components

## Testing
- `npx eslint src/pages/App/index.jsx src/pages/App/FavoritesView.jsx src/components/ui/HistoryDisplay/HistoryDisplay.jsx --fix`
- `npx stylelint "src/theme/spacing.css" "src/pages/App/App.css" --fix`
- `npx prettier -w src/theme/spacing.css src/pages/App/App.css src/pages/App/index.jsx src/pages/App/FavoritesView.jsx src/components/ui/HistoryDisplay/HistoryDisplay.jsx`
- `mvn spotless:apply` *(fails: 'dependencies.dependency.version' missing for multiple artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68bef6cbafd08332ba9579ab2aa9e44c