### PR TITLE
Refine preferences modal styling

### DIFF
--- a/website/src/__tests__/Preferences.test.jsx
+++ b/website/src/__tests__/Preferences.test.jsx
@@ -9,6 +9,7 @@ const mockSetTheme = jest.fn();
 const mockTtsVoices = jest.fn().mockResolvedValue([]);
 const mockT = {
   prefTitle: "Preferences",
+  prefDescription: "Description",
   prefLanguage: "Language",
   prefSearchLanguage: "Search Language",
   prefVoiceEn: "English Voice",
@@ -44,6 +45,10 @@ jest.unstable_mockModule("@/hooks", () => ({
     ref: { current: null },
   }),
   useMediaQuery: () => false,
+}));
+jest.unstable_mockModule("@/components", () => ({
+  __esModule: true,
+  VoiceSelector: ({ lang }) => <div data-testid={`voice-selector-${lang}`} />,
 }));
 jest.unstable_mockModule("@/store", () => ({
   useUserStore: (fn) => fn({ user: { plan: "free" } }),

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -8,6 +8,8 @@ export default {
   updateButton: "Update",
   updateSuccess: "Update success",
   prefTitle: "Preferences",
+  prefDescription:
+    "Tailor Glancy's languages, voices, and ambience to suit every session.",
   prefLanguage: "Source Language",
   prefSearchLanguage: "Target Language",
   prefDictionaryModel: "Default Model",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -8,6 +8,7 @@ export default {
   updateButton: "更新",
   updateSuccess: "更新成功",
   prefTitle: "偏好设置",
+  prefDescription: "协调语言、音色与外观，让每次查词都恰到好处。",
   prefLanguage: "源语言",
   prefSearchLanguage: "目标语言",
   prefDictionaryModel: "默认模型",

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -1,12 +1,96 @@
-.preferences-form {
+.container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-4);
   width: 100%;
+  padding: clamp(var(--space-3), 4vw, var(--space-4));
+  background: color-mix(in srgb, var(--color-surface-alt) 92%, transparent);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 24px 48px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
 }
 
-.preferences-form button[type='submit'] {
-  width: 100%;
-  background: var(--primary-bg);
+.header {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.02em;
+  color: var(--color-text);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.form {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.fields {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.submit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary-bg) 94%, transparent) 0%,
+    color-mix(in srgb, var(--primary-bg) 80%, transparent) 100%
+  );
   color: var(--primary-color);
+  font-weight: var(--font-medium);
+  font-size: var(--text-base);
+  letter-spacing: 0.015em;
+  cursor: pointer;
+  box-shadow: 0 16px 32px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.submit-button:focus {
+  outline: 2px solid color-mix(in srgb, var(--primary-bg) 65%, transparent);
+  outline-offset: 2px;
+}
+
+.submit-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px
+    color-mix(in srgb, var(--shadow-color) 30%, transparent);
+}
+
+.submit-button:active {
+  transform: translateY(0);
+}
+
+@media (width >= 480px) {
+  .container {
+    padding: clamp(var(--space-3), 3vw, var(--space-5));
+  }
+
+  .form {
+    gap: var(--space-4);
+  }
 }

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from "react";
-import "@/pages/App/App.css";
+import { useState, useEffect, useMemo, useCallback, useId } from "react";
 import styles from "./Preferences.module.css";
 import { useLanguage } from "@/context";
 import { useTheme } from "@/context";
@@ -11,107 +10,182 @@ import FormRow from "@/components/form/FormRow.jsx";
 import { useApi } from "@/hooks";
 import { VoiceSelector } from "@/components";
 
+const SOURCE_LANG_STORAGE_KEY = "sourceLang";
+const TARGET_LANG_STORAGE_KEY = "targetLang";
+const DEFAULT_SOURCE_LANG = "auto";
+const DEFAULT_TARGET_LANG = "ENGLISH";
+const DEFAULT_THEME = "system";
+
 function Preferences() {
   const { t } = useLanguage();
   const { theme, setTheme } = useTheme();
   const { user } = useUser();
   const api = useApi();
   const [sourceLang, setSourceLang] = useState(
-    localStorage.getItem("sourceLang") || "auto",
+    localStorage.getItem(SOURCE_LANG_STORAGE_KEY) || DEFAULT_SOURCE_LANG,
   );
   const [targetLang, setTargetLang] = useState(
-    localStorage.getItem("targetLang") || "ENGLISH",
+    localStorage.getItem(TARGET_LANG_STORAGE_KEY) || DEFAULT_TARGET_LANG,
   );
   const [popupOpen, setPopupOpen] = useState(false);
   const [popupMsg, setPopupMsg] = useState("");
+  const headingId = useId();
+  const descriptionId = useId();
+
+  const languageOptions = useMemo(
+    () => [
+      { value: DEFAULT_SOURCE_LANG, label: t.autoDetect },
+      { value: "CHINESE", label: "CHINESE" },
+      { value: "ENGLISH", label: "ENGLISH" },
+    ],
+    [t],
+  );
+
+  const searchLanguageOptions = useMemo(
+    () => [
+      { value: "CHINESE", label: "CHINESE" },
+      { value: "ENGLISH", label: "ENGLISH" },
+    ],
+    [],
+  );
+
+  const themeOptions = useMemo(
+    () => [
+      { value: "light", label: "light" },
+      { value: "dark", label: "dark" },
+      { value: DEFAULT_THEME, label: "system" },
+    ],
+    [],
+  );
+
+  const persistLanguages = useCallback((source, target) => {
+    localStorage.setItem(SOURCE_LANG_STORAGE_KEY, source);
+    localStorage.setItem(TARGET_LANG_STORAGE_KEY, target);
+  }, []);
+
+  const openPopup = useCallback((message) => {
+    setPopupMsg(message);
+    setPopupOpen(true);
+  }, []);
+
+  const applyPreferences = useCallback(
+    (data) => {
+      const nextSource = data.systemLanguage || DEFAULT_SOURCE_LANG;
+      const nextTarget = data.searchLanguage || DEFAULT_TARGET_LANG;
+      setSourceLang(nextSource);
+      setTargetLang(nextTarget);
+      persistLanguages(nextSource, nextTarget);
+      setTheme(data.theme || DEFAULT_THEME);
+    },
+    [persistLanguages, setTheme],
+  );
 
   useEffect(() => {
-    if (!user) return;
+    if (!user) {
+      return;
+    }
     api
       .request(`${API_PATHS.preferences}/user`)
       .then((data) => {
-        const sl = data.systemLanguage || "auto";
-        const tl = data.searchLanguage || "ENGLISH";
-        setSourceLang(sl);
-        setTargetLang(tl);
-        localStorage.setItem("sourceLang", sl);
-        localStorage.setItem("targetLang", tl);
-        setTheme(data.theme || "system");
+        applyPreferences(data);
       })
       .catch((err) => {
         console.error(err);
-        setPopupMsg(t.fail);
-        setPopupOpen(true);
+        openPopup(t.fail);
       });
-  }, [setTheme, t, user, api]);
+  }, [api, applyPreferences, openPopup, t.fail, user]);
 
-  const handleSave = async (e) => {
-    e.preventDefault();
-    if (!user) return;
-    await api.jsonRequest(`${API_PATHS.preferences}/user`, {
-      method: "POST",
-      body: {
-        systemLanguage: sourceLang,
-        searchLanguage: targetLang,
-        theme,
-      },
-    });
-    localStorage.setItem("sourceLang", sourceLang);
-    localStorage.setItem("targetLang", targetLang);
-    setPopupMsg(t.saveSuccess);
-    setPopupOpen(true);
-  };
+  const handleSave = useCallback(
+    async (event) => {
+      event.preventDefault();
+      if (!user) {
+        return;
+      }
+      try {
+        await api.jsonRequest(`${API_PATHS.preferences}/user`, {
+          method: "POST",
+          body: {
+            systemLanguage: sourceLang,
+            searchLanguage: targetLang,
+            theme,
+          },
+        });
+        persistLanguages(sourceLang, targetLang);
+        openPopup(t.saveSuccess);
+      } catch (error) {
+        console.error(error);
+        openPopup(t.fail);
+      }
+    },
+    [
+      api,
+      openPopup,
+      persistLanguages,
+      sourceLang,
+      targetLang,
+      theme,
+      t.fail,
+      t.saveSuccess,
+      user,
+    ],
+  );
 
   return (
-    <div className="app">
-      <h2>{t.prefTitle}</h2>
-      <form className={styles["preferences-form"]} onSubmit={handleSave}>
-        <FormRow label={t.prefLanguage} id="source-lang">
-          <SelectField
-            value={sourceLang}
-            onChange={setSourceLang}
-            options={[
-              { value: "auto", label: t.autoDetect },
-              { value: "CHINESE", label: "CHINESE" },
-              { value: "ENGLISH", label: "ENGLISH" },
-            ]}
-          />
-        </FormRow>
-        <FormRow label={t.prefSearchLanguage} id="target-lang">
-          <SelectField
-            value={targetLang}
-            onChange={setTargetLang}
-            options={[
-              { value: "CHINESE", label: "CHINESE" },
-              { value: "ENGLISH", label: "ENGLISH" },
-            ]}
-          />
-        </FormRow>
-        <FormRow label={t.prefVoiceEn} id="voice-en">
-          <VoiceSelector lang="en" />
-        </FormRow>
-        <FormRow label={t.prefVoiceZh} id="voice-zh">
-          <VoiceSelector lang="zh" />
-        </FormRow>
-        <FormRow label={t.prefTheme} id="theme-select">
-          <SelectField
-            value={theme}
-            onChange={setTheme}
-            options={[
-              { value: "light", label: "light" },
-              { value: "dark", label: "dark" },
-              { value: "system", label: "system" },
-            ]}
-          />
-        </FormRow>
-        <button type="submit">{t.saveButton}</button>
+    <section
+      className={styles.container}
+      aria-labelledby={headingId}
+      aria-describedby={descriptionId}
+    >
+      <header className={styles.header}>
+        <h2 id={headingId} className={styles.title}>
+          {t.prefTitle}
+        </h2>
+        <p id={descriptionId} className={styles.subtitle}>
+          {t.prefDescription}
+        </p>
+      </header>
+      <form className={styles.form} onSubmit={handleSave}>
+        <div className={styles.fields}>
+          <FormRow label={t.prefLanguage} id="source-lang">
+            <SelectField
+              value={sourceLang}
+              onChange={setSourceLang}
+              options={languageOptions}
+            />
+          </FormRow>
+          <FormRow label={t.prefSearchLanguage} id="target-lang">
+            <SelectField
+              value={targetLang}
+              onChange={setTargetLang}
+              options={searchLanguageOptions}
+            />
+          </FormRow>
+          <FormRow label={t.prefVoiceEn} id="voice-en">
+            <VoiceSelector lang="en" />
+          </FormRow>
+          <FormRow label={t.prefVoiceZh} id="voice-zh">
+            <VoiceSelector lang="zh" />
+          </FormRow>
+          <FormRow label={t.prefTheme} id="theme-select">
+            <SelectField
+              value={theme}
+              onChange={setTheme}
+              options={themeOptions}
+            />
+          </FormRow>
+        </div>
+        <div className={styles.actions}>
+          <button type="submit" className={styles["submit-button"]}>
+            {t.saveButton}
+          </button>
+        </div>
       </form>
       <MessagePopup
         open={popupOpen}
         message={popupMsg}
         onClose={() => setPopupOpen(false)}
       />
-    </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- redesign the preferences modal layout to use a dedicated container, descriptive header, and resilient option handling
- refresh modal styling with theme-aware spacing, typography, and elevated button treatment for a more cohesive look
- add localized preference descriptions and stabilize tests by mocking the voice selector component

## Testing
- npm run lint
- npm run lint:css
- npm test -- Preferences

------
https://chatgpt.com/codex/tasks/task_e_68ca9e15f12083329ff53505a477edb7