### PR TITLE
Handle unauthorized history requests gracefully

### DIFF
--- a/website/src/components/Sidebar/HistoryList.jsx
+++ b/website/src/components/Sidebar/HistoryList.jsx
@@ -1,40 +1,69 @@
+import { useEffect, useState } from "react";
 import { useHistory, useFavorites, useUser } from "@/context";
 import { useLanguage } from "@/context";
 import ListItem from "@/components/ui/ListItem";
 import ItemMenu from "@/components/ui/ItemMenu";
+import Toast from "@/components/ui/Toast";
 import styles from "./Sidebar.module.css";
 
 function HistoryList({ onSelect }) {
-  const { history, removeHistory, favoriteHistory } = useHistory();
+  const { history, removeHistory, favoriteHistory, loadHistory, error } =
+    useHistory();
   const { toggleFavorite } = useFavorites();
   const { user } = useUser();
   const { t } = useLanguage();
+  const [errorMessage, setErrorMessage] = useState("");
 
-  if (history.length === 0) return null;
+  useEffect(() => {
+    if (!user?.token) return;
+    loadHistory(user);
+  }, [user, loadHistory]);
+
+  useEffect(() => {
+    if (!error) return;
+    setErrorMessage(error);
+  }, [error]);
+
+  const handleToastClose = () => {
+    setErrorMessage("");
+  };
+
+  const hasHistory = history.length > 0;
 
   return (
-    <div className={`${styles["sidebar-section"]} ${styles["history-list"]}`}>
-      <ul>
-        {history.map((h, i) => (
-          <ListItem
-            key={i}
-            text={h}
-            onClick={() => onSelect && onSelect(h)}
-            actions={
-              <ItemMenu
-                favoriteLabel={t.favoriteAction}
-                deleteLabel={t.deleteAction}
-                onFavorite={() => {
-                  favoriteHistory(h, user);
-                  toggleFavorite(h);
-                }}
-                onDelete={() => removeHistory(h, user)}
+    <>
+      {hasHistory && (
+        <div
+          className={`${styles["sidebar-section"]} ${styles["history-list"]}`}
+        >
+          <ul>
+            {history.map((h, i) => (
+              <ListItem
+                key={i}
+                text={h}
+                onClick={() => onSelect && onSelect(h)}
+                actions={
+                  <ItemMenu
+                    favoriteLabel={t.favoriteAction}
+                    deleteLabel={t.deleteAction}
+                    onFavorite={() => {
+                      favoriteHistory(h, user);
+                      toggleFavorite(h);
+                    }}
+                    onDelete={() => removeHistory(h, user)}
+                  />
+                }
               />
-            }
-          />
-        ))}
-      </ul>
-    </div>
+            ))}
+          </ul>
+        </div>
+      )}
+      <Toast
+        open={!!errorMessage}
+        message={errorMessage}
+        onClose={handleToastClose}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- guard history loading in the sidebar so it only executes after a valid user token is available and surface store errors via a toast notification
- enhance the history store error handling to clear the session on 401 responses while resetting stale state after successful refreshes

## Testing
- npx eslint src/components/Sidebar/HistoryList.jsx --fix
- npx stylelint "src/components/Sidebar/*.css" --fix
- npx prettier -w src/components/Sidebar/HistoryList.jsx src/store/historyStore.ts
- mvn -f backend/pom.xml spotless:apply *(fails: Maven cannot reach central repository from the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94a7723bc8332ae7fe5c10d831f3d