### PR TITLE
fix: align brand name with locale

### DIFF
--- a/website/src/components/__tests__/AuthForm.test.jsx
+++ b/website/src/components/__tests__/AuthForm.test.jsx
@@ -10,6 +10,7 @@ jest.unstable_mockModule("@/context", () => ({
   useLocale: () => ({ locale: "en-US" }),
   useApiContext: () => ({ request: async () => {} }),
   useLanguage: () => ({
+    lang: "en",
     t: {
       continueButton: "Continue",
       invalidAccount: "Invalid account",
@@ -78,7 +79,7 @@ describe("AuthForm", () => {
         method: "username",
       }),
     );
-    expect(screen.getByAltText("glancy-web")).toHaveAttribute(
+    expect(screen.getByAltText("Glancy")).toHaveAttribute(
       "src",
       iconRegistry["glancy-web"].light,
     );

--- a/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
+++ b/website/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`AuthForm submits valid credentials 1`] = `
     class="auth-page"
   >
     <img
-      alt="glancy-web"
+      alt="Glancy"
       class="auth-logo"
       src="/assets/glancy-web-light.svg"
     />
@@ -29,7 +29,7 @@ exports[`AuthForm submits valid credentials 1`] = `
         value="alice"
       />
       <div
-        class="password-row"
+        class="password-row-single"
       >
         <div
           class="wrapper"

--- a/website/src/components/form/AuthForm.jsx
+++ b/website/src/components/form/AuthForm.jsx
@@ -10,6 +10,7 @@ import ThemeIcon from "@/components/ui/Icon";
 import ICP from "@/components/ui/ICP";
 import PasswordInput from "@/components/ui/PasswordInput";
 import { useLanguage } from "@/context";
+import { getBrandText } from "@/utils";
 
 const USERNAME_METHOD = "username";
 
@@ -54,7 +55,8 @@ function AuthForm({
   showCodeButton = () => false,
   icons = defaultIcons,
 }) {
-  const { t } = useLanguage();
+  const { lang, t } = useLanguage();
+  const brandText = useMemo(() => getBrandText(lang), [lang]);
   const availableFormMethods = useMemo(
     () => (Array.isArray(formMethods) ? formMethods : []),
     [formMethods],
@@ -146,8 +148,12 @@ function AuthForm({
 
   return (
     <div className={styles["auth-page"]}>
-      <ThemeIcon name="glancy-web" className={styles["auth-logo"]} />
-      <div className={styles["auth-brand"]}>Glancy</div>
+      <ThemeIcon
+        name="glancy-web"
+        alt={brandText}
+        className={styles["auth-logo"]}
+      />
+      <div className={styles["auth-brand"]}>{brandText}</div>
       <MultiLineText as="h1" className={styles["auth-title"]} text={title} />
       {renderForm()}
       <div className={styles["auth-switch"]}>

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -74,7 +74,7 @@ export default {
   guest: "游客",
   upgrade: "升级",
   upgradeAvailable: "升级可用",
-  profile: "自定义 Glancy",
+  profile: "自定义格律词典",
   settings: "设置",
   shortcuts: "快捷键",
   logout: "退出登录",


### PR DESCRIPTION
## Summary
- read the current language when rendering the authentication form brand name
- centralize brand text through the locale-aware helper for logo alt text and caption
- update Simplified Chinese copy to consistently use the localized application name

## Testing
- npm run test -- -u AuthForm

------
https://chatgpt.com/codex/tasks/task_e_68ca21f42c64833281a61da243584bc9