### PR TITLE
Handle auth errors in history store

### DIFF
--- a/website/src/components/Sidebar/HistoryList.jsx
+++ b/website/src/components/Sidebar/HistoryList.jsx
@@ -1,46 +1,65 @@
-import { useEffect } from 'react'
-import { useHistory, useFavorites, useUser } from '@/context'
-import { useLanguage } from '@/context'
-import ListItem from '@/components/ui/ListItem'
-import ItemMenu from '@/components/ui/ItemMenu'
-import styles from './Sidebar.module.css'
+import { useEffect } from "react";
+import { useHistory, useFavorites, useUser } from "@/context";
+import { useLanguage } from "@/context";
+import ListItem from "@/components/ui/ListItem";
+import ItemMenu from "@/components/ui/ItemMenu";
+import Toast from "@/components/ui/Toast";
+import styles from "./Sidebar.module.css";
 
 function HistoryList({ onSelect }) {
-  const { history, loadHistory, removeHistory, favoriteHistory } = useHistory()
-  const { toggleFavorite } = useFavorites()
-  const { user } = useUser()
-  const { t } = useLanguage()
+  const {
+    history,
+    loadHistory,
+    removeHistory,
+    favoriteHistory,
+    error,
+    clearError,
+  } = useHistory();
+  const { toggleFavorite } = useFavorites();
+  const { user } = useUser();
+  const { t } = useLanguage();
 
   useEffect(() => {
-    loadHistory(user)
-  }, [user, loadHistory])
-
-  if (history.length === 0) return null
+    if (!user?.token) return;
+    loadHistory(user);
+  }, [user, loadHistory]);
 
   return (
-    <div className={`${styles['sidebar-section']} ${styles['history-list']}`}>
-      <ul>
-        {history.map((h, i) => (
-          <ListItem
-            key={i}
-            text={h}
-            onClick={() => onSelect && onSelect(h)}
-            actions={(
-              <ItemMenu
-                favoriteLabel={t.favoriteAction}
-                deleteLabel={t.deleteAction}
-                onFavorite={() => {
-                  favoriteHistory(h, user)
-                  toggleFavorite(h)
-                }}
-                onDelete={() => removeHistory(h, user)}
+    <>
+      {history.length > 0 && (
+        <div
+          className={`${styles["sidebar-section"]} ${styles["history-list"]}`}
+        >
+          <ul>
+            {history.map((h, i) => (
+              <ListItem
+                key={i}
+                text={h}
+                onClick={() => onSelect && onSelect(h)}
+                actions={
+                  <ItemMenu
+                    favoriteLabel={t.favoriteAction}
+                    deleteLabel={t.deleteAction}
+                    onFavorite={() => {
+                      favoriteHistory(h, user);
+                      toggleFavorite(h);
+                    }}
+                    onDelete={() => removeHistory(h, user)}
+                  />
+                }
               />
-            )}
-          />
-        ))}
-      </ul>
-    </div>
-  )
+            ))}
+          </ul>
+        </div>
+      )}
+      <Toast
+        open={!!error}
+        message={error || ""}
+        onClose={clearError}
+        duration={5000}
+      />
+    </>
+  );
 }
 
-export default HistoryList
+export default HistoryList;


### PR DESCRIPTION
## Summary
- guard history loading in the sidebar behind a token check and surface store errors with a toast
- clear the persisted history state and user session when history APIs return 401s, and add a helper to dismiss errors

## Testing
- npx eslint --fix src/components/Sidebar/HistoryList.jsx src/store/historyStore.ts
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/Sidebar/HistoryList.jsx src/store/historyStore.ts
- mvn spotless:apply *(fails: unable to reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68c9420113ac833284ee4324de56b835