### PR TITLE
refactor: centralize ICP link in sidebar

### DIFF
--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -25,6 +25,11 @@
   border-top: 1px solid transparent;
 }
 
+.sidebar-icp {
+  margin-left: auto;
+  text-align: right;
+}
+
 /* adapt header components used inside sidebar */
 .sidebar-user :global(.header-section) {
   display: block;
@@ -85,11 +90,11 @@
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .history-list li:hover {
+:root[data-theme="dark"] .history-list li:hover {
   background-color: var(--color-overlay-inverse);
 }
 
-:root[data-theme='dark'] .sidebar-user .user-menu li:hover {
+:root[data-theme="dark"] .sidebar-user .user-menu li:hover {
   background-color: var(--color-overlay-inverse);
 }
 
@@ -118,6 +123,6 @@
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .collection-button:hover {
+:root[data-theme="dark"] .collection-button:hover {
   background-color: var(--color-overlay-inverse);
 }

--- a/website/src/components/Sidebar/SidebarUser.jsx
+++ b/website/src/components/Sidebar/SidebarUser.jsx
@@ -1,12 +1,14 @@
-import { UserMenu } from '@/components/Header'
-import styles from './Sidebar.module.css'
+import { UserMenu } from "@/components/Header";
+import ICP from "@/components/ui/ICP";
+import styles from "./Sidebar.module.css";
 
 function SidebarUser() {
   return (
-    <div className={styles['sidebar-user']}>
+    <div className={styles["sidebar-user"]}>
       <UserMenu size={32} showName />
+      <ICP className={styles["sidebar-icp"]} />
     </div>
-  )
+  );
 }
 
-export default SidebarUser
+export default SidebarUser;

--- a/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
+++ b/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
@@ -84,17 +84,6 @@ exports[`AuthForm submits valid credentials 1`] = `
           Privacy Policy
         </a>
       </div>
-      <div
-        class="icp"
-      >
-        <a
-          href="https://beian.miit.gov.cn/"
-          rel="noopener"
-          target="_blank"
-        >
-          京ICP备2025135702号-1
-        </a>
-      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/website/src/components/form/AuthForm.jsx
+++ b/website/src/components/form/AuthForm.jsx
@@ -7,7 +7,6 @@ import MultiLineText from "@/components/ui/MultiLineText.jsx";
 import styles from "./AuthForm.module.css";
 import MessagePopup from "@/components/ui/MessagePopup";
 import ThemeIcon from "@/components/ui/Icon";
-import ICP from "@/components/ui/ICP";
 import { useLanguage } from "@/context";
 
 const defaultIcons = {
@@ -136,7 +135,6 @@ function AuthForm({
         <div className={styles["footer-links"]}>
           <a href="#">{t.termsOfUse}</a> | <a href="#">{t.privacyPolicy}</a>
         </div>
-        <ICP />
       </div>
       <MessagePopup
         open={showNotice}

--- a/website/src/components/ui/ICP/ICP.jsx
+++ b/website/src/components/ui/ICP/ICP.jsx
@@ -1,15 +1,16 @@
-import { ICP_INFO } from '@/config/icp.js'
-import styles from './ICP.module.css'
+import { ICP_INFO } from "@/config/icp.js";
+import styles from "./ICP.module.css";
 
-function ICP() {
-  const { link, text } = ICP_INFO
+function ICP({ className }) {
+  const { link, text } = ICP_INFO;
+  const classes = [styles.icp, className].filter(Boolean).join(" ");
   return (
-    <div className={styles.icp}>
+    <div className={classes}>
       <a href={link} target="_blank" rel="noopener">
         {text}
       </a>
     </div>
-  )
+  );
 }
 
-export default ICP
+export default ICP;

--- a/website/src/components/ui/ICP/ICP.module.css
+++ b/website/src/components/ui/ICP/ICP.module.css
@@ -1,8 +1,6 @@
 .icp {
-  text-align: center;
   font-size: 0.75rem;
   color: var(--text-muted);
-  margin: 8px 0;
 }
 
 .icp a {

--- a/website/src/pages/App/__tests__/streaming.test.jsx
+++ b/website/src/pages/App/__tests__/streaming.test.jsx
@@ -23,9 +23,6 @@ jest.unstable_mockModule("@/components/ui/DictionaryEntry", () => ({
 jest.unstable_mockModule("@/components/ui/HistoryDisplay", () => ({
   default: () => null,
 }));
-jest.unstable_mockModule("@/components/ui/ICP", () => ({
-  default: () => null,
-}));
 jest.unstable_mockModule("@/components/ui/MessagePopup", () => ({
   default: () => null,
 }));

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -11,7 +11,6 @@ import ChatInput from "@/components/ui/ChatInput";
 import Layout from "@/components/Layout";
 import HistoryDisplay from "@/components/ui/HistoryDisplay";
 import { useModelStore } from "@/store";
-import ICP from "@/components/ui/ICP";
 import FavoritesView from "./FavoritesView.jsx";
 import { useAppShortcuts } from "@/hooks";
 import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
@@ -240,7 +239,6 @@ function App() {
               placeholder={t.inputPlaceholder}
               maxRows={5}
             />
-            <ICP />
           </div>
         }
       >


### PR DESCRIPTION
## Summary
- add ICP link to Sidebar user section
- remove ICP references from app and auth pages
- expose ICP component className for layout flexibility

## Testing
- `npx eslint src/components/ui/ICP/ICP.jsx src/components/Sidebar/SidebarUser.jsx src/pages/App/index.jsx src/components/form/AuthForm.jsx src/pages/App/__tests__/streaming.test.jsx --fix`
- `npx stylelint "src/components/ui/ICP/ICP.module.css" "src/components/Sidebar/Sidebar.module.css" --fix`
- `npx prettier -w src/components/ui/ICP/ICP.jsx src/components/ui/ICP/ICP.module.css src/components/Sidebar/SidebarUser.jsx src/components/Sidebar/Sidebar.module.css src/pages/App/index.jsx src/components/form/AuthForm.jsx src/pages/App/__tests__/streaming.test.jsx`
- `npx prettier -w src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap --parser babel`
- `npm test` (fails: Syntax error reading regular expression)


------
https://chatgpt.com/codex/tasks/task_e_68bf05f59c688332bf3300806a803e42