### PR TITLE
Adjust sidebar item padding

### DIFF
--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -74,7 +74,9 @@
 }
 
 .history-list li {
-  padding: var(--sidebar-item-padding, 8px 16px);
+  padding-block: var(--sidebar-item-padding-y, 8px);
+  padding-inline-start: 0;
+  padding-inline-end: var(--sidebar-item-padding-x, 16px);
 }
 
 .history-list li:hover {
@@ -112,7 +114,9 @@
 .collection-button {
   cursor: pointer;
   user-select: none;
-  padding: var(--sidebar-item-padding, 8px 16px);
+  padding-block: var(--sidebar-item-padding-y, 8px);
+  padding-inline-start: 0;
+  padding-inline-end: var(--sidebar-item-padding-x, 16px);
   border-radius: var(--radius-sm, 4px);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- adjust sidebar history list item padding to remove the left inset while keeping consistent vertical spacing
- align collection button padding with the sidebar spacing tokens for symmetry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9431f9df88332a62fbd90a45c7846