### PR TITLE
feat: add hover states for sidebar sections

### DIFF
--- a/website/src/components/Sidebar/Favorites.jsx
+++ b/website/src/components/Sidebar/Favorites.jsx
@@ -13,6 +13,12 @@ function Favorites({ onToggle }) {
     if (onToggle) onToggle((v) => !v);
   };
 
+  const favoritesSectionClassName = [
+    styles["sidebar-section"],
+    styles["favorites-list"],
+    styles["sidebar-hoverable"],
+  ].join(" ");
+
   const favoritesLabel = t.favorites || FALLBACK_FAVORITES_LABEL;
   const favoritesIconAlt = getFavoritesIconAlt(
     favoritesLabel,
@@ -20,7 +26,7 @@ function Favorites({ onToggle }) {
   );
 
   return (
-    <div className={`${styles["sidebar-section"]} ${styles["favorites-list"]}`}>
+    <div className={favoritesSectionClassName}>
       <h3 className={styles["collection-button"]} onClick={handleClick}>
         <ThemeIcon
           name="star-solid"

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -128,3 +128,18 @@
 :root[data-theme="dark"] .collection-button:hover {
   background-color: var(--color-overlay-inverse);
 }
+
+.sidebar-hoverable {
+  border-radius: var(--radius-sm, 4px);
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.sidebar-hoverable:where(:hover, :focus-within) {
+  background-color: var(--color-overlay-weak);
+}
+
+:root[data-theme="dark"] .sidebar-hoverable:where(:hover, :focus-within) {
+  background-color: var(--color-overlay-inverse);
+}

--- a/website/src/components/Sidebar/SidebarUser.jsx
+++ b/website/src/components/Sidebar/SidebarUser.jsx
@@ -1,12 +1,16 @@
-import { UserMenu } from '@/components/Header'
-import styles from './Sidebar.module.css'
+import { UserMenu } from "@/components/Header";
+import styles from "./Sidebar.module.css";
 
 function SidebarUser() {
+  const sidebarUserClassName = [
+    styles["sidebar-user"],
+    styles["sidebar-hoverable"],
+  ].join(" ");
   return (
-    <div className={styles['sidebar-user']}>
+    <div className={sidebarUserClassName}>
       <UserMenu size={32} showName />
     </div>
-  )
+  );
 }
 
-export default SidebarUser
+export default SidebarUser;


### PR DESCRIPTION
## Summary
- add a reusable sidebar hover surface style that mirrors the history list feedback
- apply the shared hover treatment to the favorites block and user menu area in the sidebar

## Testing
- npx eslint src/components/Sidebar/Favorites.jsx src/components/Sidebar/SidebarUser.jsx --fix
- npx stylelint "src/components/Sidebar/Sidebar.module.css" --fix
- npx prettier -w src/components/Sidebar/Favorites.jsx src/components/Sidebar/SidebarUser.jsx src/components/Sidebar/Sidebar.module.css
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68caa04dd92c8332b9b6abbc3e0a5150