### PR TITLE
Add fallback redirect for unmatched routes

### DIFF
--- a/website/src/components/FallbackRedirect.jsx
+++ b/website/src/components/FallbackRedirect.jsx
@@ -1,0 +1,22 @@
+import { useMemo } from "react";
+import { Navigate } from "react-router-dom";
+import { useUser } from "@/context";
+
+const FALLBACK_ROUTES = Object.freeze({
+  authenticated: "/",
+  unauthenticated: "/login",
+});
+
+function FallbackRedirect() {
+  const { user } = useUser();
+
+  const targetPath = useMemo(
+    () =>
+      user ? FALLBACK_ROUTES.authenticated : FALLBACK_ROUTES.unauthenticated,
+    [user],
+  );
+
+  return <Navigate to={targetPath} replace />;
+}
+
+export default FallbackRedirect;

--- a/website/src/components/index.js
+++ b/website/src/components/index.js
@@ -2,6 +2,7 @@ export { default as Button } from "./ui/Button";
 export { default as ListItem } from "./ui/ListItem";
 export { default as ItemMenu } from "./ui/ItemMenu";
 
+export { default as FallbackRedirect } from "./FallbackRedirect.jsx";
 export { default as Avatar } from "./ui/Avatar";
 export { default as DictionaryEntry } from "./ui/DictionaryEntry";
 export { default as ErrorBoundary } from "./ui/ErrorBoundary";

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -1,34 +1,39 @@
-import { StrictMode, Suspense, lazy, useEffect } from 'react'
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import ErrorBoundary from './components/ui/ErrorBoundary'
-import './styles/index.css'
-import Loader from './components/ui/Loader'
-import AuthWatcher from './components/AuthWatcher'
+import { StrictMode, Suspense, lazy, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import ErrorBoundary from "./components/ui/ErrorBoundary";
+import "./styles/index.css";
+import Loader from "./components/ui/Loader";
+import AuthWatcher from "./components/AuthWatcher";
+import FallbackRedirect from "./components/FallbackRedirect.jsx";
 
-const App = lazy(() => import('./pages/App'))
-const Login = lazy(() => import('./pages/auth/Login'))
-const Register = lazy(() => import('./pages/auth/Register'))
-import { LanguageProvider, ThemeProvider, AppProvider, ApiProvider } from '@/context'
+const App = lazy(() => import("./pages/App"));
+const Login = lazy(() => import("./pages/auth/Login"));
+const Register = lazy(() => import("./pages/auth/Register"));
+import {
+  LanguageProvider,
+  ThemeProvider,
+  AppProvider,
+  ApiProvider,
+} from "@/context";
 
 // eslint-disable-next-line react-refresh/only-export-components
 function ViewportHeightUpdater() {
   useEffect(() => {
     const updateVh = () => {
       document.documentElement.style.setProperty(
-        '--vh',
-        `${window.innerHeight}px`
-      )
-    }
-    updateVh()
-    window.addEventListener('resize', updateVh)
-    return () => window.removeEventListener('resize', updateVh)
-  }, [])
-  return null
+        "--vh",
+        `${window.innerHeight}px`,
+      );
+    };
+    updateVh();
+    window.addEventListener("resize", updateVh);
+    return () => window.removeEventListener("resize", updateVh);
+  }, []);
+  return null;
 }
 
-
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
     <ViewportHeightUpdater />
     <AppProvider>
@@ -42,7 +47,8 @@ createRoot(document.getElementById('root')).render(
                   <Routes>
                     <Route path="/login" element={<Login />} />
                     <Route path="/register" element={<Register />} />
-                    <Route path="*" element={<App />} />
+                    <Route path="/" element={<App />} />
+                    <Route path="*" element={<FallbackRedirect />} />
                   </Routes>
                 </Suspense>
               </ErrorBoundary>
@@ -52,10 +58,10 @@ createRoot(document.getElementById('root')).render(
       </ApiProvider>
     </AppProvider>
   </StrictMode>,
-)
+);
 
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
-  })
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js");
+  });
 }


### PR DESCRIPTION
## Summary
- add a dedicated FallbackRedirect component that routes authenticated users home and guests to the login
- wire the router to serve App at the root path and send unknown paths through the fallback redirect
- expose the redirect component via the components barrel for future reuse

## Testing
- npx eslint --fix src/components/FallbackRedirect.jsx src/main.jsx src/components/index.js
- npx stylelint "src/**/*.{css,scss}" --fix
- npx prettier -w src/components/FallbackRedirect.jsx src/main.jsx src/components/index.js
- mvn spotless:apply *(fails: unable to reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84737cdcc8332ba1de049330fc7e4