### PR TITLE
feat: add themed favorites icon to sidebar

### DIFF
--- a/website/src/components/Sidebar/Favorites.jsx
+++ b/website/src/components/Sidebar/Favorites.jsx
@@ -1,20 +1,37 @@
-import { useLanguage } from '@/context'
-import styles from './Sidebar.module.css'
+import ThemeIcon from "@/components/ui/Icon";
+import { useLanguage } from "@/context";
+import styles from "./Sidebar.module.css";
+
+const FALLBACK_FAVORITES_LABEL = "Favorites";
+
+const getFavoritesIconAlt = (label, altFromLocale) => altFromLocale || label;
 
 function Favorites({ onToggle }) {
-  const { t } = useLanguage()
+  const { t } = useLanguage();
 
   const handleClick = () => {
-    if (onToggle) onToggle((v) => !v)
-  }
+    if (onToggle) onToggle((v) => !v);
+  };
+
+  const favoritesLabel = t.favorites || FALLBACK_FAVORITES_LABEL;
+  const favoritesIconAlt = getFavoritesIconAlt(
+    favoritesLabel,
+    t.favoritesIconAlt,
+  );
 
   return (
-    <div className={`${styles['sidebar-section']} ${styles['favorites-list']}`}>
-      <h3 className={styles['collection-button']} onClick={handleClick}>
-        {t.favorites || 'Favorites'}
+    <div className={`${styles["sidebar-section"]} ${styles["favorites-list"]}`}>
+      <h3 className={styles["collection-button"]} onClick={handleClick}>
+        <ThemeIcon
+          name="star-solid"
+          alt={favoritesIconAlt}
+          width={16}
+          height={16}
+        />
+        {favoritesLabel}
       </h3>
     </div>
-  )
+  );
 }
 
-export default Favorites
+export default Favorites;


### PR DESCRIPTION
## Summary
- add the shared ThemeIcon to the favorites trigger while keeping the component stateless
- derive localized labels and alt text to keep accessibility aligned with translations

## Testing
- npx prettier -w src/components/Sidebar/Favorites.jsx
- npx eslint --fix src/components/Sidebar/Favorites.jsx
- npx stylelint "src/**/*.css" --fix
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68c99ec770ac83328128e6a5df0c6f18