### PR TITLE
feat: tighten auth route redirection logic

### DIFF
--- a/website/src/__tests__/AuthWatcher.test.jsx
+++ b/website/src/__tests__/AuthWatcher.test.jsx
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+const mockNavigate = jest.fn();
+let currentUser = null;
+
+jest.unstable_mockModule("@/context", () => ({
+  useUser: () => ({ user: currentUser }),
+}));
+
+jest.unstable_mockModule("react-router-dom", async () => {
+  const actual = await import("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const router = await import("react-router-dom");
+const { MemoryRouter } = router;
+const { default: AuthWatcher } = await import("@/components/AuthWatcher");
+
+beforeEach(() => {
+  currentUser = null;
+  mockNavigate.mockClear();
+});
+
+/**
+ * 测试逻辑：在无用户信息且访问受保护路径时，应重定向到登录页。
+ * 测试步骤：设置 currentUser 为空，使用 MemoryRouter 从受保护路径启动，渲染组件并等待导航行为。
+ */
+test("redirects anonymous visitor to login when accessing protected route", async () => {
+  currentUser = null;
+
+  render(
+    <MemoryRouter initialEntries={["/settings"]}>
+      <AuthWatcher />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() =>
+    expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true }),
+  );
+});
+
+/**
+ * 测试逻辑：在已有用户信息且访问公共认证路径时，应重定向到首页以避免重复访问认证页。
+ * 测试步骤：设置 currentUser 为模拟用户，使用 MemoryRouter 从 /login 启动，渲染组件并等待导航行为。
+ */
+test("redirects authenticated visitor away from public auth routes", async () => {
+  currentUser = { id: "user-1" };
+
+  render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <AuthWatcher />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() =>
+    expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }),
+  );
+});

--- a/website/src/components/AuthWatcher/index.jsx
+++ b/website/src/components/AuthWatcher/index.jsx
@@ -1,19 +1,28 @@
-import { useEffect } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { useUser } from '@/context'
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useUser } from "@/context";
+
+const PUBLIC_ROUTES = ["/login", "/register"];
 
 function AuthWatcher() {
-  const { user } = useUser()
-  const navigate = useNavigate()
-  const location = useLocation()
+  const { user } = useUser();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   useEffect(() => {
-    if (!user && location.pathname !== '/login' && location.pathname !== '/register') {
-      navigate('/login', { replace: true })
-    }
-  }, [user, location, navigate])
+    const isPublicRoute = PUBLIC_ROUTES.includes(pathname);
 
-  return null
+    if (!user && !isPublicRoute) {
+      navigate("/login", { replace: true });
+      return;
+    }
+
+    if (user && isPublicRoute) {
+      navigate("/", { replace: true });
+    }
+  }, [user, pathname, navigate]);
+
+  return null;
 }
 
-export default AuthWatcher
+export default AuthWatcher;


### PR DESCRIPTION
## Summary
- centralize the list of public auth routes in `AuthWatcher`
- redirect authenticated users away from public auth pages and unauthenticated visitors to the login screen
- add tests that pin the navigation behaviour for authenticated and anonymous scenarios

## Testing
- npm test -- AuthWatcher *(fails: Node.js OOM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c841f26a088332971375d3c0ad7764