### PR TITLE
Adjust login option spacing

### DIFF
--- a/website/src/components/form/AuthForm.module.css
+++ b/website/src/components/form/AuthForm.module.css
@@ -153,17 +153,21 @@
 }
 
 .login-options {
-  --login-option-size: 48px;
-  --login-option-gap: var(--space-2);
+  --login-option-size: 52px;
+  --login-option-gap: var(--space-5);
+  --login-options-max-width: calc(
+    var(--login-option-size) * 5 + var(--login-option-gap) * 4
+  );
 
   display: grid;
-  width: 100%;
+  width: min(100%, var(--login-options-max-width));
   max-width: 360px;
   grid-auto-flow: column;
   grid-auto-columns: var(--login-option-size);
-  justify-content: center;
+  justify-content: space-between;
   column-gap: var(--login-option-gap);
-  margin-bottom: var(--space-1);
+  padding-inline: clamp(var(--space-1), 2vw, var(--space-3));
+  margin-bottom: var(--space-2);
 }
 
 .login-options button {


### PR DESCRIPTION
## Summary
- widen the spacing tokens for the auth form login option buttons to create more breathing room
- fix the grid container sizing so four- and five-option layouts share the same overall width and add responsive horizontal padding

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68caa9dd4e0c83329c49604e0371db80