### PR TITLE
feat: 同步页签图标与系统主题

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -2,29 +2,34 @@
 <html lang="zh" data-theme="system">
   <head>
     <meta charset="UTF-8" />
-    <link id="favicon" rel="icon" type="image/svg+xml" href="/src/assets/brand/glancy-web-light.svg" />
+    <link
+      id="favicon"
+      rel="icon"
+      type="image/svg+xml"
+      href="/src/assets/brand/glancy-web-light.svg"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>格律词典</title>
   </head>
   <body>
     <div id="root"></div>
     <script>
-      ;(function () {
-        const storedLang = localStorage.getItem('lang')
+      (function () {
+        const storedLang = localStorage.getItem("lang");
         if (storedLang) {
-          document.documentElement.lang = storedLang
+          document.documentElement.lang = storedLang;
         }
-        const theme = localStorage.getItem('theme') || 'system'
-        const dark = window.matchMedia('(prefers-color-scheme: dark)').matches
-        const resolved = theme === 'system' ? (dark ? 'dark' : 'light') : theme
-        document.documentElement.dataset.theme = resolved
-        const link = document.getElementById('favicon')
+        const theme = localStorage.getItem("theme") || "system";
+        const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const resolved = theme === "system" ? (dark ? "dark" : "light") : theme;
+        document.documentElement.dataset.theme = resolved;
+        const link = document.getElementById("favicon");
         if (link) {
-          link.href = resolved === 'dark'
-            ? '/src/assets/brand/glancy-web-dark.svg'
-            : '/src/assets/brand/glancy-web-light.svg'
+          link.href = dark
+            ? "/src/assets/brand/glancy-web-dark.svg"
+            : "/src/assets/brand/glancy-web-light.svg";
         }
-      })()
+      })();
     </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/website/src/context/ThemeContext.jsx
+++ b/website/src/context/ThemeContext.jsx
@@ -1,53 +1,65 @@
-import { createContext, useContext, useEffect, useState } from 'react'
-import lightIcon from '@/assets/brand/glancy-web-light.svg'
-import darkIcon from '@/assets/brand/glancy-web-dark.svg'
+import { createContext, useContext, useEffect, useState } from "react";
+import lightIcon from "@/assets/brand/glancy-web-light.svg";
+import darkIcon from "@/assets/brand/glancy-web-dark.svg";
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const ThemeContext = createContext({
-  theme: 'system',
-  resolvedTheme: 'light',
-  setTheme: () => {}
-})
+  theme: "system",
+  resolvedTheme: "light",
+  setTheme: () => {},
+});
 
 export function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'system')
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem("theme") || "system",
+  );
   const [resolvedTheme, setResolvedTheme] = useState(() => {
-    const stored = localStorage.getItem('theme') || 'system'
-    if (stored === 'system') {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    const stored = localStorage.getItem("theme") || "system";
+    if (stored === "system") {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
     }
-    return stored
-  })
-
+    return stored;
+  });
 
   useEffect(() => {
-    localStorage.setItem('theme', theme)
-    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    localStorage.setItem("theme", theme);
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
     const apply = () => {
-      let current = theme
-      if (theme === 'system') {
-        current = media.matches ? 'dark' : 'light'
+      let current = theme;
+      if (theme === "system") {
+        current = media.matches ? "dark" : "light";
       }
-      setResolvedTheme(current)
-      document.documentElement.dataset.theme = current
-      const link = document.getElementById('favicon')
+      setResolvedTheme(current);
+      document.documentElement.dataset.theme = current;
+    };
+    apply();
+    if (theme === "system") {
+      media.addEventListener("change", apply);
+      return () => media.removeEventListener("change", apply);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const apply = () => {
+      const link = document.getElementById("favicon");
       if (link) {
-        link.href = current === 'dark' ? darkIcon : lightIcon
+        link.href = media.matches ? darkIcon : lightIcon;
       }
-    }
-    apply()
-    if (theme === 'system') {
-      media.addEventListener('change', apply)
-      return () => media.removeEventListener('change', apply)
-    }
-  }, [theme])
+    };
+    apply();
+    media.addEventListener("change", apply);
+    return () => media.removeEventListener("change", apply);
+  }, []);
 
   return (
     <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
       {children}
     </ThemeContext.Provider>
-  )
+  );
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const useTheme = () => useContext(ThemeContext)
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary
- init script uses system color scheme to choose favicon independent from page theme
- ThemeProvider updates favicon on system color scheme changes

## Testing
- `npm run lint`
- `npm run lint:css`
- `npx prettier -w index.html src/context/ThemeContext.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c7b1d2483328c5bad1b057867cf