### PR TITLE
Refine sidebar spacing variables

### DIFF
--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -1,11 +1,17 @@
 .sidebar-section {
-  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sidebar-item-gap, 4px);
+  padding-inline: var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
 }
 
 .sidebar-section ul {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sidebar-item-gap, 4px);
 }
 
 .sidebar-section select {
@@ -16,9 +22,9 @@
   margin-top: auto;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sidebar-brand-gap, 8px);
   height: var(--bar-height);
-  padding: 0 20px;
+  padding: 0 var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
   position: sticky;
   bottom: 0;
   background: inherit;
@@ -35,7 +41,7 @@
 .sidebar-user .user-menu button.with-name {
   width: var(--user-menu-width);
   justify-content: flex-start;
-  padding: 8px 0;
+  padding: var(--sidebar-item-padding-y, 8px) 0;
   color: inherit;
 }
 
@@ -59,6 +65,7 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  gap: var(--sidebar-section-gap, 24px);
 }
 
 .history-list {
@@ -67,14 +74,7 @@
 }
 
 .history-list li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 4px 0;
-  padding-left: 8px;
-  position: relative;
-  border-radius: 4px;
-  cursor: pointer;
+  padding: var(--sidebar-item-padding, 8px 16px);
 }
 
 .history-list li:hover {
@@ -85,17 +85,17 @@
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .history-list li:hover {
+:root[data-theme="dark"] .history-list li:hover {
   background-color: var(--color-overlay-inverse);
 }
 
-:root[data-theme='dark'] .sidebar-user .user-menu li:hover {
+:root[data-theme="dark"] .sidebar-user .user-menu li:hover {
   background-color: var(--color-overlay-inverse);
 }
 
 .sidebar-user .user-menu button.with-name:hover {
   background-color: var(--color-overlay-inverse);
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
 }
 
 .favorites-list ul {
@@ -104,20 +104,25 @@
   margin: 0;
   overflow-y: auto;
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sidebar-item-gap, 4px);
 }
 
 .collection-button {
   cursor: pointer;
   user-select: none;
-  padding: 4px 0;
-  padding-left: 8px;
-  border-radius: 4px;
+  padding: var(--sidebar-item-padding, 8px 16px);
+  border-radius: var(--radius-sm, 4px);
+  display: flex;
+  align-items: center;
+  gap: var(--sidebar-brand-gap, 8px);
 }
 
 .collection-button:hover {
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .collection-button:hover {
+:root[data-theme="dark"] .collection-button:hover {
   background-color: var(--color-overlay-inverse);
 }

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -1,11 +1,23 @@
 .sidebar {
+  --sidebar-padding: calc(var(--space-4, 24px) - var(--space-1, 4px));
+  --sidebar-inline-padding: var(--sidebar-padding);
+  --sidebar-section-gap: var(--space-4, 24px);
+  --sidebar-item-gap: var(--space-1, 4px);
+  --sidebar-brand-gap: var(--space-2, 8px);
+  --sidebar-item-padding-y: var(--space-2, 8px);
+  --sidebar-item-padding-x: var(--space-3, 16px);
+  --sidebar-item-padding: var(--sidebar-item-padding-y)
+    var(--sidebar-item-padding-x);
+
   width: 240px;
   height: var(--vh);
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
-  padding: 20px;
+  padding-block: var(--sidebar-padding);
+  padding-inline: 0;
   display: flex;
   flex-direction: column;
+  gap: var(--sidebar-section-gap);
   position: sticky;
   top: 0;
   align-self: start;
@@ -20,12 +32,13 @@
   top: 0;
   height: var(--bar-height);
   background: inherit;
-  padding: 0 20px;
+  padding: 0 var(--sidebar-inline-padding);
 }
 
 .brand-main {
   display: flex;
   align-items: center;
+  gap: var(--sidebar-brand-gap);
   cursor: pointer;
 }
 
@@ -36,7 +49,6 @@
 .sidebar-brand img {
   width: 32px;
   height: 32px;
-  margin-right: 8px;
 }
 
 .sidebar-brand span {


### PR DESCRIPTION
## Summary
- define reusable sidebar spacing custom properties and apply them to the brand header
- adopt shared gap and padding variables across sidebar sections to align history, favorites, and user areas

## Testing
- `npm run lint -- --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src`
- `mvn spotless:apply` *(fails: unable to resolve Spring Boot dependencies without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68c9334bf3cc8332bdf28973139a102d