### PR TITLE
fix: improve logout button contrast

### DIFF
--- a/website/src/components/modals/LogoutConfirmModal.module.css
+++ b/website/src/components/modals/LogoutConfirmModal.module.css
@@ -25,7 +25,7 @@
 
 .logout-btn {
   background: var(--highlight-color);
-  color: var(--primary-bg);
+  color: var(--primary-color);
   border: none;
   border-radius: var(--radius-xl);
   padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- improve logout modal button text color for theme contrast

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/components/modals/LogoutConfirmModal.module.css`
- `mvn -q -f backend/pom.xml spotless:apply` *(failed: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c830ec6dd4833294a2b35ebe8c623d