### PR TITLE
fix: align logout confirmation copy with glancy branding

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -79,7 +79,7 @@ export default {
   shortcuts: "Shortcuts",
   logout: "Log out",
   logoutConfirmTitle: "Are you sure you want to log out?",
-  logoutConfirmMessage: "Log out of ChatGPT as {email}?",
+  logoutConfirmMessage: "Log out of Glancy as {email}?",
   share: "Share",
   report: "Report",
   shortcutsTitle: "Keyboard Shortcuts",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -79,7 +79,7 @@ export default {
   shortcuts: "快捷键",
   logout: "退出登录",
   logoutConfirmTitle: "确定要退出登录吗？",
-  logoutConfirmMessage: "以 {email} 身份退出 ChatGPT？",
+  logoutConfirmMessage: "以 {email} 身份退出格律词典？",
   share: "分享",
   report: "举报",
   shortcutsTitle: "键盘快捷键",


### PR DESCRIPTION
## Summary
- update the logout confirmation message in English to reference Glancy instead of ChatGPT
- synchronize the Chinese translation to mention 格律词典 for logout confirmation

## Testing
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w src/i18n/common/en.js src/i18n/common/zh.js

------
https://chatgpt.com/codex/tasks/task_e_68ca4b9e3a1883328dd514a53eaafd18