### PR TITLE
Adjust ListItem actions hover visibility

### DIFF
--- a/website/src/components/ui/ListItem/ListItem.module.css
+++ b/website/src/components/ui/ListItem/ListItem.module.css
@@ -1,5 +1,5 @@
-@import url('@/theme/spacing.css');
-@import url('@/theme/variables.css');
+@import url("@/theme/spacing.css");
+@import url("@/theme/variables.css");
 
 .item {
   display: flex;
@@ -15,7 +15,7 @@
   background-color: var(--color-overlay-weak);
 }
 
-:root[data-theme='dark'] .item:hover {
+:root[data-theme="dark"] .item:hover {
   background-color: var(--color-overlay-inverse);
 }
 
@@ -28,4 +28,13 @@
   align-items: center;
   gap: var(--space-1);
   position: relative;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.item:hover .actions,
+.item:focus-within .actions {
+  opacity: 1;
+  pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- fade ListItem action controls in only when the row is hovered or focused to keep the layout calm

## Testing
- npx eslint --fix src/components/ui/ListItem/ListItem.jsx
- npx stylelint --fix src/components/ui/ListItem/ListItem.module.css
- npx prettier -w src/components/ui/ListItem/ListItem.module.css
- mvn spotless:apply *(fails: unable to reach Maven Central to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c9431fad248332b2f0c9ae977b424b