### PR TITLE
feat: 使用 requestSubmit 统一聊天输入提交

### DIFF
--- a/website/src/components/ui/ChatInput/ActionInput.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput.jsx
@@ -24,6 +24,7 @@ function ActionInput({
   const isEmpty = value.trim() === "";
   const localRef = useRef(null);
   const textareaRef = inputRef || localRef;
+  const formRef = useRef(null);
 
   const autoResize = useCallback(
     (el) => {
@@ -62,11 +63,11 @@ function ActionInput({
   const handleKeyDown = useCallback(
     (e) => {
       if (e.key === "Enter" && !e.shiftKey) {
-        handleSubmit(e);
         e.preventDefault();
+        formRef.current?.requestSubmit();
       }
     },
-    [handleSubmit],
+    [formRef],
   );
 
   const handleClick = useCallback(
@@ -80,7 +81,11 @@ function ActionInput({
   );
 
   return (
-    <form className={styles["input-wrapper"]} onSubmit={handleSubmit}>
+    <form
+      ref={formRef}
+      className={styles["input-wrapper"]}
+      onSubmit={handleSubmit}
+    >
       <SearchBox>
         <textarea
           ref={textareaRef}

--- a/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
@@ -1,5 +1,6 @@
 import { render, fireEvent, screen } from "@testing-library/react";
 import { jest } from "@jest/globals";
+import { useState } from "react";
 import ActionInput from "@/components/ui/ChatInput/ActionInput.jsx";
 
 /**
@@ -17,4 +18,26 @@ test("submits on Enter and ignores Shift+Enter", () => {
 
   fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
   expect(onSubmit).toHaveBeenCalledTimes(1);
+});
+
+/**
+ * 回车提交后应清空输入框：
+ * - 父组件通过 setState 将值重置为空；
+ * - 按 Enter 触发提交后，textarea 的值应变为空。
+ */
+test("clears value via parent state on Enter submit", () => {
+  function Wrapper() {
+    const [value, setValue] = useState("hello");
+    return (
+      <ActionInput
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onSubmit={() => setValue("")}
+      />
+    );
+  }
+  render(<Wrapper />);
+  const textarea = screen.getByRole("textbox");
+  fireEvent.keyDown(textarea, { key: "Enter" });
+  expect(textarea.value).toBe("");
 });


### PR DESCRIPTION
## Summary
- 引入 formRef 并使用 `requestSubmit` 触发表单提交
- 新增用例验证回车提交后输入框被清空

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/components/ui/ChatInput/ActionInput.jsx src/components/ui/ChatInput/__tests__/ActionInput.test.jsx`
- `mvn -q -f backend/pom.xml spotless:apply` (failed: 'dependencies.dependency.version' missing)
- `npm test` (failed: JavaScript heap out of memory)


------
https://chatgpt.com/codex/tasks/task_e_68c56e4e85d083328d68ac3f9a72b94e