### PR TITLE
Handle unauthorized logout and refresh history

### DIFF
--- a/website/src/context/ApiContext.jsx
+++ b/website/src/context/ApiContext.jsx
@@ -1,16 +1,53 @@
-import { createContext, useContext, useMemo } from 'react'
-import { useUser } from './AppContext.jsx'
-import { createApi } from '@/api/index.js'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import { useNavigate } from "react-router-dom";
+import { useUser } from "./AppContext.jsx";
+import { createApi } from "@/api/index.js";
+import { resetClientSessionState } from "@/session/sessionLifecycle.js";
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const ApiContext = createContext(createApi())
+export const ApiContext = createContext(createApi());
 
 export function ApiProvider({ children }) {
-  const { user, clearUser } = useUser()
-  const token = user?.token
-  const api = useMemo(() => createApi({ token, onUnauthorized: clearUser }), [token, clearUser])
-  return <ApiContext.Provider value={api}>{children}</ApiContext.Provider>
+  const { user, clearUser } = useUser();
+  const token = user?.token;
+  const navigate = useNavigate();
+  const hasHandledUnauthorizedRef = useRef(false);
+
+  useEffect(() => {
+    hasHandledUnauthorizedRef.current = false;
+  }, [token]);
+
+  const handleUnauthorized = useCallback(() => {
+    if (hasHandledUnauthorizedRef.current) return;
+
+    hasHandledUnauthorizedRef.current = true;
+    resetClientSessionState();
+    clearUser();
+
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.clear();
+      } catch (error) {
+        console.error("Failed to clear local storage during logout", error);
+      }
+    }
+
+    navigate("/login", { replace: true });
+  }, [clearUser, navigate]);
+
+  const api = useMemo(
+    () => createApi({ token, onUnauthorized: handleUnauthorized }),
+    [token, handleUnauthorized],
+  );
+  return <ApiContext.Provider value={api}>{children}</ApiContext.Provider>;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const useApiContext = () => useContext(ApiContext)
+export const useApiContext = () => useContext(ApiContext);

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -35,12 +35,12 @@ function ViewportHeightUpdater() {
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <ViewportHeightUpdater />
-    <AppProvider>
-      <ApiProvider>
-        <LanguageProvider>
-          <ThemeProvider>
-            <BrowserRouter>
+    <BrowserRouter>
+      <ViewportHeightUpdater />
+      <AppProvider>
+        <ApiProvider>
+          <LanguageProvider>
+            <ThemeProvider>
               <AuthWatcher />
               <ErrorBoundary>
                 <Suspense fallback={<Loader />}>
@@ -52,11 +52,11 @@ createRoot(document.getElementById("root")).render(
                   </Routes>
                 </Suspense>
               </ErrorBoundary>
-            </BrowserRouter>
-          </ThemeProvider>
-        </LanguageProvider>
-      </ApiProvider>
-    </AppProvider>
+            </ThemeProvider>
+          </LanguageProvider>
+        </ApiProvider>
+      </AppProvider>
+    </BrowserRouter>
   </StrictMode>,
 );
 

--- a/website/src/pages/auth/Login/index.jsx
+++ b/website/src/pages/auth/Login/index.jsx
@@ -1,30 +1,32 @@
-import { useNavigate } from 'react-router-dom'
-import { AuthForm } from '@/components'
-import { API_PATHS } from '@/config/api.js'
-import { useUser } from '@/context'
-import { useApi } from '@/hooks'
-import { useLanguage } from '@/context'
-import { validateAccount } from '@/utils/validators.js'
-import { useAuthFormConfig } from '../useAuthFormConfig.js'
+import { useNavigate } from "react-router-dom";
+import { AuthForm } from "@/components";
+import { API_PATHS } from "@/config/api.js";
+import { useUser } from "@/context";
+import { useApi } from "@/hooks";
+import { useLanguage } from "@/context";
+import { validateAccount } from "@/utils/validators.js";
+import { useAuthFormConfig } from "../useAuthFormConfig.js";
+import { hydrateClientSessionState } from "@/session/sessionLifecycle.js";
 
 function Login() {
-  const { setUser } = useUser()
-  const api = useApi()
-  const navigate = useNavigate()
-  const { t } = useLanguage()
+  const { setUser } = useUser();
+  const api = useApi();
+  const navigate = useNavigate();
+  const { t } = useLanguage();
 
   const handleLogin = async ({ account, password, method }) => {
     const data = await api.jsonRequest(API_PATHS.login, {
-      method: 'POST',
-      body: { account, password, method }
-    })
-    setUser(data)
-    navigate('/')
-  }
+      method: "POST",
+      body: { account, password, method },
+    });
+    setUser(data);
+    await hydrateClientSessionState(data);
+    navigate("/");
+  };
 
   const { placeholders, formMethods, methodOrder } = useAuthFormConfig({
-    includeUsername: true
-  })
+    includeUsername: true,
+  });
 
   return (
     <AuthForm
@@ -36,14 +38,12 @@ function Login() {
       formMethods={formMethods}
       methodOrder={methodOrder}
       passwordPlaceholder={(m) =>
-        m === 'username'
-          ? t.passwordPlaceholder
-          : t.passwordOrCodePlaceholder
+        m === "username" ? t.passwordPlaceholder : t.passwordOrCodePlaceholder
       }
-      showCodeButton={(m) => m !== 'username'}
+      showCodeButton={(m) => m !== "username"}
       validateAccount={validateAccount}
     />
-  )
+  );
 }
 
-export default Login
+export default Login;

--- a/website/src/session/sessionLifecycle.js
+++ b/website/src/session/sessionLifecycle.js
@@ -1,0 +1,42 @@
+import {
+  useFavoritesStore,
+  useHistoryStore,
+  useVoiceStore,
+  useWordStore,
+} from "@/store";
+
+function clearHistoryState() {
+  const historyStore = useHistoryStore.getState();
+  if (historyStore?.clearHistory) {
+    historyStore.clearHistory();
+  }
+}
+
+function clearFavoritesState() {
+  useFavoritesStore.setState({ favorites: [] });
+}
+
+function clearWordCache() {
+  const wordStore = useWordStore.getState();
+  wordStore?.clear?.();
+}
+
+function clearVoicePreferences() {
+  useVoiceStore.setState({ voices: {} });
+}
+
+export function resetClientSessionState() {
+  clearHistoryState();
+  clearFavoritesState();
+  clearWordCache();
+  clearVoicePreferences();
+}
+
+export async function hydrateClientSessionState(user) {
+  if (!user?.token) return;
+
+  const historyStore = useHistoryStore.getState();
+  if (historyStore?.loadHistory) {
+    await historyStore.loadHistory(user);
+  }
+}


### PR DESCRIPTION
## Summary
- add a session lifecycle utility to centralize cleanup and rehydration logic
- expand the API context unauthorized handler to reset client state, clear storage, and redirect to login
- ensure the login flow hydrates history data after successful authentication and adjust provider nesting for navigation access

## Testing
- `npx eslint . --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w "src/context/ApiContext.jsx" "src/main.jsx" "src/pages/auth/Login/index.jsx" "src/session/sessionLifecycle.js"`
- `mvn spotless:apply` *(fails: cannot reach Maven Central in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c941fea230833288eae887d96c7e04