### PR TITLE
Adjust login field labels spacing

### DIFF
--- a/website/src/i18n/auth/en.js
+++ b/website/src/i18n/auth/en.js
@@ -1,6 +1,6 @@
 export default {
   loginTitle: "User Login",
-  account: "Username/Email/Phone:",
+  account: "Username / Email / Phone:",
   username: "Username:",
   password: "Password:",
   confirmPassword: "Confirm Password:",

--- a/website/src/i18n/auth/zh.js
+++ b/website/src/i18n/auth/zh.js
@@ -1,6 +1,6 @@
 export default {
   loginTitle: "用户登录",
-  account: "用户名/邮箱/手机号：",
+  account: "用户名 / 邮箱 / 手机号：",
   username: "用户名：",
   password: "密码：",
   confirmPassword: "确认密码：",
@@ -12,7 +12,7 @@ export default {
   registerCreate: "创建账号",
   registerSwitch: "已有账号？",
   passwordPlaceholder: "密码",
-  passwordOrCodePlaceholder: "密码/验证码",
+  passwordOrCodePlaceholder: "密码 / 验证码",
   codePlaceholder: "验证码",
   codeButtonLabel: "获取验证码",
   codeButtonCountdown: "{count}秒",


### PR DESCRIPTION
## Summary
- add spacing around slashes in Chinese login field labels to align with UI typography guidelines
- mirror slash spacing adjustments in the English login label for cross-language consistency

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/i18n/auth/zh.js src/i18n/auth/en.js

------
https://chatgpt.com/codex/tasks/task_e_68ca6585fdd08332a4539e89421b7d27