### PR TITLE
Add partial update support for user preferences

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/UserPreferenceController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/UserPreferenceController.java
@@ -3,6 +3,7 @@ package com.glancy.backend.controller;
 import com.glancy.backend.config.auth.AuthenticatedUser;
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
+import com.glancy.backend.dto.UserPreferenceUpdateRequest;
 import com.glancy.backend.service.UserPreferenceService;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,18 @@ public class UserPreferenceController {
     ) {
         UserPreferenceResponse resp = userPreferenceService.savePreference(userId, req);
         return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+
+    /**
+     * Partially update stored preferences for the user.
+     */
+    @PatchMapping("/user")
+    public ResponseEntity<UserPreferenceResponse> updatePreference(
+        @AuthenticatedUser Long userId,
+        @RequestBody UserPreferenceUpdateRequest req
+    ) {
+        UserPreferenceResponse resp = userPreferenceService.updatePreference(userId, req);
+        return ResponseEntity.ok(resp);
     }
 
     /**

--- a/backend/src/main/java/com/glancy/backend/dto/UserPreferenceUpdateRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserPreferenceUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.glancy.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.glancy.backend.entity.DictionaryModel;
+import lombok.Data;
+import org.springframework.lang.Nullable;
+
+/**
+ * Request body used when partially updating stored user preferences.
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserPreferenceUpdateRequest {
+
+    @Nullable
+    private String theme;
+
+    @Nullable
+    private String systemLanguage;
+
+    @Nullable
+    private String searchLanguage;
+
+    @Nullable
+    private DictionaryModel dictionaryModel;
+}

--- a/backend/src/main/java/com/glancy/backend/service/UserPreferenceService.java
+++ b/backend/src/main/java/com/glancy/backend/service/UserPreferenceService.java
@@ -2,6 +2,7 @@ package com.glancy.backend.service;
 
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
+import com.glancy.backend.dto.UserPreferenceUpdateRequest;
 import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.UserPreference;
@@ -71,6 +72,35 @@ public class UserPreferenceService {
             .findByUserId(userId)
             .orElseGet(() -> createDefaultPreference(userId));
         return toResponse(pref);
+    }
+
+    /**
+     * Partially update user preferences while preserving unspecified values.
+     */
+    @Transactional
+    public UserPreferenceResponse updatePreference(Long userId, UserPreferenceUpdateRequest req) {
+        log.info("Updating preferences for user {}", userId);
+        UserPreference pref = userPreferenceRepository
+            .findByUserId(userId)
+            .orElseGet(() -> createDefaultPreference(userId));
+
+        if (req.getTheme() != null) {
+            pref.setTheme(req.getTheme());
+        }
+        if (req.getSystemLanguage() != null) {
+            pref.setSystemLanguage(req.getSystemLanguage());
+        }
+        if (req.getSearchLanguage() != null) {
+            pref.setSearchLanguage(req.getSearchLanguage());
+        }
+        if (req.getDictionaryModel() != null) {
+            pref.setDictionaryModel(req.getDictionaryModel());
+        } else if (pref.getDictionaryModel() == null) {
+            pref.setDictionaryModel(DEFAULT_DICTIONARY_MODEL);
+        }
+
+        UserPreference saved = userPreferenceRepository.save(pref);
+        return toResponse(saved);
     }
 
     private UserPreferenceResponse toResponse(UserPreference pref) {

--- a/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
+import com.glancy.backend.dto.UserPreferenceUpdateRequest;
 import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.service.UserPreferenceService;
 import org.junit.jupiter.api.Test;
@@ -82,5 +83,29 @@ class UserPreferenceControllerTest {
             .perform(get("/api/preferences/user").header("X-USER-TOKEN", "tkn"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.userId").value(2L));
+    }
+
+    /**
+     * 测试 updatePreference 接口
+     */
+    @Test
+    void updatePreference() throws Exception {
+        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en", DictionaryModel.DOUBAO);
+        when(userPreferenceService.updatePreference(eq(2L), any(UserPreferenceUpdateRequest.class))).thenReturn(resp);
+
+        UserPreferenceUpdateRequest req = new UserPreferenceUpdateRequest();
+        req.setTheme("dark");
+
+        when(userService.authenticateToken("tkn")).thenReturn(2L);
+
+        mockMvc
+            .perform(
+                patch("/api/preferences/user")
+                    .header("X-USER-TOKEN", "tkn")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.theme").value("dark"));
     }
 }

--- a/backend/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
+import com.glancy.backend.dto.UserPreferenceUpdateRequest;
 import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.entity.User;
+import com.glancy.backend.entity.UserPreference;
 import com.glancy.backend.repository.UserPreferenceRepository;
 import com.glancy.backend.repository.UserRepository;
 import io.github.cdimascio.dotenv.Dotenv;
@@ -88,5 +90,72 @@ class UserPreferenceServiceTest {
         assertEquals("light", fetched.getTheme());
         assertEquals("en", fetched.getSystemLanguage());
         assertEquals(DictionaryModel.DOUBAO, fetched.getDictionaryModel());
+    }
+
+    /**
+     * 测试 updatePreference 仅更新主题时的处理逻辑
+     */
+    @Test
+    void testUpdatePreferenceThemeOnly() {
+        User user = new User();
+        user.setUsername("prefuser3");
+        user.setPassword("pass");
+        user.setEmail("pref3@example.com");
+        user.setPhone("44");
+        userRepository.save(user);
+
+        UserPreferenceRequest req = new UserPreferenceRequest();
+        req.setTheme("light");
+        req.setSystemLanguage("en");
+        req.setSearchLanguage("en");
+        req.setDictionaryModel(DictionaryModel.DOUBAO);
+        userPreferenceService.savePreference(user.getId(), req);
+
+        UserPreference stored = userPreferenceRepository.findByUserId(user.getId()).orElseThrow();
+        stored.setDictionaryModel(null);
+        userPreferenceRepository.save(stored);
+
+        UserPreferenceUpdateRequest updateRequest = new UserPreferenceUpdateRequest();
+        updateRequest.setTheme("dark");
+
+        UserPreferenceResponse updated = userPreferenceService.updatePreference(user.getId(), updateRequest);
+
+        assertEquals("dark", updated.getTheme());
+        assertEquals("en", updated.getSystemLanguage());
+        assertEquals("en", updated.getSearchLanguage());
+        assertEquals(DictionaryModel.DOUBAO, updated.getDictionaryModel());
+    }
+
+    /**
+     * 测试 updatePreference 同时更新多个字段时的处理逻辑
+     */
+    @Test
+    void testUpdatePreferenceMultipleFields() {
+        User user = new User();
+        user.setUsername("prefuser4");
+        user.setPassword("pass");
+        user.setEmail("pref4@example.com");
+        user.setPhone("55");
+        userRepository.save(user);
+
+        UserPreferenceRequest req = new UserPreferenceRequest();
+        req.setTheme("light");
+        req.setSystemLanguage("en");
+        req.setSearchLanguage("en");
+        req.setDictionaryModel(DictionaryModel.DOUBAO);
+        userPreferenceService.savePreference(user.getId(), req);
+
+        UserPreferenceUpdateRequest updateRequest = new UserPreferenceUpdateRequest();
+        updateRequest.setTheme("dark");
+        updateRequest.setSystemLanguage("fr");
+        updateRequest.setSearchLanguage("es");
+        updateRequest.setDictionaryModel(DictionaryModel.DOUBAO);
+
+        UserPreferenceResponse updated = userPreferenceService.updatePreference(user.getId(), updateRequest);
+
+        assertEquals("dark", updated.getTheme());
+        assertEquals("fr", updated.getSystemLanguage());
+        assertEquals("es", updated.getSearchLanguage());
+        assertEquals(DictionaryModel.DOUBAO, updated.getDictionaryModel());
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated DTO for partial user preference updates with optional fields
- expose a PATCH endpoint and service method that update only supplied preference values while defaulting the dictionary model
- cover the new update behaviour with controller and service tests for single-field and multi-field scenarios

## Testing
- mvn spotless:apply *(fails: network unreachable)*
- mvn test *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c84c57b6a88332a0260e7cf4236b30