### PR TITLE
feat(ui): introduce reusable GlassPanel with interactive feedback

### DIFF
--- a/website/src/components/__tests__/ListItem.test.jsx
+++ b/website/src/components/__tests__/ListItem.test.jsx
@@ -1,0 +1,24 @@
+import { render, fireEvent } from "@testing-library/react";
+import ListItem from "@/components/ui/ListItem";
+
+/**
+ * 验证 ListItem 在指针交互时能正确切换样式类。
+ */
+test("toggles interactive classes on pointer events", () => {
+  const { getByRole } = render(
+    <ul>
+      <ListItem text="示例" />
+    </ul>,
+  );
+  const item = getByRole("listitem");
+
+  fireEvent.mouseEnter(item);
+  expect(item.className).toContain("hovered");
+  fireEvent.mouseLeave(item);
+  expect(item.className).not.toContain("hovered");
+
+  fireEvent.mouseDown(item);
+  expect(item.className).toContain("active");
+  fireEvent.mouseUp(item);
+  expect(item.className).not.toContain("active");
+});

--- a/website/src/components/index.js
+++ b/website/src/components/index.js
@@ -1,6 +1,7 @@
 export { default as Button } from "./ui/Button";
 export { default as ListItem } from "./ui/ListItem";
 export { default as ItemMenu } from "./ui/ItemMenu";
+export { default as GlassPanel } from "./ui/GlassPanel";
 
 export { default as Avatar } from "./ui/Avatar";
 export { default as DictionaryEntry } from "./ui/DictionaryEntry";

