### PR TITLE
test: streamline WordService streaming tests

### DIFF
--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
@@ -3,7 +3,6 @@ package com.glancy.backend.service;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import com.glancy.backend.client.DictionaryClient;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.Word;
@@ -29,9 +28,6 @@ class WordServiceStreamPersistenceTest {
     private WordService wordService;
 
     @Mock
-    private DictionaryClient dictionaryClient;
-
-    @Mock
     private WordSearcher wordSearcher;
 
     @Mock
@@ -50,7 +46,6 @@ class WordServiceStreamPersistenceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         wordService = new WordService(
-            dictionaryClient,
             wordSearcher,
             wordRepository,
             userPreferenceRepository,

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
@@ -3,7 +3,6 @@ package com.glancy.backend.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.glancy.backend.client.DictionaryClient;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.llm.parser.WordResponseParser;
 import com.glancy.backend.llm.service.WordSearcher;
@@ -24,9 +23,6 @@ class WordServiceStreamingErrorTest {
     private WordService wordService;
 
     @Mock
-    private DictionaryClient dictionaryClient;
-
-    @Mock
     private WordSearcher wordSearcher;
 
     @Mock
@@ -45,7 +41,6 @@ class WordServiceStreamingErrorTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         wordService = new WordService(
-            dictionaryClient,
             wordSearcher,
             wordRepository,
             userPreferenceRepository,


### PR DESCRIPTION
## Summary
- remove obsolete DictionaryClient from WordServiceStreamPersistenceTest and WordServiceStreamingErrorTest
- construct WordService with WordSearcher, WordRepository, UserPreferenceRepository, SearchRecordService, and WordResponseParser only

## Testing
- `npx eslint --fix .`
- `npx stylelint "**/*.{css,scss}" --fix`
- `npx prettier -w .`
- `mvn spotless:apply` *(fails: dependencies.dependency.version is missing)*
- `mvn -q test` *(fails: dependencies.dependency.version is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c10f7307f08332a8edf1c907960193