### PR TITLE
Refine TTS API to rely on authenticated session

### DIFF
--- a/website/src/api/tts.js
+++ b/website/src/api/tts.js
@@ -7,20 +7,21 @@ import { apiRequest } from "./client.js";
  * content type, allowing callers to handle 204 responses gracefully.
  */
 export function createTtsApi(request = apiRequest) {
-  const post = (path, { userId, token, ...body }) => {
-    const params = new URLSearchParams({ userId });
-    return request(`${path}?${params.toString()}`, {
+  const post = (path, { token, ...body }) =>
+    request(path, {
       token,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
-  };
 
   const speakWord = (opts) => post(API_PATHS.ttsWord, opts);
   const speakSentence = (opts) => post(API_PATHS.ttsSentence, opts);
-  const fetchVoices = ({ userId, lang, token }) => {
-    const params = new URLSearchParams({ userId, lang });
+  const fetchVoices = ({ lang, token } = {}) => {
+    if (!lang) {
+      throw new Error("Language is required to load voices");
+    }
+    const params = new URLSearchParams({ lang });
     return request(`${API_PATHS.ttsVoices}?${params.toString()}`, { token });
   };
 

--- a/website/src/hooks/__tests__/useTtsPlayer.test.js
+++ b/website/src/hooks/__tests__/useTtsPlayer.test.js
@@ -40,7 +40,7 @@ jest.unstable_mockModule("@/hooks/useApi.js", () => ({
   useApi: () => ({ tts: { speakWord } }),
 }));
 jest.unstable_mockModule("@/store", () => ({
-  useUserStore: (sel) => sel({ user: { id: "1" } }),
+  useUserStore: (sel) => sel({ user: { id: "1", token: "t" } }),
 }));
 
 const { useTtsPlayer } = await import("@/hooks/useTtsPlayer.js");
@@ -69,7 +69,6 @@ describe("useTtsPlayer", () => {
     });
 
     const payload = {
-      userId: "1",
       text: "hi",
       lang: "en",
       voice: "v1",

--- a/website/src/hooks/useTtsPlayer.js
+++ b/website/src/hooks/useTtsPlayer.js
@@ -15,7 +15,7 @@ import { useUserStore } from "@/store";
 export function useTtsPlayer({ scope = "word" } = {}) {
   const api = useApi();
   const tts = api.tts;
-  const userId = useUserStore((s) => s.user?.id);
+  const hasSession = useUserStore((s) => Boolean(s.user?.token));
   const audioRef = useRef(null);
   const urlRef = useRef("");
   const releaseUrl = useCallback(() => {
@@ -72,9 +72,9 @@ export function useTtsPlayer({ scope = "word" } = {}) {
       if (isDev) {
         console.debug("TTS fetch start", { scope, payload });
       }
-      let resp = await fn({ userId, ...payload, shortcut: true });
+      let resp = await fn({ ...payload, shortcut: true });
       if (resp instanceof Response && resp.status === 204) {
-        resp = await fn({ userId, ...payload, shortcut: false });
+        resp = await fn({ ...payload, shortcut: false });
       }
       const data = resp instanceof Response ? await resp.json() : resp;
       if (isDev) {
@@ -82,12 +82,12 @@ export function useTtsPlayer({ scope = "word" } = {}) {
       }
       return data;
     },
-    [tts, scope, userId],
+    [tts, scope],
   );
 
   const play = useCallback(
     async ({ text, lang, voice, speed = 1.0, format = "mp3" }) => {
-      if (!text || !lang || !userId) return;
+      if (!text || !lang || !hasSession) return;
       setLoading(true);
       setError(null);
       try {
@@ -158,7 +158,7 @@ export function useTtsPlayer({ scope = "word" } = {}) {
         setLoading(false);
       }
     },
-    [fetchAudio, scope, userId, releaseUrl],
+    [fetchAudio, scope, hasSession, releaseUrl],
   );
 
   const stop = useCallback(() => {


### PR DESCRIPTION
## Summary
- remove redundant userId query handling in the TTS API helpers and enforce language validation
- refresh the voice selector to fetch based on session state, reset voices when the session is unavailable, and keep cache in sync with subscription changes
- drop userId payload usage in the TTS player hook and align unit tests with the new contract

## Testing
- npx eslint --fix src/api/tts.js src/components/tts/VoiceSelector.jsx src/hooks/__tests__/useTtsPlayer.test.js src/hooks/useTtsPlayer.js
- npx stylelint --fix "src/components/tts/*.css"
- npx prettier -w src/api/tts.js src/components/tts/VoiceSelector.jsx src/hooks/__tests__/useTtsPlayer.test.js src/hooks/useTtsPlayer.js
- npm test -- useTtsPlayer
- mvn spotless:apply (fails: unable to download Maven dependencies – network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68c841ca5fb08332b6d24874646fe1c4