### PR TITLE
chore: 移除无用模型翻译键

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -80,8 +80,6 @@ export default {
   logout: "Log out",
   logoutConfirmTitle: "Are you sure you want to log out?",
   logoutConfirmMessage: "Log out of ChatGPT as {email}?",
-  DEEPSEEK: "DeepSeek",
-  DOUBAO_FLASH: "Doubao Flash",
   share: "Share",
   report: "Report",
   shortcutsTitle: "Keyboard Shortcuts",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -80,8 +80,6 @@ export default {
   logout: "退出登录",
   logoutConfirmTitle: "确定要退出登录吗？",
   logoutConfirmMessage: "以 {email} 身份退出 ChatGPT？",
-  DEEPSEEK: "DeepSeek 模型",
-  DOUBAO_FLASH: "豆包 Flash",
   share: "分享",
   report: "举报",
   shortcutsTitle: "键盘快捷键",


### PR DESCRIPTION
## Summary
- 移除 DeepSeek 与 Doubao Flash 对应的多语言键值

## Testing
- `npx eslint src/i18n/common/en.js src/i18n/common/zh.js --fix`
- `npx stylelint "src/i18n/common/*.js" --fix` *(失败: Unexpected unknown type selector "export")*
- `npx prettier -w src/i18n/common/en.js src/i18n/common/zh.js`
- `npm test` *(失败: JavaScript heap out of memory)*
- `mvn -q spotless:apply` *(失败: 'dependencies.dependency.version' is missing)*
- `mvn -q test` *(失败: 'dependencies.dependency.version' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0733ed9dc8332a1b22d0b831d472e