### PR TITLE
feat: 支持 Cookie 授权登录流

### DIFF
--- a/website/src/components/AuthWatcher/index.jsx
+++ b/website/src/components/AuthWatcher/index.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useUser } from "@/context";
+import { useCookieConsentStore } from "@/store";
 
 const PUBLIC_ROUTES = ["/login", "/register"];
 
@@ -8,19 +9,43 @@ function AuthWatcher() {
   const { user } = useUser();
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const requireCookieAccess = useCookieConsentStore(
+    (state) => state.requireCookieAccess,
+  );
+  const synchronizeLoginCookie = useCookieConsentStore(
+    (state) => state.synchronizeLoginCookie,
+  );
+  const hasLoginCookie = useCookieConsentStore((state) => state.hasLoginCookie);
 
   useEffect(() => {
     const isPublicRoute = PUBLIC_ROUTES.includes(pathname);
 
     if (!user && !isPublicRoute) {
-      navigate("/login", { replace: true });
+      let shouldRedirectToLogin = false;
+      if (requireCookieAccess()) {
+        shouldRedirectToLogin = synchronizeLoginCookie();
+      } else {
+        shouldRedirectToLogin = false;
+      }
+      if (shouldRedirectToLogin || hasLoginCookie) {
+        navigate("/login", { replace: true });
+      } else {
+        navigate("/register", { replace: true });
+      }
       return;
     }
 
     if (user && isPublicRoute) {
       navigate("/", { replace: true });
     }
-  }, [user, pathname, navigate]);
+  }, [
+    user,
+    pathname,
+    navigate,
+    hasLoginCookie,
+    requireCookieAccess,
+    synchronizeLoginCookie,
+  ]);
 
   return null;
 }

