### PR TITLE
Ensure account modals overlay page and add close control

### DIFF
--- a/website/src/components/modals/BaseModal.jsx
+++ b/website/src/components/modals/BaseModal.jsx
@@ -1,13 +1,30 @@
-import Modal from './Modal.jsx'
+import PropTypes from "prop-types";
+import Modal from "./Modal.jsx";
+import { useLanguage } from "@/context";
 
-function BaseModal({ open, onClose, className = '', children }) {
-  if (!open) return null
+function BaseModal({ open, onClose, className = "", children, closeLabel }) {
+  const { t } = useLanguage();
+  if (!open) return null;
+
+  const resolvedCloseLabel = closeLabel ?? t.close;
 
   return (
-    <Modal onClose={onClose} className={className}>
+    <Modal
+      onClose={onClose}
+      className={className}
+      closeLabel={resolvedCloseLabel}
+    >
       {children}
     </Modal>
-  )
+  );
 }
 
-export default BaseModal
+BaseModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  closeLabel: PropTypes.string,
+};
+
+export default BaseModal;

--- a/website/src/components/modals/Modal.jsx
+++ b/website/src/components/modals/Modal.jsx
@@ -1,17 +1,116 @@
-import styles from './Modal.module.css'
-import { useEscapeKey } from '@/hooks'
-import { withStopPropagation } from '@/utils/stopPropagation.js'
+import PropTypes from "prop-types";
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import styles from "./Modal.module.css";
+import { useEscapeKey } from "@/hooks";
+import { withStopPropagation } from "@/utils/stopPropagation.js";
 
-function Modal({ onClose, className = '', children }) {
-  useEscapeKey(onClose)
+const MODAL_ROOT_ID = "glancy-modal-root";
+let modalRoot;
+let modalInstances = 0;
+let previousBodyOverflow = "";
+let previousBodyPaddingRight = "";
 
-  return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={className} onClick={withStopPropagation()}>
-        {children}
-      </div>
-    </div>
-  )
+function ensureModalRoot() {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  if (modalRoot && document.body.contains(modalRoot)) {
+    return modalRoot;
+  }
+
+  const existing = document.getElementById(MODAL_ROOT_ID);
+  if (existing) {
+    modalRoot = existing;
+    return modalRoot;
+  }
+
+  modalRoot = document.createElement("div");
+  modalRoot.setAttribute("id", MODAL_ROOT_ID);
+  document.body.appendChild(modalRoot);
+  return modalRoot;
 }
 
-export default Modal
+function lockBodyScroll() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  if (modalInstances === 0) {
+    previousBodyOverflow = document.body.style.overflow;
+    previousBodyPaddingRight = document.body.style.paddingRight;
+
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth;
+    document.body.style.overflow = "hidden";
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+  }
+  modalInstances += 1;
+}
+
+function unlockBodyScroll() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  modalInstances = Math.max(0, modalInstances - 1);
+  if (modalInstances === 0) {
+    document.body.style.overflow = previousBodyOverflow;
+    document.body.style.paddingRight = previousBodyPaddingRight;
+  }
+}
+
+function Modal({ onClose, className = "", children, closeLabel = "Close" }) {
+  useEscapeKey(onClose);
+
+  useEffect(() => {
+    const root = ensureModalRoot();
+    if (!root) return undefined;
+
+    lockBodyScroll();
+
+    return () => {
+      unlockBodyScroll();
+    };
+  }, []);
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const root = ensureModalRoot();
+  if (!root) {
+    return null;
+  }
+
+  const contentClassName = className
+    ? `${styles.content} ${className}`
+    : styles.content;
+
+  return createPortal(
+    <div className={styles.overlay} role="presentation" onClick={onClose}>
+      <div
+        className={contentClassName}
+        role="dialog"
+        aria-modal="true"
+        onClick={withStopPropagation()}
+      >
+        <button
+          type="button"
+          className={styles["close-button"]}
+          aria-label={closeLabel}
+          onClick={onClose}
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        {children}
+      </div>
+    </div>,
+    root,
+  );
+}
+
+Modal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  closeLabel: PropTypes.string,
+};
+
+export default Modal;

--- a/website/src/components/modals/Modal.module.css
+++ b/website/src/components/modals/Modal.module.css
@@ -7,3 +7,46 @@
   align-items: center;
   z-index: 1000;
 }
+
+.content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: 0 26px 68px -32px var(--shadow-color);
+}
+
+.close-button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--app-color) 20%, transparent);
+  background: color-mix(in srgb, var(--app-bg) 80%, transparent);
+  color: var(--app-color);
+  display: grid;
+  place-items: center;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.close-button:hover,
+.close-button:focus-visible {
+  background: color-mix(in srgb, var(--app-bg) 60%, transparent);
+  border-color: color-mix(in srgb, var(--app-color) 30%, transparent);
+  box-shadow: 0 12px 24px -18px var(--shadow-color);
+}
+
+.close-button:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+}

--- a/website/src/components/modals/ModalContent.module.css
+++ b/website/src/components/modals/ModalContent.module.css
@@ -1,6 +1,6 @@
 :global(.modal-content) {
   background: var(--app-bg);
   color: var(--app-color);
-  padding: 20px;
-  border-radius: var(--radius-md);
+  padding: 32px 32px 28px;
+  border-radius: var(--radius-lg);
 }


### PR DESCRIPTION
## Summary
- render the modal component through a document-level portal, add body scroll locking, and introduce a dedicated close control
- surface a localized close label through BaseModal and refresh shared modal padding to give the top-right control room

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68ca9fcd3b3083329816b23af6965a16