### PR TITLE
Adjust AuthForm password layout for code button

### DIFF
--- a/website/src/components/form/AuthForm.jsx
+++ b/website/src/components/form/AuthForm.jsx
@@ -88,6 +88,8 @@ function AuthForm({
         ? passwordPlaceholder(method)
         : passwordPlaceholder;
     const hasCodeButton = showCodeButton(method);
+    const passwordRowClassName =
+      styles[hasCodeButton ? "password-row" : "password-row-single"];
 
     return (
       <form onSubmit={handleSubmit} className={styles["auth-form"]}>
@@ -101,7 +103,7 @@ function AuthForm({
             onChange={(e) => setAccount(e.target.value)}
           />
         )}
-        <div className={styles["password-row"]}>
+        <div className={passwordRowClassName}>
           <PasswordInput
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/website/src/components/form/AuthForm.module.css
+++ b/website/src/components/form/AuthForm.module.css
@@ -177,19 +177,29 @@
     box-shadow 0.3s ease;
 }
 
-.password-row {
-  --auth-code-button-width: clamp(128px, 32%, 152px);
-
-  display: grid;
+.password-row,
+.password-row-single {
   width: 100%;
   max-width: 360px;
-  grid-template-columns: minmax(0, 1fr) var(--auth-code-button-width);
-  column-gap: var(--space-2);
   align-items: stretch;
   margin-bottom: 20px;
 }
 
-.password-row .auth-input {
+.password-row {
+  --auth-code-button-width: clamp(128px, 32%, 152px);
+
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--auth-code-button-width);
+  column-gap: var(--space-2);
+}
+
+.password-row-single {
+  display: flex;
+  flex-direction: column;
+}
+
+.password-row .auth-input,
+.password-row-single .auth-input {
   margin-bottom: 0;
   width: 100%;
   min-width: 0;


### PR DESCRIPTION
## Summary
- switch the password field container class in `AuthForm` based on whether the verification code button is shown
- add CSS module styles for a single-column password row when no code button is rendered to maintain alignment

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68c9b06ed6248332b3b926658501852e