### PR TITLE
Refine login option spacing

### DIFF
--- a/website/src/components/form/AuthForm.module.css
+++ b/website/src/components/form/AuthForm.module.css
@@ -153,11 +153,17 @@
 }
 
 .login-options {
-  display: flex;
+  --login-option-size: 48px;
+  --login-option-gap: var(--space-2);
+
+  display: grid;
   width: 100%;
   max-width: 360px;
-  justify-content: space-between;
-  margin-bottom: 12px;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--login-option-size);
+  justify-content: center;
+  column-gap: var(--login-option-gap);
+  margin-bottom: var(--space-1);
 }
 
 .login-options button {
@@ -167,9 +173,9 @@
   background: var(--input-bg);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
-  padding: 12px;
-  width: 48px;
-  height: 48px;
+  padding: var(--space-2);
+  width: var(--login-option-size);
+  height: var(--login-option-size);
   cursor: pointer;
   transition:
     background 0.3s ease,


### PR DESCRIPTION
## Summary
- tighten the spacing between alternative auth option icons while keeping the container width consistent
- center the icon row with a grid layout and theme spacing tokens for a refined presentation

## Testing
- npm run lint -- --fix
- npx stylelint "src/components/form/AuthForm.module.css" --fix
- npx prettier -w src/components/form/AuthForm.module.css

------
https://chatgpt.com/codex/tasks/task_e_68ca9d2ecd208332bbf8434187864c2b