### PR TITLE
fix: localize phone input placeholder

### DIFF
--- a/website/src/components/form/AuthForm.jsx
+++ b/website/src/components/form/AuthForm.jsx
@@ -119,7 +119,11 @@ function AuthForm({
     return (
       <form onSubmit={handleSubmit} className={styles["auth-form"]}>
         {method === "phone" ? (
-          <PhoneInput value={account} onChange={setAccount} />
+          <PhoneInput
+            value={account}
+            onChange={setAccount}
+            placeholder={placeholders.phone}
+          />
         ) : (
           <input
             className={styles["auth-input"]}

--- a/website/src/components/form/PhoneInput.jsx
+++ b/website/src/components/form/PhoneInput.jsx
@@ -1,57 +1,121 @@
-import { useState, useEffect, useRef } from 'react'
-import { useLocale } from '@/context'
-import styles from './PhoneInput.module.css'
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useLocale } from "@/context";
+import styles from "./PhoneInput.module.css";
 
 const CODE_LIST = [
-  { country: 'CN', code: '+86' },
-  { country: 'US', code: '+1' },
-  { country: 'GB', code: '+44' },
-  { country: 'DE', code: '+49' },
-  { country: 'FR', code: '+33' },
-  { country: 'RU', code: '+7' },
-  { country: 'JP', code: '+81' },
-  { country: 'ES', code: '+34' },
-  { country: 'IN', code: '+91' },
-  { country: 'AU', code: '+61' }
-].sort((a, b) => a.code[1].localeCompare(b.code[1]))
+  { country: "CN", code: "+86" },
+  { country: "US", code: "+1" },
+  { country: "GB", code: "+44" },
+  { country: "DE", code: "+49" },
+  { country: "FR", code: "+33" },
+  { country: "RU", code: "+7" },
+  { country: "JP", code: "+81" },
+  { country: "ES", code: "+34" },
+  { country: "IN", code: "+91" },
+  { country: "AU", code: "+61" },
+].sort((a, b) => a.code[1].localeCompare(b.code[1]));
 
-function PhoneInput({ onChange, placeholder = 'Phone number' }) {
-  const [code, setCode] = useState('+1')
-  const [number, setNumber] = useState('')
-  const [open, setOpen] = useState(false)
-  const ref = useRef(null)
-  const { locale } = useLocale()
+const DEFAULT_CODE = "+1";
+const CODE_LIST_BY_LENGTH_DESC = [...CODE_LIST].sort(
+  (a, b) => b.code.length - a.code.length,
+);
 
-  useEffect(() => {
-    if (!locale) return
-    const found = CODE_LIST.find((c) => c.country === locale.country)
-    if (found) setCode(found.code)
-  }, [locale])
+const parsePhoneValue = (rawValue, fallbackCode = DEFAULT_CODE) => {
+  if (typeof rawValue !== "string" || rawValue.length === 0) {
+    return { code: fallbackCode, number: "" };
+  }
 
-  useEffect(() => {
-    const handler = (e) => {
-      if (!ref.current?.contains(e.target)) setOpen(false)
+  const matchedEntry = CODE_LIST_BY_LENGTH_DESC.find(({ code }) =>
+    rawValue.startsWith(code),
+  );
+
+  if (matchedEntry) {
+    return {
+      code: matchedEntry.code,
+      number: rawValue.slice(matchedEntry.code.length),
+    };
+  }
+
+  if (rawValue.startsWith("+")) {
+    const match = rawValue.match(/^\+\d+/);
+    if (match) {
+      return {
+        code: match[0],
+        number: rawValue.slice(match[0].length),
+      };
     }
-    document.addEventListener('click', handler)
-    return () => document.removeEventListener('click', handler)
-  }, [])
-
-  const select = (c) => {
-    setCode(c)
-    setOpen(false)
-    if (onChange) onChange(c + number)
   }
 
-  const handleNumber = (e) => {
-    setNumber(e.target.value)
-    if (onChange) onChange(code + e.target.value)
-  }
+  return { code: fallbackCode, number: rawValue };
+};
+
+function PhoneInput({ value = "", onChange, placeholder = "" }) {
+  const initial = parsePhoneValue(value, DEFAULT_CODE);
+  const [code, setCode] = useState(initial.code);
+  const [number, setNumber] = useState(initial.number);
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+  const { locale } = useLocale();
+
+  const emitChange = useCallback(
+    (nextCode, nextNumber) => {
+      if (onChange) {
+        onChange(`${nextCode}${nextNumber}`);
+      }
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
+    const parsed = parsePhoneValue(value, DEFAULT_CODE);
+    setCode(parsed.code);
+    setNumber(parsed.number);
+  }, [value]);
+
+  useEffect(() => {
+    if (!locale?.country || value) {
+      return;
+    }
+    const found = CODE_LIST.find((entry) => entry.country === locale.country);
+    if (found && found.code !== code) {
+      setCode(found.code);
+      emitChange(found.code, number);
+    }
+  }, [locale, value, code, number, emitChange]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!ref.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("click", handler);
+    return () => document.removeEventListener("click", handler);
+  }, []);
+
+  const select = (nextCode) => {
+    setCode(nextCode);
+    setOpen(false);
+    emitChange(nextCode, number);
+  };
+
+  const handleNumber = (event) => {
+    const nextNumber = event.target.value;
+    setNumber(nextNumber);
+    emitChange(code, nextNumber);
+  };
 
   return (
-    <div className={styles['phone-input']} ref={ref}>
-      <div className={styles['phone-code']} onClick={() => setOpen((o) => !o)}>{code}</div>
+    <div className={styles["phone-input"]} ref={ref}>
+      <div
+        className={styles["phone-code"]}
+        onClick={() => setOpen((openState) => !openState)}
+      >
+        {code}
+      </div>
       {open && (
-        <div className={styles['code-options']}>
+        <div className={styles["code-options"]}>
           {CODE_LIST.map((c) => (
             <div key={c.code} onClick={() => select(c.code)}>
               {c.code}
@@ -60,13 +124,13 @@ function PhoneInput({ onChange, placeholder = 'Phone number' }) {
         </div>
       )}
       <input
-        className={styles['phone-number']}
+        className={styles["phone-number"]}
         value={number}
         onChange={handleNumber}
         placeholder={placeholder}
       />
     </div>
-  )
+  );
 }
 
-export default PhoneInput
+export default PhoneInput;


### PR DESCRIPTION
## Summary
- feed localized placeholders into the phone login method so the UI matches the selected language
- refactor the phone input to accept controlled values, keep locale-derived dialing codes, and emit updates consistently

## Testing
- npm run lint -- --fix src/components/form/AuthForm.jsx src/components/form/PhoneInput.jsx
- npm run lint:css -- --fix src/components/form/PhoneInput.module.css
- npx prettier -w src/components/form/AuthForm.jsx src/components/form/PhoneInput.jsx

------
https://chatgpt.com/codex/tasks/task_e_68ca8674249083329e599d69f2e114f2