### PR TITLE
feat: localize accessibility labels

### DIFF
--- a/website/src/components/tts/PronounceableWord.jsx
+++ b/website/src/components/tts/PronounceableWord.jsx
@@ -1,48 +1,50 @@
-import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import MessagePopup from '@/components/ui/MessagePopup'
-import Toast from '@/components/ui/Toast'
-import UpgradeModal from '@/components/modals/UpgradeModal.jsx'
-import { useTtsPlayer } from '@/hooks/useTtsPlayer.js'
-import { useVoiceStore } from '@/store'
-import { useLanguage } from '@/context'
-import styles from './PronounceableWord.module.css'
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import MessagePopup from "@/components/ui/MessagePopup";
+import Toast from "@/components/ui/Toast";
+import UpgradeModal from "@/components/modals/UpgradeModal.jsx";
+import { useTtsPlayer } from "@/hooks/useTtsPlayer.js";
+import { useVoiceStore } from "@/store";
+import { useLanguage } from "@/context";
+import styles from "./PronounceableWord.module.css";
 
 /**
  * Text element that plays word pronunciation when clicked.
  * Mirrors error handling of TtsButton for consistent UX.
  */
 export default function PronounceableWord({ text, lang, className }) {
-  const navigate = useNavigate()
-  const { t } = useLanguage()
-  const { play, stop, loading, playing, error } = useTtsPlayer({ scope: 'word' })
-  const [toastMsg, setToastMsg] = useState('')
-  const [popupMsg, setPopupMsg] = useState('')
-  const [upgradeOpen, setUpgradeOpen] = useState(false)
+  const navigate = useNavigate();
+  const { t } = useLanguage();
+  const { play, stop, loading, playing, error } = useTtsPlayer({
+    scope: "word",
+  });
+  const [toastMsg, setToastMsg] = useState("");
+  const [popupMsg, setPopupMsg] = useState("");
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
 
   const handleClick = async () => {
-    if (loading) return
+    if (loading) return;
     if (playing) {
-      stop()
-      return
+      stop();
+      return;
     }
-    const voice = useVoiceStore.getState().getVoice(lang)
-    await play({ text, lang, voice })
-  }
+    const voice = useVoiceStore.getState().getVoice(lang);
+    await play({ text, lang, voice });
+  };
 
   useEffect(() => {
-    if (!error) return
+    if (!error) return;
     switch (error.code) {
       case 401:
-        navigate('/login')
-        break
+        navigate("/login");
+        break;
       case 403:
-        setPopupMsg(error.message)
-        break
+        setPopupMsg(error.message);
+        break;
       default:
-        setToastMsg(error.message)
+        setToastMsg(error.message);
     }
-  }, [error, navigate])
+  }, [error, navigate]);
 
   const cls = [
     styles.word,
@@ -51,7 +53,7 @@ export default function PronounceableWord({ text, lang, className }) {
     className,
   ]
     .filter(Boolean)
-    .join(' ')
+    .join(" ");
 
   return (
     <>
@@ -60,29 +62,33 @@ export default function PronounceableWord({ text, lang, className }) {
         tabIndex={0}
         className={cls}
         onClick={handleClick}
-        onKeyDown={(e) => e.key === 'Enter' && handleClick()}
-        aria-label="播放发音"
+        onKeyDown={(e) => e.key === "Enter" && handleClick()}
+        aria-label={t.playWordAudio}
       >
         {text}
       </span>
       <MessagePopup
         open={!!popupMsg}
         message={popupMsg}
-        onClose={() => setPopupMsg('')}
+        onClose={() => setPopupMsg("")}
       >
         <button
           type="button"
-          className={styles['upgrade-btn']}
+          className={styles["upgrade-btn"]}
           onClick={() => {
-            setUpgradeOpen(true)
-            setPopupMsg('')
+            setUpgradeOpen(true);
+            setPopupMsg("");
           }}
         >
           {t.upgrade}
         </button>
       </MessagePopup>
       <UpgradeModal open={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
-      <Toast open={!!toastMsg} message={toastMsg} onClose={() => setToastMsg('')} />
+      <Toast
+        open={!!toastMsg}
+        message={toastMsg}
+        onClose={() => setToastMsg("")}
+      />
     </>
-  )
+  );
 }

--- a/website/src/components/tts/TtsButton.jsx
+++ b/website/src/components/tts/TtsButton.jsx
@@ -1,13 +1,13 @@
-import { useMemo, useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import ThemeIcon from '@/components/ui/Icon'
-import MessagePopup from '@/components/ui/MessagePopup'
-import Toast from '@/components/ui/Toast'
-import UpgradeModal from '@/components/modals/UpgradeModal.jsx'
-import { useTtsPlayer } from '@/hooks/useTtsPlayer.js'
-import { useVoiceStore } from '@/store'
-import { useLanguage } from '@/context'
-import styles from './TtsButton.module.css'
+import { useMemo, useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import ThemeIcon from "@/components/ui/Icon";
+import MessagePopup from "@/components/ui/MessagePopup";
+import Toast from "@/components/ui/Toast";
+import UpgradeModal from "@/components/modals/UpgradeModal.jsx";
+import { useTtsPlayer } from "@/hooks/useTtsPlayer.js";
+import { useVoiceStore } from "@/store";
+import { useLanguage } from "@/context";
+import styles from "./TtsButton.module.css";
 
 /**
  * Unified TTS play button for words and sentences.
@@ -17,30 +17,30 @@ export default function TtsButton({
   text,
   lang,
   voice,
-  scope = 'word',
+  scope = "word",
   size,
   disabled = false,
 }) {
-  const navigate = useNavigate()
-  const { t } = useLanguage()
-  const { play, stop, loading, playing, error } = useTtsPlayer({ scope })
-  const [toastMsg, setToastMsg] = useState('')
-  const [popupMsg, setPopupMsg] = useState('')
-  const [upgradeOpen, setUpgradeOpen] = useState(false)
+  const navigate = useNavigate();
+  const { t } = useLanguage();
+  const { play, stop, loading, playing, error } = useTtsPlayer({ scope });
+  const [toastMsg, setToastMsg] = useState("");
+  const [popupMsg, setPopupMsg] = useState("");
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
   const tooltip = useMemo(
-    () => (scope === 'sentence' ? '播放例句发音' : '播放发音'),
-    [scope],
-  )
+    () => (scope === "sentence" ? t.playSentenceAudio : t.playWordAudio),
+    [scope, t],
+  );
 
   const handleClick = async () => {
-    if (disabled || loading) return
+    if (disabled || loading) return;
     if (playing) {
-      stop()
-      return
+      stop();
+      return;
     }
-    const selectedVoice = voice ?? useVoiceStore.getState().getVoice(lang)
-    await play({ text, lang, voice: selectedVoice })
-  }
+    const selectedVoice = voice ?? useVoiceStore.getState().getVoice(lang);
+    await play({ text, lang, voice: selectedVoice });
+  };
 
   const btnClass = [
     styles.button,
@@ -49,23 +49,23 @@ export default function TtsButton({
     disabled && styles.disabled,
   ]
     .filter(Boolean)
-    .join(' ')
+    .join(" ");
 
-  const iconSize = size || (scope === 'sentence' ? 24 : 20)
+  const iconSize = size || (scope === "sentence" ? 24 : 20);
 
   useEffect(() => {
-    if (!error) return
+    if (!error) return;
     switch (error.code) {
       case 401:
-        navigate('/login')
-        break
+        navigate("/login");
+        break;
       case 403:
-        setPopupMsg(error.message)
-        break
+        setPopupMsg(error.message);
+        break;
       default:
-        setToastMsg(error.message)
+        setToastMsg(error.message);
     }
-  }, [error, navigate])
+  }, [error, navigate]);
 
   return (
     <>
@@ -82,21 +82,25 @@ export default function TtsButton({
       <MessagePopup
         open={!!popupMsg}
         message={popupMsg}
-        onClose={() => setPopupMsg('')}
+        onClose={() => setPopupMsg("")}
       >
         <button
           type="button"
-          className={styles['upgrade-btn']}
+          className={styles["upgrade-btn"]}
           onClick={() => {
-            setUpgradeOpen(true)
-            setPopupMsg('')
+            setUpgradeOpen(true);
+            setPopupMsg("");
           }}
         >
           {t.upgrade}
         </button>
       </MessagePopup>
       <UpgradeModal open={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
-      <Toast open={!!toastMsg} message={toastMsg} onClose={() => setToastMsg('')} />
+      <Toast
+        open={!!toastMsg}
+        message={toastMsg}
+        onClose={() => setToastMsg("")}
+      />
     </>
-  )
+  );
 }

--- a/website/src/components/tts/__tests__/PronounceableWord.test.jsx
+++ b/website/src/components/tts/__tests__/PronounceableWord.test.jsx
@@ -1,33 +1,40 @@
 /* eslint-env jest */
-import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
-import { jest } from '@jest/globals'
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { jest } from "@jest/globals";
 
 // mock hooks and UI components to isolate pronunciation behavior
-const play = jest.fn()
-const stop = jest.fn()
+const play = jest.fn();
+const stop = jest.fn();
 const useTtsPlayer = jest.fn(() => ({
   play,
   stop,
   loading: false,
   playing: false,
   error: null,
-}))
+}));
 
