### PR TITLE
refactor: streamline auth form header

### DIFF
--- a/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
+++ b/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
@@ -5,12 +5,6 @@ exports[`AuthForm submits valid credentials 1`] = `
   <div
     class="auth-page"
   >
-    <a
-      class="auth-close"
-      href="/"
-    >
-      ×
-    </a>
     <img
       alt="glancy-web"
       class="auth-logo"

--- a/website/src/components/form/AuthForm.jsx
+++ b/website/src/components/form/AuthForm.jsx
@@ -121,9 +121,6 @@ function AuthForm({
 
   return (
     <div className={styles["auth-page"]}>
-      <Link to="/" className={styles["auth-close"]}>
-        ×
-      </Link>
       <ThemeIcon name="glancy-web" className={styles["auth-logo"]} />
       <div className={styles["auth-brand"]}>Glancy</div>
       <MultiLineText as="h1" className={styles["auth-title"]} text={title} />

--- a/website/src/components/form/AuthForm.module.css
+++ b/website/src/components/form/AuthForm.module.css
@@ -258,12 +258,3 @@
   text-decoration: none;
   margin: 0 4px;
 }
-
-.auth-close {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  text-decoration: none;
-  color: var(--text-muted);
-  font-size: 24px;
-}

--- a/website/src/pages/auth/AuthPage.module.css
+++ b/website/src/pages/auth/AuthPage.module.css
@@ -45,12 +45,3 @@
   text-decoration: none;
   margin: 0 4px;
 }
-
-.auth-close {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  text-decoration: none;
-  color: var(--text-muted);
-  font-size: 24px;
-}


### PR DESCRIPTION
## Summary
- remove the redundant close link from the auth form header
- drop the unused `auth-close` styles from form and page css modules
- refresh the auth form snapshot to align with the updated markup

## Testing
- npx eslint --fix src/components/form/AuthForm.jsx
- npx stylelint "src/components/form/AuthForm.module.css" "src/pages/auth/AuthPage.module.css" --fix
- npx prettier -w src/components/form/AuthForm.jsx src/components/form/AuthForm.module.css src/pages/auth/AuthPage.module.css
- npx prettier --parser babel -w src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap

------
https://chatgpt.com/codex/tasks/task_e_68c9acc92d608332b3b8b06ebdbb32d9