--- a/website/src/components/ui/GlassPanel/GlassPanel.jsx
+++ b/website/src/components/ui/GlassPanel/GlassPanel.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import styles from "./GlassPanel.module.css";
+
+/**
+ * GlassPanel is a generic container that renders a blurred, translucent surface
+ * with subtle interactive feedback.
+ *
+ * @param {Object} props - Component props.
+ * @param {React.ElementType} [props.as='div'] - The underlying element to render.
+ * @param {string} [props.className] - Additional class names for customization.
+ * @param {React.ReactNode} props.children - Content to be displayed inside the panel.
+ * @returns {JSX.Element}
+ */
+function GlassPanel({
+  as = "div",
+  className = "",
+  children,
+  onMouseEnter,
+  onMouseLeave,
+  onMouseDown,
+  onMouseUp,
+  onTouchStart,
+  onTouchEnd,
+  ...rest
+}) {
+  const Tag = as;
+  const [isHovered, setIsHovered] = useState(false);
+  const [isActive, setIsActive] = useState(false);
+
+  const handleMouseEnter = (e) => {
+    setIsHovered(true);
+    onMouseEnter?.(e);
+  };
+
+  const handleMouseLeave = (e) => {
+    setIsHovered(false);
+    setIsActive(false);
+    onMouseLeave?.(e);
+  };
+
+  const handleMouseDown = (e) => {
+    setIsActive(true);
+    onMouseDown?.(e);
+  };
+
+  const handleMouseUp = (e) => {
+    setIsActive(false);
+    onMouseUp?.(e);
+  };
+
+  const handleTouchStart = (e) => {
+    setIsActive(true);
+    onTouchStart?.(e);
+  };
+
+  const handleTouchEnd = (e) => {
+    setIsActive(false);
+    onTouchEnd?.(e);
+  };
+
+  const classes = [
+    styles.panel,
+    isHovered && styles.hovered,
+    isActive && styles.active,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Tag
+      className={classes}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+export default GlassPanel;

--- a/website/src/components/ui/GlassPanel/GlassPanel.module.css
+++ b/website/src/components/ui/GlassPanel/GlassPanel.module.css
@@ -1,0 +1,36 @@
+@import url("@/theme/variables.css");
+
+.panel {
+  backdrop-filter: blur(10px);
+  background: linear-gradient(
+    135deg,
+    rgb(255 255 255 / 60%),
+    rgb(255 255 255 / 20%)
+  );
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 10%);
+  transition:
+    transform 0.2s ease,
+    filter 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+:root[data-theme="dark"] .panel {
+  background: linear-gradient(
+    135deg,
+    rgb(255 255 255 / 15%),
+    rgb(255 255 255 / 5%)
+  );
+}
+
+.hovered {
+  filter: brightness(1.05);
+  transform: scale(1.01);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 12%);
+}
+
+.active {
+  filter: brightness(1.1);
+  transform: scale(0.97);
+  box-shadow: 0 3px 12px rgb(0 0 0 / 20%);
+}

--- a/website/src/components/ui/GlassPanel/index.js
+++ b/website/src/components/ui/GlassPanel/index.js
@@ -1,0 +1,1 @@
+export { default } from "./GlassPanel.jsx";

--- a/website/src/components/ui/ListItem/ListItem.jsx
+++ b/website/src/components/ui/ListItem/ListItem.jsx
@@ -1,13 +1,26 @@
-import React from 'react'
-import styles from './ListItem.module.css'
+import React from "react";
+import GlassPanel from "../GlassPanel";
+import styles from "./ListItem.module.css";
 
-function ListItem({ text, onClick, actions, className = '', textClassName = '' }) {
+function ListItem({
+  text,
+  onClick,
+  actions,
+  className = "",
+  textClassName = "",
+}) {
   return (
-    <li className={[styles.item, className].filter(Boolean).join(' ')} onClick={onClick}>
-      <span className={[styles.text, textClassName].filter(Boolean).join(' ')}>{text}</span>
+    <GlassPanel
+      as="li"
+      className={[styles.item, className].filter(Boolean).join(" ")}
+      onClick={onClick}
+    >
+      <span className={[styles.text, textClassName].filter(Boolean).join(" ")}>
+        {text}
+      </span>
       {actions ? <div className={styles.actions}>{actions}</div> : null}
-    </li>
-  )
+    </GlassPanel>
+  );
 }
 
-export default ListItem
+export default ListItem;

--- a/website/src/components/ui/ListItem/ListItem.module.css
+++ b/website/src/components/ui/ListItem/ListItem.module.css
@@ -1,22 +1,13 @@
-@import url('@/theme/spacing.css');
-@import url('@/theme/variables.css');
+@import url("@/theme/spacing.css");
+@import url("@/theme/variables.css");
 
 .item {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: var(--space-1) var(--space-2);
-  border-radius: var(--radius-sm);
   position: relative;
   cursor: pointer;
-}
-
-.item:hover {
-  background-color: var(--color-overlay-weak);
-}
-
-:root[data-theme='dark'] .item:hover {
-  background-color: var(--color-overlay-inverse);
 }
 
 .text {


### PR DESCRIPTION
## Summary
- add GlassPanel component with blur, gradient, and hover/active animations
- wrap ListItem with GlassPanel and export new component
- test ListItem to ensure hover and active classes toggle correctly

## Testing
- `npx prettier -w src/components/ui/GlassPanel/GlassPanel.jsx src/components/ui/GlassPanel/GlassPanel.module.css src/components/ui/GlassPanel/index.js src/components/ui/ListItem/ListItem.jsx src/components/ui/ListItem/ListItem.module.css src/components/index.js src/components/__tests__/ListItem.test.jsx`
- `npx eslint --fix src/components/ui/GlassPanel/GlassPanel.jsx src/components/ui/ListItem/ListItem.jsx src/components/index.js src/components/__tests__/ListItem.test.jsx`
- `npx stylelint "src/components/ui/GlassPanel/GlassPanel.module.css" "src/components/ui/ListItem/ListItem.module.css" --fix`
- `mvn -q -f backend/pom.xml spotless:apply` *(fails: dependencies.dependency.version for spring-boot-starter-web etc. is missing)*
- `npm test` *(fails: Syntax error reading regular expression in words.stream.test.js, useStreamWord.test.js, DictionaryEntry.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c06bba2aa0833292ee56faf7111a68