### PR TITLE
feat: customize auth alternate option labels

### DIFF
--- a/website/src/components/__tests__/AuthForm.test.jsx
+++ b/website/src/components/__tests__/AuthForm.test.jsx
@@ -20,6 +20,8 @@ jest.unstable_mockModule("@/context", () => ({
       notImplementedYet: "Not implemented yet",
       termsOfUse: "Terms of Use",
       privacyPolicy: "Privacy Policy",
+      otherLoginOptions: "Other login options",
+      otherRegisterOptions: "Other register options",
     },
   }),
 }));
@@ -84,6 +86,32 @@ describe("AuthForm", () => {
       iconRegistry["glancy-web"].light,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  /**
+   * Ensures the caller can override the default separator label, enabling
+   * context-aware messaging between login and registration flows.
+   */
+  test("renders custom alternative option label when provided", () => {
+    render(
+      <MemoryRouter>
+        <AuthForm
+          title="Register"
+          switchText="Back to login?"
+          switchLink="/login"
+          onSubmit={jest.fn()}
+          placeholders={{ username: "Username" }}
+          formMethods={["username", "wechat"]}
+          methodOrder={["username", "wechat"]}
+          defaultMethod="username"
+          otherOptionsLabel="Other register options"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("separator", { name: "Other register options" }),
+    ).toBeInTheDocument();
   });
 
   /**

--- a/website/src/components/form/AuthForm.jsx
+++ b/website/src/components/form/AuthForm.jsx
@@ -54,6 +54,7 @@ function AuthForm({
   passwordPlaceholder = "Password",
   showCodeButton = () => false,
   icons = defaultIcons,
+  otherOptionsLabel,
 }) {
   const { lang, t } = useLanguage();
   const brandText = useMemo(() => getBrandText(lang), [lang]);
@@ -72,7 +73,12 @@ function AuthForm({
   );
   const [showNotice, setShowNotice] = useState(false);
   const [noticeMsg, setNoticeMsg] = useState("");
-  const otherLoginOptionsLabel = t.otherLoginOptions ?? "Other login options";
+  const fallbackOtherOptionsLabel =
+    t.otherLoginOptions ?? "Other login options";
+  const trimmedOtherOptionsLabel =
+    typeof otherOptionsLabel === "string" ? otherOptionsLabel.trim() : "";
+  const resolvedOtherOptionsLabel =
+    trimmedOtherOptionsLabel || fallbackOtherOptionsLabel;
   const handleSendCode = () => {};
 
   useEffect(() => {
@@ -169,10 +175,10 @@ function AuthForm({
       <div
         className={styles.divider}
         role="separator"
-        aria-label={otherLoginOptionsLabel}
+        aria-label={resolvedOtherOptionsLabel}
       >
         <span className={styles["divider-label"]}>
-          {otherLoginOptionsLabel}
+          {resolvedOtherOptionsLabel}
         </span>
       </div>
       <div className={styles["login-options"]}>

--- a/website/src/i18n/auth/en.js
+++ b/website/src/i18n/auth/en.js
@@ -22,4 +22,5 @@ export default {
   termsOfUse: "Terms of Use",
   privacyPolicy: "Privacy Policy",
   otherLoginOptions: "Other login options",
+  otherRegisterOptions: "Other register options",
 };

--- a/website/src/i18n/auth/zh.js
+++ b/website/src/i18n/auth/zh.js
@@ -22,4 +22,5 @@ export default {
   termsOfUse: "使用条款",
   privacyPolicy: "隐私政策",
   otherLoginOptions: "其他登录选项",
+  otherRegisterOptions: "其他注册选项",
 };

--- a/website/src/pages/auth/Login/index.jsx
+++ b/website/src/pages/auth/Login/index.jsx
@@ -49,6 +49,7 @@ function Login() {
       }
       showCodeButton={(m) => m !== "username"}
       validateAccount={validateAccount}
+      otherOptionsLabel={t.otherLoginOptions}
     />
   );
 }

--- a/website/src/pages/auth/Register/index.jsx
+++ b/website/src/pages/auth/Register/index.jsx
@@ -50,6 +50,7 @@ function Register() {
       passwordPlaceholder={() => t.codePlaceholder}
       showCodeButton={() => true}
       validateAccount={validateAccount}
+      otherOptionsLabel={t.otherRegisterOptions}
     />
   );
 }


### PR DESCRIPTION
## Summary
- allow AuthForm to accept a caller-provided label for alternative sign-in methods
- show login and register specific copy by wiring locale strings for each flow
- cover the customization path with a focused AuthForm unit test

## Testing
- npm run test -- AuthForm
- npx eslint --fix src/components/form/AuthForm.jsx src/pages/auth/Login/index.jsx src/pages/auth/Register/index.jsx src/components/__tests__/AuthForm.test.jsx src/i18n/auth/en.js src/i18n/auth/zh.js
- npx stylelint --fix "src/components/form/*.module.css"
- npx prettier -w src/components/form/AuthForm.jsx src/pages/auth/Login/index.jsx src/pages/auth/Register/index.jsx src/components/__tests__/AuthForm.test.jsx src/i18n/auth/en.js src/i18n/auth/zh.js

------
https://chatgpt.com/codex/tasks/task_e_68caa80a2cf08332ab50cd299aef4f7a