### PR TITLE
refactor: add action input component

### DIFF
--- a/website/src/components/ui/ChatInput/ActionInput.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput.jsx
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef } from "react";
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./ChatInput.module.css";
+
+const ICON_SIZE = 36;
+
+/**
+ * ActionInput renders a textarea with an internally positioned action button.
+ * The button toggles between voice trigger and form submit depending on the
+ * trimmed content value.
+ */
+function ActionInput({
+  value,
+  onChange,
+  onSubmit,
+  onVoice,
+  inputRef,
+  placeholder,
+  sendLabel = "Send",
+  voiceLabel = "Voice",
+  rows = 1,
+  maxRows = 5,
+}) {
+  const isEmpty = value.trim() === "";
+  const localRef = useRef(null);
+  const textareaRef = inputRef || localRef;
+
+  const autoResize = useCallback(
+    (el) => {
+      const lineHeight = parseFloat(
+        window.getComputedStyle(el).lineHeight || "20",
+      );
+      const maxHeight = lineHeight * maxRows;
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    },
+    [maxRows],
+  );
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      autoResize(textareaRef.current);
+    }
+  }, [autoResize, value, textareaRef]);
+
+  const handleChange = (e) => {
+    autoResize(e.target);
+    onChange?.(e);
+  };
+
+  const handleClick = (e) => {
+    if (isEmpty && onVoice) {
+      e.preventDefault();
+      onVoice();
+    }
+  };
+
+  return (
+    <form className={styles["input-wrapper"]} onSubmit={onSubmit}>
+      <textarea
+        ref={textareaRef}
+        rows={rows}
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        className={styles.textarea}
+      />
+      <button
+        type={isEmpty ? "button" : "submit"}
+        className={styles["action-button"]}
+        onClick={handleClick}
+        aria-label={isEmpty ? voiceLabel : sendLabel}
+      >
+        {isEmpty ? (
+          <ThemeIcon
+            name="voice-button"
+            alt={voiceLabel}
+            width={ICON_SIZE}
+            height={ICON_SIZE}
+          />
+        ) : (
+          <ThemeIcon
+            name="send-button"
+            alt={sendLabel}
+            width={ICON_SIZE}
+            height={ICON_SIZE}
+          />
+        )}
+      </button>
+    </form>
+  );
+}
+
+export default ActionInput;

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -1,15 +1,20 @@
 .container {
-  display: flex;
-  align-items: flex-end;
   width: 100%;
-  gap: 16px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.input-wrapper {
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .textarea {
-  flex: 1;
+  width: 100%;
   border: none;
   border-radius: var(--radius-xl);
-  padding: 12px 20px;
+  padding: 12px 56px 12px 20px;
   outline: none;
   font-size: 1rem;
   line-height: 1.5;
@@ -18,18 +23,12 @@
   overflow: hidden;
 }
 
-.button {
+.action-button {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
   border: none;
   background: none;
   padding: 8px;
   cursor: pointer;
-}
-
-.button + .button {
-  margin-left: 16px;
-}
-
-.icon {
-  width: 36px;
-  height: 36px;
 }

--- a/website/src/components/ui/ChatInput/index.jsx
+++ b/website/src/components/ui/ChatInput/index.jsx
@@ -1,89 +1,11 @@
-import { useCallback, useEffect, useRef } from "react";
-import ThemeIcon from "@/components/ui/Icon";
+import ActionInput from "./ActionInput";
 import styles from "./ChatInput.module.css";
 
-/**
- * Chat input field with dual submit/voice behaviour.
- * When the field is empty the button acts as a voice trigger
- * instead of submitting the form.
- */
-function ChatInput({
-  value,
-  onChange,
-  onSubmit,
-  onVoice,
-  inputRef,
-  placeholder,
-  sendLabel = "Send",
-  voiceLabel = "Voice",
-  rows = 1,
-  maxRows = 5,
-}) {
-  const isEmpty = value.trim() === "";
-  const localRef = useRef(null);
-  const textareaRef = inputRef || localRef;
-
-  const autoResize = useCallback(
-    (el) => {
-      const lineHeight = parseFloat(
-        window.getComputedStyle(el).lineHeight || "20",
-      );
-      const maxHeight = lineHeight * maxRows;
-      el.style.height = "auto";
-      el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
-    },
-    [maxRows],
-  );
-
-  useEffect(() => {
-    if (textareaRef.current) {
-      autoResize(textareaRef.current);
-    }
-  }, [autoResize, value, textareaRef]);
-
-  const handleClick = (e) => {
-    if (isEmpty && onVoice) {
-      e.preventDefault();
-      onVoice();
-    }
-  };
-
-  const handleChange = (e) => {
-    autoResize(e.target);
-    onChange?.(e);
-  };
-
+function ChatInput(props) {
   return (
-    <form className={styles.container} onSubmit={onSubmit}>
-      <textarea
-        ref={textareaRef}
-        rows={rows}
-        placeholder={placeholder}
-        value={value}
-        onChange={handleChange}
-        className={styles.textarea}
-      />
-      <button
-        type={isEmpty ? "button" : "submit"}
-        className={styles.button}
-        onClick={handleClick}
-        aria-label={isEmpty ? voiceLabel : sendLabel}
-      >
-        {isEmpty ? (
-          <ThemeIcon
-            name="voice-button"
-            alt={voiceLabel}
-            className={styles.icon}
-          />
-        ) : (
-          <ThemeIcon
-            name="send-button"
-            alt={sendLabel}
-            className={styles.icon}
-          />
-        )}
-      </button>
-    </form>
+    <div className={styles.container}>
+      <ActionInput {...props} />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- create reusable ActionInput component combining textarea and inline action button
- refactor ChatInput to use ActionInput and callbacks
- update styling for internal action button and input wrapper

## Testing
- `npx eslint src/components/ui/ChatInput/ActionInput.jsx src/components/ui/ChatInput/index.jsx --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/components/ui/ChatInput/ActionInput.jsx src/components/ui/ChatInput/index.jsx src/components/ui/ChatInput/ChatInput.module.css`
- `npm test` *(fails: Syntax error reading regular expression, heap out of memory)*
- `mvn -q spotless:apply` *(fails: Non-resolvable import POM: could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68c05231bd748332b56074c449b33767