### PR TITLE
refactor: centralize history loading

### DIFF
--- a/website/src/components/Sidebar/HistoryList.jsx
+++ b/website/src/components/Sidebar/HistoryList.jsx
@@ -1,46 +1,41 @@
-import { useEffect } from 'react'
-import { useHistory, useFavorites, useUser } from '@/context'
-import { useLanguage } from '@/context'
-import ListItem from '@/components/ui/ListItem'
-import ItemMenu from '@/components/ui/ItemMenu'
-import styles from './Sidebar.module.css'
+import { useHistory, useFavorites, useUser } from "@/context";
+import { useLanguage } from "@/context";
+import ListItem from "@/components/ui/ListItem";
+import ItemMenu from "@/components/ui/ItemMenu";
+import styles from "./Sidebar.module.css";
 
 function HistoryList({ onSelect }) {
-  const { history, loadHistory, removeHistory, favoriteHistory } = useHistory()
-  const { toggleFavorite } = useFavorites()
-  const { user } = useUser()
-  const { t } = useLanguage()
+  const { history, removeHistory, favoriteHistory } = useHistory();
+  const { toggleFavorite } = useFavorites();
+  const { user } = useUser();
+  const { t } = useLanguage();
 
-  useEffect(() => {
-    loadHistory(user)
-  }, [user, loadHistory])
-
-  if (history.length === 0) return null
+  if (history.length === 0) return null;
 
   return (
-    <div className={`${styles['sidebar-section']} ${styles['history-list']}`}>
+    <div className={`${styles["sidebar-section"]} ${styles["history-list"]}`}>
       <ul>
         {history.map((h, i) => (
           <ListItem
             key={i}
             text={h}
             onClick={() => onSelect && onSelect(h)}
-            actions={(
+            actions={
               <ItemMenu
                 favoriteLabel={t.favoriteAction}
                 deleteLabel={t.deleteAction}
                 onFavorite={() => {
-                  favoriteHistory(h, user)
-                  toggleFavorite(h)
+                  favoriteHistory(h, user);
+                  toggleFavorite(h);
                 }}
                 onDelete={() => removeHistory(h, user)}
               />
-            )}
+            }
           />
         ))}
       </ul>
     </div>
-  )
+  );
 }
 
-export default HistoryList
+export default HistoryList;


### PR DESCRIPTION
## Summary
- remove the duplicate history loading effect from the sidebar list so the app-level store load drives updates

## Testing
- npx eslint --fix src
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/Sidebar/HistoryList.jsx
- ./mvnw spotless:apply *(fails: network is unreachable when downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68c941fff6088332a73636858c44f63c