--- a/website/src/components/CookieConsent/CookieConsent.module.css
+++ b/website/src/components/CookieConsent/CookieConsent.module.css
@@ -1,0 +1,139 @@
+.wrapper {
+  position: fixed;
+  inset-inline: 0;
+  bottom: var(--space-4);
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  z-index: var(--z-index-popover);
+}
+
+.banner {
+  width: min(640px, calc(100% - var(--space-3) * 2));
+  background: color-mix(in srgb, var(--color-surface-alt) 85%, transparent);
+  border-radius: 28px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+  box-shadow: 0 20px 60px
+    color-mix(in srgb, var(--shadow-color) 80%, transparent);
+  backdrop-filter: blur(18px);
+  padding: calc(var(--space-4) + 4px) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  color: var(--color-text);
+  pointer-events: auto;
+  position: relative;
+  overflow: hidden;
+}
+
+.banner::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--highlight-color) 25%, transparent),
+    transparent 45%
+  );
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.banner::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 26px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+  pointer-events: none;
+}
+
+.content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.description {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.notice {
+  font-size: 13px;
+  color: var(--highlight-color);
+  line-height: 1.6;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  position: relative;
+}
+
+.primary {
+  background: var(--primary-bg);
+  color: var(--primary-color);
+  border-radius: 999px;
+  padding: 12px 24px;
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: 0 12px 32px
+    color-mix(in srgb, var(--shadow-color) 60%, transparent);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 44px
+    color-mix(in srgb, var(--shadow-color) 70%, transparent);
+}
+
+.secondary {
+  border-radius: 999px;
+  padding: 12px 24px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 65%, transparent);
+  background: color-mix(in srgb, var(--color-surface-muted) 60%, transparent);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.secondary:hover {
+  border-color: color-mix(in srgb, var(--highlight-color) 55%, transparent);
+  color: var(--color-text);
+}
+
+@media (width <= 600px) {
+  .banner {
+    border-radius: 24px;
+    padding: var(--space-3);
+  }
+
+  .banner::after {
+    border-radius: 22px;
+  }
+
+  .title {
+    font-size: 16px;
+  }
+
+  .description {
+    font-size: 13px;
+  }
+}

--- a/website/src/components/CookieConsent/index.jsx
+++ b/website/src/components/CookieConsent/index.jsx
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import Button from "@/components/ui/Button";
+import { useLanguage } from "@/context";
+import { useCookieConsentStore } from "@/store";
+import styles from "./CookieConsent.module.css";
+
+function CookieConsent() {
+  const { t } = useLanguage();
+  const status = useCookieConsentStore((state) => state.status);
+  const promptVisible = useCookieConsentStore((state) => state.promptVisible);
+  const promptContext = useCookieConsentStore((state) => state.promptContext);
+  const setPromptVisible = useCookieConsentStore(
+    (state) => state.setPromptVisible,
+  );
+  const acceptCookies = useCookieConsentStore((state) => state.acceptCookies);
+  const rejectCookies = useCookieConsentStore((state) => state.rejectCookies);
+  const synchronizeLoginCookie = useCookieConsentStore(
+    (state) => state.synchronizeLoginCookie,
+  );
+
+  useEffect(() => {
+    if (status === "accepted") {
+      synchronizeLoginCookie();
+      return;
+    }
+    if (status === "unknown" && !promptVisible) {
+      setPromptVisible(true, "initial");
+    }
+  }, [status, promptVisible, setPromptVisible, synchronizeLoginCookie]);
+
+  if (!promptVisible) {
+    return null;
+  }
+
+  const description =
+    promptContext === "required"
+      ? t.cookieConsentRequired
+      : t.cookieConsentDescription;
+
+  return (
+    <div className={styles.wrapper} role="dialog" aria-live="polite">
+      <div className={styles.banner}>
+        <div className={styles.content}>
+          <div className={styles.title}>{t.cookieConsentTitle}</div>
+          <div className={styles.description}>{description}</div>
+          <div className={styles.notice}>{t.cookieConsentNotice}</div>
+        </div>
+        <div className={styles.actions}>
+          <Button
+            className={styles.primary}
+            onClick={() => {
+              acceptCookies();
+            }}
+          >
+            {t.cookieConsentAccept}
+          </Button>
+          <Button
+            className={styles.secondary}
+            onClick={() => {
+              rejectCookies();
+            }}
+          >
+            {t.cookieConsentDecline}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CookieConsent;

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -97,4 +97,13 @@ export default {
   deleteAction: "Delete",
   searchPlaceholder: "What are we querying next?",
   inputPlaceholder: "Word, Phrase or Sentence",
+  cookieConsentTitle: "Your privacy, elevated",
+  cookieConsentDescription:
+    "We use cookies to remember trusted devices and tailor your sign-in journey.",
+  cookieConsentRequired:
+    "This feature needs cookies to recall your previous visits. Allow cookies to continue with your saved experience.",
+  cookieConsentNotice:
+    "You can revisit this choice whenever you need. We only use cookies to secure and refine your experience.",
+  cookieConsentAccept: "Allow cookies",
+  cookieConsentDecline: "Maybe later",
 };

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -97,4 +97,13 @@ export default {
   deleteAction: "删除",
   searchPlaceholder: "接下来查询什么？",
   inputPlaceholder: "单词、短语或句子",
+  cookieConsentTitle: "尊重隐私的尊奢体验",
+  cookieConsentDescription:
+    "我们会使用 Cookie 记录已信任的设备，为您定制更顺滑的登录旅程。",
+  cookieConsentRequired:
+    "此功能需要 Cookie 来识别您曾经的访问，请授权后继续享受专属体验。",
+  cookieConsentNotice:
+    "您可以随时重新调整选择，我们仅为安全与体验优化使用 Cookie。",
+  cookieConsentAccept: "同意并继续",
+  cookieConsentDecline: "暂不授权",
 };

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -5,6 +5,7 @@ import ErrorBoundary from "./components/ui/ErrorBoundary";
 import "./styles/index.css";
 import Loader from "./components/ui/Loader";
 import AuthWatcher from "./components/AuthWatcher";
+import CookieConsent from "./components/CookieConsent";
 import FallbackRedirect from "./components/FallbackRedirect.jsx";
 
 const App = lazy(() => import("./pages/App"));
@@ -41,6 +42,7 @@ createRoot(document.getElementById("root")).render(
         <ApiProvider>
           <LanguageProvider>
             <ThemeProvider>
+              <CookieConsent />
               <AuthWatcher />
               <ErrorBoundary>
                 <Suspense fallback={<Loader />}>

--- a/website/src/pages/auth/Login/index.jsx
+++ b/website/src/pages/auth/Login/index.jsx
@@ -7,12 +7,16 @@ import { useLanguage } from "@/context";
 import { validateAccount } from "@/utils/validators.js";
 import { useAuthFormConfig } from "../useAuthFormConfig.js";
 import { hydrateClientSessionState } from "@/session/sessionLifecycle.js";
+import { useCookieConsentStore } from "@/store";
 
 function Login() {
   const { setUser } = useUser();
   const api = useApi();
   const navigate = useNavigate();
   const { t } = useLanguage();
+  const recordLoginCookie = useCookieConsentStore(
+    (state) => state.recordLoginCookie,
+  );
 
   const handleLogin = async ({ account, password, method }) => {
     const data = await api.jsonRequest(API_PATHS.login, {
@@ -20,6 +24,7 @@ function Login() {
       body: { account, password, method },
     });
     setUser(data);
+    recordLoginCookie();
     await hydrateClientSessionState(data);
     navigate("/");
   };

--- a/website/src/pages/auth/Register/index.jsx
+++ b/website/src/pages/auth/Register/index.jsx
@@ -6,12 +6,16 @@ import { useUser } from "@/context";
 import { useLanguage } from "@/context";
 import { validateAccount } from "@/utils/validators.js";
 import { useAuthFormConfig } from "../useAuthFormConfig.js";
+import { useCookieConsentStore } from "@/store";
 
 function Register() {
   const api = useApi();
   const { setUser } = useUser();
   const navigate = useNavigate();
   const { t } = useLanguage();
+  const recordLoginCookie = useCookieConsentStore(
+    (state) => state.recordLoginCookie,
+  );
 
   const handleRegister = async ({ account, password, method }) => {
     await api.jsonRequest(API_PATHS.register, {
@@ -26,6 +30,7 @@ function Register() {
       body: { account, method, password },
     });
     setUser(loginData);
+    recordLoginCookie();
     navigate("/");
   };
 

--- a/website/src/store/__tests__/cookieConsentStore.test.js
+++ b/website/src/store/__tests__/cookieConsentStore.test.js
@@ -1,0 +1,63 @@
+import { act } from "@testing-library/react";
+import { useCookieConsentStore, LOGIN_HISTORY_COOKIE_KEY } from "@/store";
+
+describe("cookieConsentStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie = `${LOGIN_HISTORY_COOKIE_KEY}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    act(() => {
+      useCookieConsentStore.getState().resetConsent();
+    });
+  });
+
+  /**
+   * 测试场景：用户同意使用 Cookie 时，会写入持久化状态并同步已有的登录历史 Cookie。
+   */
+  test("acceptCookies persists consent and reflects existing login cookie", () => {
+    document.cookie = `${LOGIN_HISTORY_COOKIE_KEY}=1; path=/`;
+    act(() => {
+      useCookieConsentStore.getState().acceptCookies();
+    });
+    expect(useCookieConsentStore.getState().status).toBe("accepted");
+    expect(useCookieConsentStore.getState().hasLoginCookie).toBe(true);
+    const persisted = JSON.parse(localStorage.getItem("cookie-consent"));
+    expect(persisted.state.status).toBe("accepted");
+  });
+
+  /**
+   * 测试场景：当功能需要 Cookie 而尚未授权时，会自动唤起底部提示并标记请求来源。
+   */
+  test("requireCookieAccess surfaces prompt when consent is missing", () => {
+    let result = true;
+    act(() => {
+      result = useCookieConsentStore.getState().requireCookieAccess();
+    });
+    expect(result).toBe(false);
+    expect(useCookieConsentStore.getState().promptVisible).toBe(true);
+    expect(useCookieConsentStore.getState().promptContext).toBe("required");
+  });
+
+  /**
+   * 测试场景：只有在用户授权后才会记录登录历史 Cookie，未授权时不会写入。
+   */
+  test("recordLoginCookie respects consent state", () => {
+    expect(document.cookie.includes(LOGIN_HISTORY_COOKIE_KEY)).toBe(false);
+    let recorded = true;
+    act(() => {
+      recorded = useCookieConsentStore.getState().recordLoginCookie();
+    });
+    expect(recorded).toBe(false);
+    expect(document.cookie.includes(LOGIN_HISTORY_COOKIE_KEY)).toBe(false);
+
+    act(() => {
+      useCookieConsentStore.getState().acceptCookies();
+    });
+    act(() => {
+      recorded = useCookieConsentStore.getState().recordLoginCookie();
+    });
+    expect(recorded).toBe(true);
+    expect(document.cookie.includes(`${LOGIN_HISTORY_COOKIE_KEY}=1`)).toBe(
+      true,
+    );
+  });
+});

--- a/website/src/store/cookieConsentStore.ts
+++ b/website/src/store/cookieConsentStore.ts
@@ -1,0 +1,103 @@
+import { createPersistentStore } from "./createPersistentStore.js";
+import { pickState } from "./persistUtils.js";
+import { deleteCookie, hasCookie, setCookie } from "@/utils/cookies.js";
+
+export type CookieConsentStatus = "unknown" | "accepted" | "rejected";
+export type CookiePromptContext = "initial" | "required" | null;
+
+export const COOKIE_CONSENT_STORAGE_KEY = "cookie-consent";
+export const LOGIN_HISTORY_COOKIE_KEY = "glancy_login_history";
+const LOGIN_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+const defaultState = {
+  status: "unknown" as CookieConsentStatus,
+  hasLoginCookie: false,
+  promptVisible: false,
+  promptContext: null as CookiePromptContext,
+};
+
+export interface CookieConsentState {
+  status: CookieConsentStatus;
+  hasLoginCookie: boolean;
+  promptVisible: boolean;
+  promptContext: CookiePromptContext;
+  setPromptVisible: (
+    visible: boolean,
+    context?: Exclude<CookiePromptContext, null>,
+  ) => void;
+  acceptCookies: () => boolean;
+  rejectCookies: () => void;
+  requireCookieAccess: () => boolean;
+  recordLoginCookie: () => boolean;
+  synchronizeLoginCookie: () => boolean;
+  resetConsent: () => void;
+}
+
+function normalizeContext(
+  context: CookiePromptContext,
+): Exclude<CookiePromptContext, null> {
+  return context ?? "initial";
+}
+
+export const useCookieConsentStore = createPersistentStore<CookieConsentState>({
+  key: COOKIE_CONSENT_STORAGE_KEY,
+  initializer: (set, get) => ({
+    ...defaultState,
+    setPromptVisible: (visible, context) => {
+      set((state) => ({
+        promptVisible: visible,
+        promptContext: visible
+          ? normalizeContext(context ?? state.promptContext)
+          : null,
+      }));
+    },
+    acceptCookies: () => {
+      set({ status: "accepted", promptVisible: false, promptContext: null });
+      return get().synchronizeLoginCookie();
+    },
+    rejectCookies: () => {
+      deleteCookie(LOGIN_HISTORY_COOKIE_KEY);
+      set({
+        status: "rejected",
+        hasLoginCookie: false,
+        promptVisible: false,
+        promptContext: null,
+      });
+    },
+    requireCookieAccess: () => {
+      if (get().status === "accepted") {
+        return true;
+      }
+      get().setPromptVisible(true, "required");
+      return false;
+    },
+    recordLoginCookie: () => {
+      if (!get().requireCookieAccess()) {
+        return false;
+      }
+      setCookie(LOGIN_HISTORY_COOKIE_KEY, "1", {
+        maxAge: LOGIN_COOKIE_MAX_AGE,
+        sameSite: "Lax",
+        path: "/",
+      });
+      set({ hasLoginCookie: true });
+      return true;
+    },
+    synchronizeLoginCookie: () => {
+      if (get().status !== "accepted") {
+        set({ hasLoginCookie: false });
+        return false;
+      }
+      const hasHistory = hasCookie(LOGIN_HISTORY_COOKIE_KEY);
+      set({ hasLoginCookie: hasHistory });
+      return hasHistory;
+    },
+    resetConsent: () => {
+      deleteCookie(LOGIN_HISTORY_COOKIE_KEY);
+      set({ ...defaultState });
+    },
+  }),
+  persistOptions: {
+    partialize: pickState(["status"]),
+  },
+});

--- a/website/src/store/index.ts
+++ b/website/src/store/index.ts
@@ -3,4 +3,9 @@ export { useHistoryStore } from "./historyStore.js";
 export { useUserStore } from "./userStore.js";
 export { useVoiceStore } from "./voiceStore.js";
 export { useWordStore } from "./wordStore.js";
+export {
+  useCookieConsentStore,
+  LOGIN_HISTORY_COOKIE_KEY,
+} from "./cookieConsentStore.js";
 export type { User } from "./userStore.js";
+export type { CookieConsentStatus } from "./cookieConsentStore.js";

--- a/website/src/utils/cookies.js
+++ b/website/src/utils/cookies.js
@@ -1,0 +1,59 @@
+const isBrowser = typeof document !== "undefined";
+
+function buildCookieString(name, value, options = {}) {
+  const segments = [`${name}=${value}`];
+
+  if (options.maxAge != null) {
+    segments.push(`Max-Age=${options.maxAge}`);
+  }
+
+  if (options.expires) {
+    segments.push(`Expires=${options.expires.toUTCString()}`);
+  }
+
+  segments.push(`Path=${options.path ?? "/"}`);
+
+  if (options.sameSite) {
+    segments.push(`SameSite=${options.sameSite}`);
+  }
+
+  if (options.secure) {
+    segments.push("Secure");
+  }
+
+  return segments.join("; ");
+}
+
+export function setCookie(name, value, options = {}) {
+  if (!isBrowser) return false;
+  document.cookie = buildCookieString(name, value, options);
+  return true;
+}
+
+export function deleteCookie(name) {
+  if (!isBrowser) return false;
+  document.cookie = buildCookieString(name, "", {
+    expires: new Date(0),
+    path: "/",
+  });
+  return true;
+}
+
+export function hasCookie(name) {
+  if (!isBrowser) return false;
+  return document.cookie
+    .split("; ")
+    .some((cookie) => cookie.startsWith(`${name}=`));
+}
+
+export function getCookie(name) {
+  if (!isBrowser) return null;
+  const cookies = document.cookie.split("; ");
+  for (const cookie of cookies) {
+    const [key, ...rest] = cookie.split("=");
+    if (key === name) {
+      return rest.join("=");
+    }
+  }
+  return null;
+}

--- a/website/src/utils/index.js
+++ b/website/src/utils/index.js
@@ -9,3 +9,4 @@ export { audioManager } from "./audioManager.js";
 export { decodeTtsAudio } from "./audio.js";
 export { createCachedFetcher } from "./cache.js";
 export { parseSse } from "./sse.js";
+export { setCookie, deleteCookie, hasCookie, getCookie } from "./cookies.js";


### PR DESCRIPTION
## Summary
- 新增 CookieConsent 组件与持久化状态，集中管理登录历史 cookie、授权提示与复用逻辑
- 未登录访问受限页面时依据历史 cookie 自动跳转登录或注册页，并在必要时唤起授权弹层
- 登录与注册流程接入 cookie 记录，并补充中英双语提示文案

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .
- npm run lint
- npm run lint:css
- npm test *(已知在现有代码中触发 `cjs-module-lexer` 解析错误)*

------
https://chatgpt.com/codex/tasks/task_e_68ca55478270833283efe0a56d4ab024