### PR TITLE
feat: add popover for item menu

### DIFF
--- a/website/src/components/ui/ItemMenu/ItemMenu.jsx
+++ b/website/src/components/ui/ItemMenu/ItemMenu.jsx
@@ -1,16 +1,20 @@
-import { useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import ThemeIcon from "@/components/ui/Icon";
-import { useOutsideToggle } from "@/hooks";
 import useMenuNavigation from "@/hooks/useMenuNavigation.js";
+import Popover from "@/components/ui/Popover/Popover.jsx";
 import { withStopPropagation } from "@/utils/stopPropagation.js";
 import styles from "./ItemMenu.module.css";
 
 function ItemMenu({ onFavorite, onDelete, favoriteLabel, deleteLabel }) {
-  const { open, setOpen, ref: wrapperRef } = useOutsideToggle(false);
+  const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
   const menuRef = useRef(null);
 
   useMenuNavigation(open, menuRef, triggerRef, setOpen);
+
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+  }, []);
 
   const handleTriggerKeyDown = (e) => {
     if (e.key === "ArrowDown" || e.key === "ArrowUp") {
@@ -26,59 +30,68 @@ function ItemMenu({ onFavorite, onDelete, favoriteLabel, deleteLabel }) {
   };
 
   return (
-    <div className={styles.wrapper} ref={wrapperRef}>
+    <div className={styles.wrapper}>
       <button
         type="button"
         className={styles.action}
         aria-haspopup="true"
         aria-expanded={open}
         onClick={withStopPropagation(() => {
-          setOpen(!open);
+          setOpen((current) => !current);
         })}
         onKeyDown={handleTriggerKeyDown}
         ref={triggerRef}
       >
         <ThemeIcon name="ellipsis-vertical" width={16} height={16} />
       </button>
-      {open && (
-        <ul className={styles.menu} role="menu" ref={menuRef}>
-          <li role="menuitem">
-            <button
-              type="button"
-              onClick={withStopPropagation(() => {
-                onFavorite();
-                setOpen(false);
-              })}
-            >
-              <ThemeIcon
-                name="star-solid"
-                width={16}
-                height={16}
-                className={styles.icon}
-              />{" "}
-              {favoriteLabel}
-            </button>
-          </li>
-          <li role="menuitem">
-            <button
-              type="button"
-              className={styles["delete-btn"]}
-              onClick={withStopPropagation(() => {
-                onDelete();
-                setOpen(false);
-              })}
-            >
-              <ThemeIcon
-                name="trash"
-                width={16}
-                height={16}
-                className={styles.icon}
-              />{" "}
-              {deleteLabel}
-            </button>
-          </li>
-        </ul>
-      )}
+      <Popover
+        isOpen={open}
+        anchorRef={triggerRef}
+        onClose={closeMenu}
+        placement="bottom"
+        align="end"
+        offset={4}
+      >
+        {open && (
+          <ul className={styles.menu} role="menu" ref={menuRef}>
+            <li role="menuitem">
+              <button
+                type="button"
+                onClick={withStopPropagation(() => {
+                  onFavorite();
+                  closeMenu();
+                })}
+              >
+                <ThemeIcon
+                  name="star-solid"
+                  width={16}
+                  height={16}
+                  className={styles.icon}
+                />{" "}
+                {favoriteLabel}
+              </button>
+            </li>
+            <li role="menuitem">
+              <button
+                type="button"
+                className={styles["delete-btn"]}
+                onClick={withStopPropagation(() => {
+                  onDelete();
+                  closeMenu();
+                })}
+              >
+                <ThemeIcon
+                  name="trash"
+                  width={16}
+                  height={16}
+                  className={styles.icon}
+                />{" "}
+                {deleteLabel}
+              </button>
+            </li>
+          </ul>
+        )}
+      </Popover>
     </div>
   );
 }

--- a/website/src/components/ui/ItemMenu/ItemMenu.module.css
+++ b/website/src/components/ui/ItemMenu/ItemMenu.module.css
@@ -1,5 +1,4 @@
 .wrapper {
-  position: relative;
   display: inline-block;
 }
 
@@ -12,15 +11,17 @@
 }
 
 .menu {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 4px);
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  box-shadow: 0 2px 8px var(--shadow-color);
-  z-index: var(--z-index-popover);
+  box-shadow: 0 12px 32px var(--shadow-color);
+  min-width: max-content;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .menu button {

--- a/website/src/components/ui/Popover/Popover.jsx
+++ b/website/src/components/ui/Popover/Popover.jsx
@@ -1,0 +1,222 @@
+import { createPortal } from "react-dom";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import styles from "./Popover.module.css";
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+const VIEWPORT_MARGIN = 8;
+
+function clamp(value, min, max) {
+  if (min > max) {
+    return value;
+  }
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function Popover({
+  anchorRef,
+  isOpen,
+  children,
+  onClose,
+  placement = "bottom",
+  align = "start",
+  offset = 8,
+  className,
+  style,
+}) {
+  const contentRef = useRef(null);
+  const frameRef = useRef(null);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const [visible, setVisible] = useState(false);
+
+  const setContentNode = useCallback((node) => {
+    contentRef.current = node;
+  }, []);
+
+  const clearFrame = useCallback(() => {
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
+
+  const applyPosition = useCallback(() => {
+    if (!isOpen || typeof window === "undefined") return;
+
+    const anchorEl = anchorRef?.current;
+    const popoverEl = contentRef.current;
+    if (!anchorEl || !popoverEl) return;
+
+    const anchorRect = anchorEl.getBoundingClientRect();
+    const popRect = popoverEl.getBoundingClientRect();
+
+    let top;
+    let left;
+
+    switch (placement) {
+      case "top":
+        top = anchorRect.top - popRect.height - offset;
+        left = anchorRect.left;
+        break;
+      case "left":
+        top = anchorRect.top;
+        left = anchorRect.left - popRect.width - offset;
+        break;
+      case "right":
+        top = anchorRect.top;
+        left = anchorRect.right + offset;
+        break;
+      case "bottom":
+      default:
+        top = anchorRect.bottom + offset;
+        left = anchorRect.left;
+        break;
+    }
+
+    const horizontalPlacement = placement === "bottom" || placement === "top";
+
+    if (horizontalPlacement) {
+      if (align === "center") {
+        left = anchorRect.left + anchorRect.width / 2 - popRect.width / 2;
+      } else if (align === "end") {
+        left = anchorRect.right - popRect.width;
+      }
+    } else if (align === "center") {
+      top = anchorRect.top + anchorRect.height / 2 - popRect.height / 2;
+    } else if (align === "end") {
+      top = anchorRect.bottom - popRect.height;
+    }
+
+    if (horizontalPlacement) {
+      const minLeft = VIEWPORT_MARGIN;
+      const maxLeft = window.innerWidth - popRect.width - VIEWPORT_MARGIN;
+      left = clamp(left, minLeft, maxLeft);
+    } else {
+      const minTop = VIEWPORT_MARGIN;
+      const maxTop = window.innerHeight - popRect.height - VIEWPORT_MARGIN;
+      top = clamp(top, minTop, maxTop);
+      const minLeft = VIEWPORT_MARGIN;
+      const maxLeft = window.innerWidth - popRect.width - VIEWPORT_MARGIN;
+      left = clamp(left, minLeft, maxLeft);
+    }
+
+    setPosition((prev) => {
+      if (prev.top === top && prev.left === left) {
+        return prev;
+      }
+      return { top, left };
+    });
+    setVisible(true);
+  }, [align, anchorRef, isOpen, offset, placement]);
+
+  const scheduleUpdate = useCallback(() => {
+    if (!isOpen || typeof window === "undefined") return;
+    clearFrame();
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      applyPosition();
+    });
+  }, [applyPosition, clearFrame, isOpen]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!isOpen) return undefined;
+    scheduleUpdate();
+    return () => {
+      clearFrame();
+    };
+  }, [clearFrame, isOpen, scheduleUpdate]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    setVisible(false);
+
+    const handleResize = () => {
+      scheduleUpdate();
+    };
+
+    const handleScroll = () => {
+      scheduleUpdate();
+    };
+
+    const handlePointerDown = (event) => {
+      const anchorEl = anchorRef?.current;
+      const popoverEl = contentRef.current;
+      if (popoverEl?.contains(event.target)) return;
+      if (anchorEl?.contains(event.target)) return;
+      onClose?.();
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose?.();
+      }
+    };
+
+    const anchorEl = anchorRef?.current;
+    const popoverEl = contentRef.current;
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => scheduleUpdate())
+        : null;
+
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", handleScroll, true);
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    if (resizeObserver) {
+      if (anchorEl) resizeObserver.observe(anchorEl);
+      if (popoverEl) resizeObserver.observe(popoverEl);
+    }
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", handleScroll, true);
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+      resizeObserver?.disconnect();
+    };
+  }, [anchorRef, isOpen, onClose, scheduleUpdate]);
+
+  useEffect(() => () => clearFrame(), [clearFrame]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setVisible(false);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+  if (typeof document === "undefined") return null;
+
+  const classNames = [styles.popover, className].filter(Boolean).join(" ");
+  const inlineStyles = {
+    top: `${position.top}px`,
+    left: `${position.left}px`,
+    ...style,
+  };
+
+  return createPortal(
+    <div
+      ref={setContentNode}
+      className={classNames}
+      data-visible={visible}
+      style={inlineStyles}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}
+
+export default Popover;

--- a/website/src/components/ui/Popover/Popover.module.css
+++ b/website/src/components/ui/Popover/Popover.module.css
@@ -1,0 +1,13 @@
+.popover {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: var(--z-index-popover);
+  display: block;
+  min-width: 0;
+  will-change: top, left;
+}
+
+.popover[data-visible="false"] {
+  visibility: hidden;
+}


### PR DESCRIPTION
## Summary
- add a reusable Popover component that renders into document.body and keeps its position in sync with layout changes
- refactor ItemMenu to use the Popover for portal-based rendering and update menu styling to respect intrinsic width

## Testing
- npx eslint --fix src/components/ui/ItemMenu/ItemMenu.jsx src/components/ui/Popover/Popover.jsx
- npx stylelint "src/components/ui/ItemMenu/ItemMenu.module.css" --fix
- npx prettier -w src/components/ui/ItemMenu/ItemMenu.jsx src/components/ui/ItemMenu/ItemMenu.module.css src/components/ui/Popover/Popover.jsx src/components/ui/Popover/Popover.module.css
- mvn spotless:apply *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c9334aa4fc8332ab3631da88adb66c