-jest.unstable_mockModule('@/hooks/useTtsPlayer.js', () => ({ useTtsPlayer }))
+jest.unstable_mockModule("@/hooks/useTtsPlayer.js", () => ({ useTtsPlayer }));
 
-const navigate = jest.fn()
-jest.unstable_mockModule('react-router-dom', () => ({ useNavigate: () => navigate }))
+const navigate = jest.fn();
+jest.unstable_mockModule("react-router-dom", () => ({
+  useNavigate: () => navigate,
+}));
 
-jest.unstable_mockModule('@/context', () => ({
-  useLanguage: () => ({ t: { upgrade: '升级' } }),
+jest.unstable_mockModule("@/context", () => ({
+  useLanguage: () => ({
+    t: {
+      upgrade: "升级",
+      playWordAudio: "Play word audio",
+    },
+  }),
   useApiContext: () => ({}),
-  useTheme: () => ({ resolvedTheme: 'light' }),
-  useLocale: () => ({ locale: 'en-US' }),
+  useTheme: () => ({ resolvedTheme: "light" }),
+  useLocale: () => ({ locale: "en-US" }),
   useAppContext: () => ({}),
-}))
+}));
 
-jest.unstable_mockModule('@/components/ui/MessagePopup', () => ({
+jest.unstable_mockModule("@/components/ui/MessagePopup", () => ({
   __esModule: true,
   default: ({ open, message, children }) =>
     open ? (
@@ -36,75 +43,97 @@ jest.unstable_mockModule('@/components/ui/MessagePopup', () => ({
         {children}
       </div>
     ) : null,
-}))
+}));
 
-jest.unstable_mockModule('@/components/ui/Toast', () => ({
+jest.unstable_mockModule("@/components/ui/Toast", () => ({
   __esModule: true,
   default: ({ open, message }) => (open ? <div>{message}</div> : null),
-}))
+}));
 
-jest.unstable_mockModule('@/components/modals/UpgradeModal.jsx', () => ({
+jest.unstable_mockModule("@/components/modals/UpgradeModal.jsx", () => ({
   __esModule: true,
   default: () => null,
-}))
+}));
 
-const { default: PronounceableWord } = await import('@/components/tts/PronounceableWord.jsx')
+const { default: PronounceableWord } = await import(
+  "@/components/tts/PronounceableWord.jsx"
+);
 
-describe('PronounceableWord', () => {
+describe("PronounceableWord", () => {
   afterEach(() => {
-    play.mockReset()
-    stop.mockReset()
-    useTtsPlayer.mockClear()
-  })
+    play.mockReset();
+    stop.mockReset();
+    useTtsPlayer.mockClear();
+  });
 
   /**
    * Clicking text invokes play with provided parameters.
    */
-  test('invokes play on click', () => {
-    const { getByText } = render(<PronounceableWord text="hello" lang="en" />)
-    fireEvent.click(getByText('hello'))
-    expect(play).toHaveBeenCalledWith({ text: 'hello', lang: 'en', voice: undefined })
-  })
+  test("invokes play on click", () => {
+    const { getByText } = render(<PronounceableWord text="hello" lang="en" />);
+    fireEvent.click(getByText("hello"));
+    expect(play).toHaveBeenCalledWith({
+      text: "hello",
+      lang: "en",
+      voice: undefined,
+    });
+  });
 
   /**
    * When already playing, click stops playback.
    */
-  test('stops when playing', () => {
-    useTtsPlayer.mockReturnValueOnce({ play, stop, loading: false, playing: true, error: null })
-    const { getByText } = render(<PronounceableWord text="hi" lang="en" />)
-    fireEvent.click(getByText('hi'))
-    expect(stop).toHaveBeenCalled()
-    expect(play).not.toHaveBeenCalled()
-  })
+  test("stops when playing", () => {
+    useTtsPlayer.mockReturnValueOnce({
+      play,
+      stop,
+      loading: false,
+      playing: true,
+      error: null,
+    });
+    const { getByText } = render(<PronounceableWord text="hi" lang="en" />);
+    fireEvent.click(getByText("hi"));
+    expect(stop).toHaveBeenCalled();
+    expect(play).not.toHaveBeenCalled();
+  });
 
   /**
    * Forbidden errors show upgrade popup.
    */
-  test('renders upgrade popup on 403 error', async () => {
+  test("renders upgrade popup on 403 error", async () => {
     useTtsPlayer.mockReturnValueOnce({
       play,
       stop,
       loading: false,
       playing: false,
-      error: { code: 403, message: 'Pro only' },
-    })
-    const { findByText } = render(<PronounceableWord text="hi" lang="en" />)
-    expect(await findByText('Pro only')).toBeInTheDocument()
-    expect(await findByText('升级')).toBeInTheDocument()
-  })
+      error: { code: 403, message: "Pro only" },
+    });
+    const { findByText } = render(<PronounceableWord text="hi" lang="en" />);
+    expect(await findByText("Pro only")).toBeInTheDocument();
+    expect(await findByText("升级")).toBeInTheDocument();
+  });
 
   /**
    * Rate limit errors render toast.
    */
-  test('renders toast on 429 error', async () => {
+  test("renders toast on 429 error", async () => {
     useTtsPlayer.mockReturnValueOnce({
       play,
       stop,
       loading: false,
       playing: false,
-      error: { code: 429, message: 'Too many' },
-    })
-    const { findByText } = render(<PronounceableWord text="hi" lang="en" />)
-    expect(await findByText('Too many')).toBeInTheDocument()
-  })
-})
+      error: { code: 429, message: "Too many" },
+    });
+    const { findByText } = render(<PronounceableWord text="hi" lang="en" />);
+    expect(await findByText("Too many")).toBeInTheDocument();
+  });
+
+  /**
+   * Localized aria-label remains accessible via translations.
+   */
+  test("applies localized aria label", () => {
+    const { getByRole } = render(<PronounceableWord text="word" lang="en" />);
+    expect(
+      getByRole("button", { name: "Play word audio" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/website/src/components/tts/__tests__/TtsButton.test.jsx
+++ b/website/src/components/tts/__tests__/TtsButton.test.jsx
@@ -1,38 +1,46 @@
 /* eslint-env jest */
-import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
-import { jest } from '@jest/globals'
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { jest } from "@jest/globals";
 
 // mock hooks and icon to isolate button behavior
-const play = jest.fn()
-const stop = jest.fn()
+const play = jest.fn();
+const stop = jest.fn();
 const useTtsPlayer = jest.fn(() => ({
   play,
   stop,
   loading: false,
   playing: false,
   error: null,
-}))
+}));
 
-jest.unstable_mockModule('@/hooks/useTtsPlayer.js', () => ({ useTtsPlayer }))
+jest.unstable_mockModule("@/hooks/useTtsPlayer.js", () => ({ useTtsPlayer }));
 
-const navigate = jest.fn()
-jest.unstable_mockModule('react-router-dom', () => ({ useNavigate: () => navigate }))
+const navigate = jest.fn();
+jest.unstable_mockModule("react-router-dom", () => ({
+  useNavigate: () => navigate,
+}));
 
-jest.unstable_mockModule('@/context', () => ({
-  useLanguage: () => ({ t: { upgrade: '升级' } }),
+jest.unstable_mockModule("@/context", () => ({
+  useLanguage: () => ({
+    t: {
+      upgrade: "升级",
+      playWordAudio: "Play word audio",
+      playSentenceAudio: "Play sentence audio",
+    },
+  }),
   useApiContext: () => ({}),
-  useTheme: () => ({ resolvedTheme: 'light' }),
-  useLocale: () => ({ locale: 'en-US' }),
+  useTheme: () => ({ resolvedTheme: "light" }),
+  useLocale: () => ({ locale: "en-US" }),
   useAppContext: () => ({}),
-}))
+}));
 
-jest.unstable_mockModule('@/components/ui/Icon', () => ({
+jest.unstable_mockModule("@/components/ui/Icon", () => ({
   __esModule: true,
   default: () => <span data-testid="icon" />,
-}))
+}));
 
-jest.unstable_mockModule('@/components/ui/MessagePopup', () => ({
+jest.unstable_mockModule("@/components/ui/MessagePopup", () => ({
   __esModule: true,
   default: ({ open, message, children }) =>
     open ? (
@@ -41,75 +49,102 @@ jest.unstable_mockModule('@/components/ui/MessagePopup', () => ({
         {children}
       </div>
     ) : null,
-}))
+}));
 
-jest.unstable_mockModule('@/components/ui/Toast', () => ({
+jest.unstable_mockModule("@/components/ui/Toast", () => ({
   __esModule: true,
   default: ({ open, message }) => (open ? <div>{message}</div> : null),
-}))
+}));
 
-jest.unstable_mockModule('@/components/modals/UpgradeModal.jsx', () => ({
+jest.unstable_mockModule("@/components/modals/UpgradeModal.jsx", () => ({
   __esModule: true,
   default: () => null,
-}))
+}));
 
-const { default: TtsButton } = await import('@/components/tts/TtsButton.jsx')
+const { default: TtsButton } = await import("@/components/tts/TtsButton.jsx");
 
-describe('TtsButton', () => {
+describe("TtsButton", () => {
   afterEach(() => {
-    play.mockReset()
-    stop.mockReset()
-    useTtsPlayer.mockClear()
-  })
+    play.mockReset();
+    stop.mockReset();
+    useTtsPlayer.mockClear();
+  });
 
   /**
    * Renders button and verifies clicking triggers play with correct params.
    */
-  test('invokes play with text and lang', () => {
-    const { getByRole } = render(<TtsButton text="hello" lang="en" />)
-    fireEvent.click(getByRole('button'))
-    expect(play).toHaveBeenCalledWith({ text: 'hello', lang: 'en', voice: undefined })
-  })
+  test("invokes play with text and lang", () => {
+    const { getByRole } = render(<TtsButton text="hello" lang="en" />);
+    fireEvent.click(getByRole("button"));
+    expect(play).toHaveBeenCalledWith({
+      text: "hello",
+      lang: "en",
+      voice: undefined,
+    });
+  });
 
   /**
    * When already playing, clicking triggers stop instead of play.
    */
-  test('stops when playing', () => {
-    useTtsPlayer.mockReturnValueOnce({ play, stop, loading: false, playing: true, error: null })
-    const { getByRole } = render(<TtsButton text="hi" lang="en" />)
-    fireEvent.click(getByRole('button'))
-    expect(stop).toHaveBeenCalled()
-    expect(play).not.toHaveBeenCalled()
-  })
+  test("stops when playing", () => {
+    useTtsPlayer.mockReturnValueOnce({
+      play,
+      stop,
+      loading: false,
+      playing: true,
+      error: null,
+    });
+    const { getByRole } = render(<TtsButton text="hi" lang="en" />);
+    fireEvent.click(getByRole("button"));
+    expect(stop).toHaveBeenCalled();
+    expect(play).not.toHaveBeenCalled();
+  });
 
   /**
    * Shows upgrade prompt on forbidden errors.
    */
-  test('renders upgrade popup on 403 error', async () => {
+  test("renders upgrade popup on 403 error", async () => {
     useTtsPlayer.mockReturnValueOnce({
       play,
       stop,
       loading: false,
       playing: false,
-      error: { code: 403, message: 'Pro only' },
-    })
-    const { findByText } = render(<TtsButton text="hi" lang="en" />)
-    expect(await findByText('Pro only')).toBeInTheDocument()
-    expect(await findByText('升级')).toBeInTheDocument()
-  })
+      error: { code: 403, message: "Pro only" },
+    });
+    const { findByText } = render(<TtsButton text="hi" lang="en" />);
+    expect(await findByText("Pro only")).toBeInTheDocument();
+    expect(await findByText("升级")).toBeInTheDocument();
+  });
 
   /**
    * Displays toast on rate limit errors.
    */
-  test('renders toast on 429 error', async () => {
+  test("renders toast on 429 error", async () => {
     useTtsPlayer.mockReturnValueOnce({
       play,
       stop,
       loading: false,
       playing: false,
-      error: { code: 429, message: 'Too many' },
-    })
-    const { findByText } = render(<TtsButton text="hi" lang="en" />)
-    expect(await findByText('Too many')).toBeInTheDocument()
-  })
-})
+      error: { code: 429, message: "Too many" },
+    });
+    const { findByText } = render(<TtsButton text="hi" lang="en" />);
+    expect(await findByText("Too many")).toBeInTheDocument();
+  });
+
+  /**
+   * Button derives aria-label from translations for each scope.
+   */
+  test("applies localized tooltip per scope", () => {
+    const { getByRole, rerender } = render(<TtsButton text="hi" lang="en" />);
+    expect(getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "Play word audio",
+    );
+
+    rerender(<TtsButton text="hi" lang="en" scope="sentence" />);
+    expect(getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "Play sentence audio",
+    );
+  });
+});

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -106,4 +106,7 @@ export default {
     "You can revisit this choice whenever you need. We only use cookies to secure and refine your experience.",
   cookieConsentAccept: "Allow cookies",
   cookieConsentDecline: "Maybe later",
+  playWordAudio: "Play pronunciation",
+  playSentenceAudio: "Play example audio",
+  favoriteRemove: "Remove from favorites",
 };

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -106,4 +106,7 @@ export default {
     "您可以随时重新调整选择，我们仅为安全与体验优化使用 Cookie。",
   cookieConsentAccept: "同意并继续",
   cookieConsentDecline: "暂不授权",
+  playWordAudio: "播放发音",
+  playSentenceAudio: "播放例句发音",
+  favoriteRemove: "取消收藏",
 };

