### PR TITLE
Adjust sidebar list item layout alignment

### DIFF
--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -75,7 +75,7 @@
 
 .history-list li {
   padding-block: var(--sidebar-item-padding-y, 8px);
-  padding-inline: 0 var(--sidebar-item-padding-x, 16px);
+  padding-inline: var(--sidebar-item-padding-y, 8px);
 }
 
 .history-list li:hover {

--- a/website/src/components/ui/ListItem/ListItem.module.css
+++ b/website/src/components/ui/ListItem/ListItem.module.css
@@ -3,7 +3,7 @@
 
 .item {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
@@ -28,6 +28,7 @@
   align-items: center;
   gap: var(--space-1);
   position: relative;
+  margin-left: auto;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;


### PR DESCRIPTION
## Summary
- align list item actions to start with content while allowing action controls to rest at the far edge
- balance horizontal padding on sidebar history entries to match their vertical spacing

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/ui/ListItem/ListItem.module.css src/components/Sidebar/Sidebar.module.css
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68c997894c148332853ea46b80e3570c