### PR TITLE
feat: localize auth code button

### DIFF
--- a/website/src/components/form/CodeButton.jsx
+++ b/website/src/components/form/CodeButton.jsx
@@ -1,34 +1,46 @@
-import { useState, useEffect } from 'react'
-import styles from './AuthForm.module.css'
+import { useState, useEffect, useMemo } from "react";
+import { useLanguage } from "@/context";
+import styles from "./AuthForm.module.css";
 
-// button with 60s countdown after click
+// button with configurable countdown triggered after click
 
-function CodeButton({ onClick }) {
-  const [count, setCount] = useState(0)
+const DEFAULT_IDLE_LABEL = "Get code";
+const DEFAULT_COUNTDOWN_TEMPLATE = "{count}s";
+
+function CodeButton({ onClick, countdownDuration = 60 }) {
+  const [count, setCount] = useState(0);
+  const { t } = useLanguage();
+
+  const buttonIdleLabel = t.codeButtonLabel ?? DEFAULT_IDLE_LABEL;
+  const countdownTemplate = t.codeButtonCountdown ?? DEFAULT_COUNTDOWN_TEMPLATE;
+  const countdownLabel = useMemo(
+    () => countdownTemplate.replace("{count}", count),
+    [count, countdownTemplate],
+  );
 
   useEffect(() => {
-    if (count === 0) return undefined
+    if (count === 0) return undefined;
     const id = setInterval(() => {
-      setCount((c) => c - 1)
-    }, 1000)
-    return () => clearInterval(id)
-  }, [count])
+      setCount((c) => c - 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [count]);
 
   const handleClick = () => {
-    if (onClick) onClick()
-    setCount(60)
-  }
+    if (onClick) onClick();
+    setCount(countdownDuration);
+  };
 
   return (
     <button
       type="button"
-      className={styles['code-btn']}
+      className={styles["code-btn"]}
       disabled={count > 0}
       onClick={handleClick}
     >
-      {count > 0 ? `${count}s` : 'Get code'}
+      {count > 0 ? countdownLabel : buttonIdleLabel}
     </button>
-  )
+  );
 }
 
-export default CodeButton
+export default CodeButton;

--- a/website/src/i18n/auth/en.js
+++ b/website/src/i18n/auth/en.js
@@ -14,6 +14,8 @@ export default {
   passwordPlaceholder: "Password",
   passwordOrCodePlaceholder: "Password / code",
   codePlaceholder: "Code",
+  codeButtonLabel: "Get code",
+  codeButtonCountdown: "{count}s",
   continueButton: "Continue",
   invalidAccount: "Invalid account",
   notImplementedYet: "Not implemented yet",

--- a/website/src/i18n/auth/zh.js
+++ b/website/src/i18n/auth/zh.js
@@ -14,6 +14,8 @@ export default {
   passwordPlaceholder: "密码",
   passwordOrCodePlaceholder: "密码/验证码",
   codePlaceholder: "验证码",
+  codeButtonLabel: "获取验证码",
+  codeButtonCountdown: "{count}秒",
   continueButton: "继续",
   invalidAccount: "账号无效",
   notImplementedYet: "尚未实现",


### PR DESCRIPTION
## Summary
- add localization-aware labels to the authentication code request button
- extend authentication i18n dictionaries with reusable code button copy for English and Chinese

## Testing
- npm run lint -- --fix src/components/form/CodeButton.jsx src/i18n/auth/en.js src/i18n/auth/zh.js
- npm run lint:css -- --fix src/components/form/AuthForm.module.css
- npx prettier -w src/components/form/CodeButton.jsx src/i18n/auth/en.js src/i18n/auth/zh.js

------
https://chatgpt.com/codex/tasks/task_e_68ca5a2f13e8833280fa7c395ea86251