--- a/website/src/pages/App/FavoritesView.jsx
+++ b/website/src/pages/App/FavoritesView.jsx
@@ -1,12 +1,18 @@
-import ListItem from '@/components/ui/ListItem'
+import ListItem from "@/components/ui/ListItem";
 
-function FavoritesView({ favorites = [], onSelect, onUnfavorite, emptyMessage }) {
+function FavoritesView({
+  favorites = [],
+  onSelect,
+  onUnfavorite,
+  emptyMessage,
+  unfavoriteLabel,
+}) {
   if (!favorites.length) {
     return (
       <div className="display-content">
         <div className="display-term">{emptyMessage}</div>
       </div>
-    )
+    );
   }
 
   return (
@@ -18,23 +24,24 @@ function FavoritesView({ favorites = [], onSelect, onUnfavorite, emptyMessage })
           text={w}
           textClassName="favorite-term"
           onClick={() => onSelect?.(w)}
-          actions={(
+          actions={
             <button
               type="button"
-              aria-label="unfavorite"
+              aria-label={unfavoriteLabel}
+              title={unfavoriteLabel}
               className="unfavorite-btn"
               onClick={(e) => {
-                e.stopPropagation()
-                onUnfavorite?.(w)
+                e.stopPropagation();
+                onUnfavorite?.(w);
               }}
             >
               ○
             </button>
-          )}
+          }
         />
       ))}
     </ul>
