### PR TITLE
chore: switch default LLM to doubao

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/config/LLMConfig.java
+++ b/backend/src/main/java/com/glancy/backend/llm/config/LLMConfig.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "llm")
 public class LLMConfig {
 
-    private String defaultClient = "deepseek";
+    private String defaultClient = "doubao";
     private double temperature = 0.7;
     private Map<String, String> apiKeys;
     private String promptPath = "prompts/english_to_chinese.txt";

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -44,15 +44,11 @@ search:
     nonMember: 10
 
 llm:
-  default-client: deepseek
+  default-client: doubao
   temperature: 0.7
   prompt-path: prompts/english_to_chinese.txt
 
 thirdparty:
-  deepseek:
-    base-url: https://api.deepseek.com
-    api-key: ""
-
   doubao:
     base-url: https://ark.cn-beijing.volces.com
     chat-path: /api/v3/chat/completions

--- a/backend/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
@@ -29,7 +29,7 @@ class WordSearcherImplTest {
     void setUp() {
         factory = mock(LLMClientFactory.class);
         config = new LLMConfig();
-        config.setDefaultClient("deepseek");
+        config.setDefaultClient("doubao");
         config.setTemperature(0.5);
         config.setPromptPath("path");
         promptManager = mock(PromptManager.class);
@@ -38,10 +38,13 @@ class WordSearcherImplTest {
         defaultClient = mock(LLMClient.class);
     }
 
+    /**
+     * 当指定客户端在工厂中找不到时，应回退到默认客户端并完成查询流程。
+     */
     @Test
     void searchFallsBackToDefaultWhenClientMissing() {
         when(factory.get("invalid")).thenReturn(null);
-        when(factory.get("deepseek")).thenReturn(defaultClient);
+        when(factory.get("doubao")).thenReturn(defaultClient);
         when(promptManager.loadPrompt(anyString())).thenReturn("prompt");
         when(searchContentManager.normalize("hello")).thenReturn("hello");
         when(defaultClient.chat(anyList(), eq(0.5))).thenReturn("content");
@@ -53,14 +56,17 @@ class WordSearcherImplTest {
 
         assertSame(expected, result);
         verify(factory).get("invalid");
-        verify(factory).get("deepseek");
+        verify(factory).get("doubao");
         verify(defaultClient).chat(anyList(), eq(0.5));
     }
 
+    /**
+     * 当默认客户端同样缺失时，系统应抛出 IllegalStateException。
+     */
     @Test
     void searchThrowsWhenDefaultMissing() {
         when(factory.get("invalid")).thenReturn(null);
-        when(factory.get("deepseek")).thenReturn(null);
+        when(factory.get("doubao")).thenReturn(null);
         WordSearcherImpl searcher = new WordSearcherImpl(factory, config, promptManager, searchContentManager, parser);
         assertThrows(IllegalStateException.class, () -> searcher.search("hi", Language.ENGLISH, "invalid"));
     }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -31,7 +31,7 @@ oss:
   access-key-secret:
 
 llm:
-  default-client: deepseek
+  default-client: doubao
   temperature: 0.7
   prompt-path: prompts/english_to_chinese.txt
 


### PR DESCRIPTION
## Summary
- set LLM defaultClient to doubao
- configure application files to use doubao by default and drop deepseek block
- adjust WordSearcherImplTest for doubao default and document test flow

## Testing
- `npx eslint --fix .`
- `npx stylelint "**/*" --fix` *(fails: JSONError in package.json)*
- `npx prettier -w .` *(fails: SyntaxError in configuration files)*
- `mvn -q spotless:apply` *(fails: network is unreachable, missing dependency versions)*
- `mvn -q test` *(fails: network is unreachable, missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68c0733aa5908332b5b43d70beba1c9f