### PR TITLE
优化认证表单验证码布局

### DIFF
--- a/website/src/components/form/AuthForm.module.css
+++ b/website/src/components/form/AuthForm.module.css
@@ -178,26 +178,37 @@
 }
 
 .password-row {
-  display: flex;
+  --auth-code-button-width: clamp(128px, 32%, 152px);
+
+  display: grid;
   width: 100%;
   max-width: 360px;
-  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) var(--auth-code-button-width);
+  column-gap: var(--space-2);
+  align-items: stretch;
   margin-bottom: 20px;
 }
 
 .password-row .auth-input {
-  flex: 1;
   margin-bottom: 0;
+  width: 100%;
+  min-width: 0;
 }
 
 .code-btn {
-  padding: 12px 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--auth-code-button-width);
+  width: var(--auth-code-button-width);
+  min-height: 48px;
+  padding: 0 var(--space-3);
   border: 1px solid var(--border-color);
   background: var(--input-bg);
   color: var(--app-color);
   border-radius: var(--radius-xl);
   font-size: 14px;
-  width: 96px;
+  white-space: nowrap;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- 在密码输入行引入 `--auth-code-button-width` 并改用 grid 布局，保持整体宽度的同时扩展验证码按钮列
- 调整验证码按钮的最小宽度、内边距与排版约束，确保多语言文案单行展示
- 复核 PasswordInput 容器的 width/min-width 设定以保证组件可收缩

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/form/AuthForm.module.css src/components/ui/PasswordInput/PasswordInput.module.css

------
https://chatgpt.com/codex/tasks/task_e_68c9acba841483328b15f8c7de823b15