### PR TITLE
feat: add scalable radius and shadow tokens

### DIFF
--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -51,7 +51,7 @@
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);
-  box-shadow: 0 2px 8px var(--shadow-color);
+  box-shadow: var(--shadow-lg);
 }
 
 .sidebar-functions {
@@ -73,7 +73,7 @@
   padding: 4px 0;
   padding-left: 8px;
   position: relative;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
@@ -85,17 +85,17 @@
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .history-list li:hover {
+:root[data-theme="dark"] .history-list li:hover {
   background-color: var(--color-overlay-inverse);
 }
 
-:root[data-theme='dark'] .sidebar-user .user-menu li:hover {
+:root[data-theme="dark"] .sidebar-user .user-menu li:hover {
   background-color: var(--color-overlay-inverse);
 }
 
 .sidebar-user .user-menu button.with-name:hover {
   background-color: var(--color-overlay-inverse);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .favorites-list ul {
@@ -111,13 +111,13 @@
   user-select: none;
   padding: 4px 0;
   padding-left: 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .collection-button:hover {
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .collection-button:hover {
+:root[data-theme="dark"] .collection-button:hover {
   background-color: var(--color-overlay-inverse);
 }

--- a/website/src/components/modals/ModalContent.module.css
+++ b/website/src/components/modals/ModalContent.module.css
@@ -3,4 +3,5 @@
   color: var(--app-color);
   padding: 20px;
   border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
 }

--- a/website/src/components/ui/Avatar/Avatar.module.css
+++ b/website/src/components/ui/Avatar/Avatar.module.css
@@ -1,5 +1,5 @@
 .avatar {
   border-radius: var(--radius-full, 50%);
   object-fit: cover;
-  box-shadow: 0 0 4px var(--shadow-color);
+  box-shadow: var(--shadow-sm);
 }

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -14,7 +14,7 @@
   outline: none;
   font-size: 1rem;
   line-height: 1.5;
-  box-shadow: 0 2px 4px var(--shadow-color);
+  box-shadow: var(--shadow-md);
   resize: none;
   overflow: hidden;
 }

--- a/website/src/components/ui/ErrorBoundary/ErrorBoundary.module.css
+++ b/website/src/components/ui/ErrorBoundary/ErrorBoundary.module.css
@@ -5,5 +5,5 @@
   background: var(--app-bg);
   color: var(--app-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px var(--shadow-color);
+  box-shadow: var(--shadow-xl);
 }

--- a/website/src/components/ui/ItemMenu/ItemMenu.module.css
+++ b/website/src/components/ui/ItemMenu/ItemMenu.module.css
@@ -19,7 +19,7 @@
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  box-shadow: 0 2px 8px var(--shadow-color);
+  box-shadow: var(--shadow-lg);
   z-index: var(--z-index-popover);
 }
 

--- a/website/src/components/ui/Toast/Toast.module.css
+++ b/website/src/components/ui/Toast/Toast.module.css
@@ -6,7 +6,7 @@
   background: rgb(0 0 0 / 80%);
   color: #fff;
   padding: 8px 16px;
-  border-radius: 4px;
-  box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
   z-index: 1000;
 }

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -71,8 +71,8 @@
   overflow-wrap: anywhere;
   background: var(--app-bg);
   color: var(--app-color);
-  border-radius: 8px;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
   line-height: 1.5;
 }
 

--- a/website/src/pages/chat/ChatView.module.css
+++ b/website/src/pages/chat/ChatView.module.css
@@ -18,7 +18,7 @@
   max-width: 70%;
   padding: 0.75rem 1rem;
   border-radius: var(--radius-lg);
-  box-shadow: 0 2px 4px var(--shadow-color);
+  box-shadow: var(--shadow-md);
   line-height: 1.5;
 }
 

--- a/website/src/styles/index.css
+++ b/website/src/styles/index.css
@@ -1,5 +1,6 @@
 @import url("@/theme/colors.css");
 @import url("@/theme/variables.css");
+@import url("@/theme/shadows.css");
 @import url("@/theme/spacing.css");
 @import url("@/theme/typography.css");
 

--- a/website/src/theme/shadows.css
+++ b/website/src/theme/shadows.css
@@ -1,0 +1,6 @@
+:root {
+  --shadow-sm: 0 1px 2px var(--shadow-color);
+  --shadow-md: 0 2px 4px var(--shadow-color);
+  --shadow-lg: 0 4px 8px var(--shadow-color);
+  --shadow-xl: 0 4px 16px var(--shadow-color);
+}

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -1,9 +1,11 @@
 :root {
   --bar-height: 60px;
   --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
   --radius-xl: 20px;
+  --radius-2xl: 24px;
+  --radius-3xl: 32px;
   --btn-padding: 0.6em 1.2em;
   --btn-border: 1px solid transparent;
   --user-menu-width: 180px;


### PR DESCRIPTION
## Summary
- expand theme radius scale and introduce shadow tokens
- apply unified tokens to sidebar, chat view, modals and common UI

## Testing
- `npx eslint src/theme/variables.css src/styles/index.css src/components/Sidebar/Sidebar.module.css src/pages/chat/ChatView.module.css src/components/ui/ErrorBoundary/ErrorBoundary.module.css src/components/ui/ChatInput/ChatInput.module.css src/components/ui/ItemMenu/ItemMenu.module.css src/components/ui/Avatar/Avatar.module.css src/components/ui/Toast/Toast.module.css src/pages/App/App.css src/components/modals/ModalContent.module.css --fix`
- `npx stylelint "src/theme/variables.css" "src/styles/index.css" "src/components/Sidebar/Sidebar.module.css" "src/pages/chat/ChatView.module.css" "src/components/ui/ErrorBoundary/ErrorBoundary.module.css" "src/components/ui/ChatInput/ChatInput.module.css" "src/components/ui/ItemMenu/ItemMenu.module.css" "src/components/ui/Avatar/Avatar.module.css" "src/components/ui/Toast/Toast.module.css" "src/pages/App/App.css" "src/components/modals/ModalContent.module.css" --fix`
- `npx prettier -w src/theme/variables.css src/theme/shadows.css src/styles/index.css src/components/Sidebar/Sidebar.module.css src/pages/chat/ChatView.module.css src/components/ui/ErrorBoundary/ErrorBoundary.module.css src/components/ui/ChatInput/ChatInput.module.css src/components/ui/ItemMenu/ItemMenu.module.css src/components/ui/Avatar/Avatar.module.css src/components/ui/Toast/Toast.module.css src/pages/App/App.css src/components/modals/ModalContent.module.css`
- `npm test` *(fail: Syntax error reading regular expression)*
- `mvn -q spotless:apply` *(fail: 'dependencies.dependency.version' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bef6c04b3883328753d49b60b2c95c