### PR TITLE
refactor: standardize avatar corner radius

### DIFF
--- a/website/src/components/Header/Header.module.css
+++ b/website/src/components/Header/Header.module.css
@@ -75,7 +75,7 @@
 .user-menu .avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  border-radius: var(--radius-avatar);
   background: var(--color-surface-alt);
   display: flex;
   align-items: center;

--- a/website/src/components/ui/Avatar/Avatar.module.css
+++ b/website/src/components/ui/Avatar/Avatar.module.css
@@ -1,5 +1,5 @@
 .avatar {
-  border-radius: var(--radius-full, 50%);
+  border-radius: var(--radius-avatar);
   object-fit: cover;
   box-shadow: 0 0 4px var(--shadow-color);
 }

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -58,7 +58,7 @@
 .avatar img {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  border-radius: var(--radius-avatar);
 }
 
 .display {

--- a/website/src/pages/profile/Profile.module.css
+++ b/website/src/pages/profile/Profile.module.css
@@ -9,7 +9,7 @@
 .avatar-area {
   width: 100px;
   height: 100px;
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-avatar);
   overflow: hidden;
   margin-bottom: 8px;
   position: relative;
@@ -24,6 +24,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  border-radius: var(--radius-avatar);
   transition: transform 0.3s;
 }
 
@@ -42,7 +43,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0 0 var(--radius-xl) var(--radius-xl);
+  border-radius: 0 0 var(--radius-avatar) var(--radius-avatar);
   font-size: 0.8rem;
   opacity: 0;
   transition: opacity 0.3s;

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -4,6 +4,7 @@
   --radius-md: 8px;
   --radius-lg: 12px;
   --radius-xl: 20px;
+  --radius-avatar: 12px;
 
   /* search box vertical padding */
   --search-box-padding-y: 12px;


### PR DESCRIPTION
## Summary
- add a dedicated avatar radius token in the theme variables to unify rounded rectangle styling
- update avatar components, header menu, and sidebar avatar image styles to consume the new token
- align profile avatar container and overlay with the shared radius for consistent presentation

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/theme/variables.css src/components/ui/Avatar/Avatar.module.css src/components/Header/Header.module.css src/pages/App/App.css src/pages/profile/Profile.module.css

------
https://chatgpt.com/codex/tasks/task_e_68c99cc33640833288abd7cc90a66dd5