### PR TITLE
Refine TTS voice fetching

### DIFF
--- a/website/src/api/tts.js
+++ b/website/src/api/tts.js
@@ -17,12 +17,19 @@ export function createTtsApi(request = apiRequest) {
 
   const speakWord = (opts) => post(API_PATHS.ttsWord, opts);
   const speakSentence = (opts) => post(API_PATHS.ttsSentence, opts);
-  const fetchVoices = ({ lang, token } = {}) => {
+  const fetchVoices = async ({ lang, token } = {}) => {
     if (!lang) {
       throw new Error("Language is required to load voices");
     }
     const params = new URLSearchParams({ lang });
-    return request(`${API_PATHS.ttsVoices}?${params.toString()}`, { token });
+    const resp = await request(`${API_PATHS.ttsVoices}?${params.toString()}`, {
+      token,
+    });
+    if (!resp || typeof resp !== "object") {
+      return [];
+    }
+    const { options } = resp;
+    return Array.isArray(options) ? options : [];
   };
 
   return { speakWord, speakSentence, fetchVoices };

--- a/website/src/components/tts/VoiceSelector.jsx
+++ b/website/src/components/tts/VoiceSelector.jsx
@@ -34,7 +34,9 @@ export default function VoiceSelector({ lang }) {
     api.tts
       .fetchVoices({ lang })
       .then((list) => {
-        if (!cancelled) setVoices(list);
+        if (!cancelled) {
+          setVoices(Array.isArray(list) ? list : []);
+        }
       })
       .catch((err) => {
         console.error(err);


### PR DESCRIPTION
## Summary
- parse the TTS voices endpoint response and fall back to an empty array when the payload is not usable
- keep the voice selector state resilient to non-array responses while loading voices for the active language

## Testing
- npx eslint --fix src/api/tts.js src/components/tts/VoiceSelector.jsx
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/api/tts.js src/components/tts/VoiceSelector.jsx
- mvn spotless:apply *(fails: unable to reach Maven Central from the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c845c350f0833286ffc85014c2a019