-  )
+  );
 }
 
-export default FavoritesView
+export default FavoritesView;

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -247,6 +247,7 @@ function App() {
               onSelect={handleSelectFavorite}
               onUnfavorite={handleUnfavorite}
               emptyMessage={t.noFavorites}
+              unfavoriteLabel={t.favoriteRemove}
             />
           ) : showHistory ? (
             <HistoryDisplay />


### PR DESCRIPTION
## Summary
- add localized strings for TTS controls and favorites actions to the language dictionary
- update TTS and favorites UI to consume localized accessibility text and ensure translations drive aria labels
- extend component tests to validate the localized aria labels for different scopes

## Testing
- `npm run test` *(fails: existing Syntax error in src/api/__tests__/words.stream.test.js)*
- `npx eslint --fix src/components/tts/TtsButton.jsx src/components/tts/PronounceableWord.jsx src/pages/App/FavoritesView.jsx src/pages/App/index.jsx src/components/tts/__tests__/TtsButton.test.jsx src/components/tts/__tests__/PronounceableWord.test.jsx src/i18n/common/en.js src/i18n/common/zh.js`
- `npx stylelint "src/components/tts/*.css" --fix`
- `npx prettier -w src/i18n/common/en.js src/i18n/common/zh.js src/components/tts/TtsButton.jsx src/components/tts/PronounceableWord.jsx src/pages/App/FavoritesView.jsx src/pages/App/index.jsx src/components/tts/__tests__/TtsButton.test.jsx src/components/tts/__tests__/PronounceableWord.test.jsx`
- `mvn spotless:apply` *(fails: cannot resolve Spring Boot dependencies without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca78e2d5908332b5239bb22ff140f1