### PR TITLE
feat: prioritize username auth method

### DIFF
--- a/website/src/components/__tests__/AuthForm.test.jsx
+++ b/website/src/components/__tests__/AuthForm.test.jsx
@@ -16,6 +16,7 @@ jest.unstable_mockModule("@/context", () => ({
       loginButton: "Log in",
       registerButton: "Sign up",
       or: "OR",
+      otherLoginOptions: "Other login options",
       notImplementedYet: "Not implemented yet",
       termsOfUse: "Terms of Use",
       privacyPolicy: "Privacy Policy",
@@ -82,6 +83,62 @@ describe("AuthForm", () => {
       iconRegistry["glancy-web"].light,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  /**
+   * Ensures the username method is selected by default whenever it is
+   * part of the available methods, even if other methods precede it or
+   * are flagged as preferred defaults.
+   */
+  test("prioritizes username method when available", () => {
+    render(
+      <MemoryRouter>
+        <AuthForm
+          title="Login"
+          switchText="Have account?"
+          switchLink="/register"
+          onSubmit={jest.fn()}
+          placeholders={{
+            username: "Username",
+            email: "Email",
+            phone: "Phone",
+          }}
+          formMethods={["email", "username", "phone"]}
+          methodOrder={["username", "email", "phone"]}
+          defaultMethod="email"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByPlaceholderText("Username")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Email")).not.toBeInTheDocument();
+  });
+
+  /**
+   * Validates that when the username method is absent, the component
+   * respects the configured default while still falling back to the
+   * first available method if the preferred default is unsupported.
+   */
+  test("falls back to first method when username is unavailable", () => {
+    render(
+      <MemoryRouter>
+        <AuthForm
+          title="Login"
+          switchText="Have account?"
+          switchLink="/register"
+          onSubmit={jest.fn()}
+          placeholders={{
+            email: "Email",
+            phone: "Phone",
+          }}
+          formMethods={["email", "phone"]}
+          methodOrder={["email", "phone"]}
+          defaultMethod="username"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByPlaceholderText("Email")).toBeInTheDocument();
   });
 
   /**

--- a/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
+++ b/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
@@ -68,10 +68,14 @@ exports[`AuthForm submits valid credentials 1`] = `
       </a>
     </div>
     <div
+      aria-label="Other login options"
       class="divider"
+      role="separator"
     >
-      <span>
-        OR
+      <span
+        class="divider-label"
+      >
+        Other login options
       </span>
     </div>
     <div

--- a/website/src/components/form/AuthForm.jsx
+++ b/website/src/components/form/AuthForm.jsx
@@ -22,13 +22,17 @@ const defaultIcons = {
   google: "google",
 };
 
-const resolveInitialMethod = (methods) => {
+const resolveInitialMethod = (methods, preferredDefault) => {
   if (!Array.isArray(methods) || methods.length === 0) {
-    return null;
+    return preferredDefault ?? null;
   }
 
   if (methods.includes(USERNAME_METHOD)) {
     return USERNAME_METHOD;
+  }
+
+  if (preferredDefault && methods.includes(preferredDefault)) {
+    return preferredDefault;
   }
 
   return methods[0] ?? null;
@@ -42,6 +46,7 @@ function AuthForm({
   placeholders = {},
   formMethods = [],
   methodOrder = [],
+  defaultMethod = null,
   validateAccount = () => true,
   passwordPlaceholder = "Password",
   showCodeButton = () => false,
@@ -49,7 +54,9 @@ function AuthForm({
 }) {
   const [account, setAccount] = useState("");
   const [password, setPassword] = useState("");
-  const [method, setMethod] = useState(() => resolveInitialMethod(formMethods));
+  const [method, setMethod] = useState(() =>
+    resolveInitialMethod(formMethods, defaultMethod),
+  );
   const [showNotice, setShowNotice] = useState(false);
   const [noticeMsg, setNoticeMsg] = useState("");
   const { t } = useLanguage();
@@ -59,11 +66,11 @@ function AuthForm({
   useEffect(() => {
     if (formMethods.includes(method)) return;
 
-    const preferredMethod = resolveInitialMethod(formMethods);
+    const preferredMethod = resolveInitialMethod(formMethods, defaultMethod);
     if (preferredMethod !== method) {
       setMethod(preferredMethod);
     }
-  }, [formMethods, method]);
+  }, [formMethods, method, defaultMethod]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/website/src/pages/auth/Login/index.jsx
+++ b/website/src/pages/auth/Login/index.jsx
@@ -24,9 +24,10 @@ function Login() {
     navigate("/");
   };
 
-  const { placeholders, formMethods, methodOrder } = useAuthFormConfig({
-    includeUsername: true,
-  });
+  const { placeholders, formMethods, methodOrder, defaultMethod } =
+    useAuthFormConfig({
+      includeUsername: true,
+    });
 
   return (
     <AuthForm
@@ -37,6 +38,7 @@ function Login() {
       placeholders={placeholders}
       formMethods={formMethods}
       methodOrder={methodOrder}
+      defaultMethod={defaultMethod}
       passwordPlaceholder={(m) =>
         m === "username" ? t.passwordPlaceholder : t.passwordOrCodePlaceholder
       }

--- a/website/src/pages/auth/Register/index.jsx
+++ b/website/src/pages/auth/Register/index.jsx
@@ -1,35 +1,36 @@
-import { useNavigate } from 'react-router-dom'
-import { AuthForm } from '@/components'
-import { API_PATHS } from '@/config/api.js'
-import { useApi } from '@/hooks'
-import { useUser } from '@/context'
-import { useLanguage } from '@/context'
-import { validateAccount } from '@/utils/validators.js'
-import { useAuthFormConfig } from '../useAuthFormConfig.js'
+import { useNavigate } from "react-router-dom";
+import { AuthForm } from "@/components";
+import { API_PATHS } from "@/config/api.js";
+import { useApi } from "@/hooks";
+import { useUser } from "@/context";
+import { useLanguage } from "@/context";
+import { validateAccount } from "@/utils/validators.js";
+import { useAuthFormConfig } from "../useAuthFormConfig.js";
 
 function Register() {
-  const api = useApi()
-  const { setUser } = useUser()
-  const navigate = useNavigate()
-  const { t } = useLanguage()
+  const api = useApi();
+  const { setUser } = useUser();
+  const navigate = useNavigate();
+  const { t } = useLanguage();
 
   const handleRegister = async ({ account, password, method }) => {
     await api.jsonRequest(API_PATHS.register, {
-      method: 'POST',
+      method: "POST",
       body: {
         [method]: account,
-        code: password
-      }
-    })
+        code: password,
+      },
+    });
     const loginData = await api.jsonRequest(API_PATHS.login, {
-      method: 'POST',
-      body: { account, method, password }
-    })
-    setUser(loginData)
-    navigate('/')
-  }
+      method: "POST",
+      body: { account, method, password },
+    });
+    setUser(loginData);
+    navigate("/");
+  };
 
-  const { placeholders, formMethods, methodOrder } = useAuthFormConfig()
+  const { placeholders, formMethods, methodOrder, defaultMethod } =
+    useAuthFormConfig();
 
   return (
     <AuthForm
@@ -40,11 +41,12 @@ function Register() {
       placeholders={placeholders}
       formMethods={formMethods}
       methodOrder={methodOrder}
+      defaultMethod={defaultMethod}
       passwordPlaceholder={() => t.codePlaceholder}
       showCodeButton={() => true}
       validateAccount={validateAccount}
     />
-  )
+  );
 }
 
-export default Register
+export default Register;

--- a/website/src/pages/auth/useAuthFormConfig.js
+++ b/website/src/pages/auth/useAuthFormConfig.js
@@ -4,6 +4,26 @@ const USERNAME_METHOD = "username";
 const PRIMARY_METHODS = Object.freeze(["phone", "email"]);
 const SUPPORTED_SOCIAL_METHODS = Object.freeze(["wechat", "apple", "google"]);
 
+const buildFormMethods = (includeUsername) => {
+  const methods = [...PRIMARY_METHODS];
+
+  if (includeUsername && !methods.includes(USERNAME_METHOD)) {
+    methods.unshift(USERNAME_METHOD);
+  }
+
+  return methods;
+};
+
+const buildMethodOrder = (includeUsername) => {
+  const order = [...PRIMARY_METHODS, ...SUPPORTED_SOCIAL_METHODS];
+
+  if (includeUsername && !order.includes(USERNAME_METHOD)) {
+    order.unshift(USERNAME_METHOD);
+  }
+
+  return order;
+};
+
 export function useAuthFormConfig({ includeUsername = false } = {}) {
   const { t } = useLanguage();
 
@@ -13,16 +33,11 @@ export function useAuthFormConfig({ includeUsername = false } = {}) {
     ...(includeUsername && { username: t.usernamePlaceholder }),
   };
 
-  const baseFormMethods = [...PRIMARY_METHODS];
-  const baseMethodOrder = [...PRIMARY_METHODS, ...SUPPORTED_SOCIAL_METHODS];
+  const formMethods = buildFormMethods(includeUsername);
+  const methodOrder = buildMethodOrder(includeUsername);
+  const defaultMethod = includeUsername
+    ? USERNAME_METHOD
+    : (formMethods[0] ?? null);
 
-  const formMethods = includeUsername
-    ? [USERNAME_METHOD, ...baseFormMethods]
-    : baseFormMethods;
-
-  const methodOrder = includeUsername
-    ? [USERNAME_METHOD, ...baseMethodOrder]
-    : baseMethodOrder;
-
-  return { placeholders, formMethods, methodOrder };
+  return { placeholders, formMethods, methodOrder, defaultMethod };
 }


### PR DESCRIPTION
## Summary
- ensure `useAuthFormConfig` promotes username-based sign-in to the front of the method list and exposes a `defaultMethod`
- update `AuthForm` to respect the preferred default while keeping backward compatibility for existing flows
- adjust login/register consumers and extend AuthForm tests and snapshots to cover the new selection logic

## Testing
- eslint --fix src/components/form/AuthForm.jsx src/components/__tests__/AuthForm.test.jsx src/pages/auth/useAuthFormConfig.js src/pages/auth/Login/index.jsx src/pages/auth/Register/index.jsx
- npx stylelint --fix "src/**/*.{css,scss}"
- npx prettier -w src/components/form/AuthForm.jsx src/components/__tests__/AuthForm.test.jsx src/pages/auth/useAuthFormConfig.js src/pages/auth/Login/index.jsx src/pages/auth/Register/index.jsx
- npm run lint
- npm run lint:css
- npm test -- AuthForm.test.jsx
- NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npx jest --runInBand Login.test.jsx *(fails with OOM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b1b7866083329869f07587f7432c