### PR TITLE
feat: support email verification based auth flows

### DIFF
--- a/backend/src/main/java/com/glancy/backend/config/EmailVerificationProperties.java
+++ b/backend/src/main/java/com/glancy/backend/config/EmailVerificationProperties.java
@@ -1,0 +1,103 @@
+package com.glancy.backend.config;
+
+import com.glancy.backend.entity.EmailVerificationPurpose;
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Structured configuration backing the email verification workflow.
+ */
+@ConfigurationProperties(prefix = "mail.verification")
+public class EmailVerificationProperties {
+
+    private String from;
+    private int codeLength = 6;
+    private Duration ttl = Duration.ofMinutes(10);
+    private Map<EmailVerificationPurpose, Template> templates = new EnumMap<>(EmailVerificationPurpose.class);
+
+    @PostConstruct
+    void validate() {
+        if (from == null || from.isBlank()) {
+            throw new IllegalStateException("mail.verification.from must be configured");
+        }
+        if (codeLength < 4) {
+            throw new IllegalStateException("mail.verification.code-length must be at least 4");
+        }
+        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+            throw new IllegalStateException("mail.verification.ttl must be positive");
+        }
+        for (EmailVerificationPurpose purpose : EmailVerificationPurpose.values()) {
+            Template template = templates.get(purpose);
+            if (template == null || template.subject == null || template.subject.isBlank()) {
+                throw new IllegalStateException(
+                    "mail.verification.templates." + purpose.name().toLowerCase() + ".subject must be set"
+                );
+            }
+            if (template.body == null || template.body.isBlank()) {
+                throw new IllegalStateException(
+                    "mail.verification.templates." + purpose.name().toLowerCase() + ".body must be set"
+                );
+            }
+        }
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public int getCodeLength() {
+        return codeLength;
+    }
+
+    public void setCodeLength(int codeLength) {
+        this.codeLength = codeLength;
+    }
+
+    public Duration getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+        this.ttl = ttl;
+    }
+
+    public Map<EmailVerificationPurpose, Template> getTemplates() {
+        return templates;
+    }
+
+    public void setTemplates(Map<EmailVerificationPurpose, Template> templates) {
+        this.templates = templates;
+    }
+
+    /**
+     * Template details for a single verification purpose.
+     */
+    public static class Template {
+
+        private String subject;
+        private String body;
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public void setSubject(String subject) {
+            this.subject = subject;
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        public void setBody(String body) {
+            this.body = body;
+        }
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/UserController.java
@@ -3,6 +3,9 @@ package com.glancy.backend.controller;
 import com.glancy.backend.config.auth.AuthenticatedUser;
 import com.glancy.backend.dto.AvatarRequest;
 import com.glancy.backend.dto.AvatarResponse;
+import com.glancy.backend.dto.EmailLoginRequest;
+import com.glancy.backend.dto.EmailRegistrationRequest;
+import com.glancy.backend.dto.EmailVerificationCodeRequest;
 import com.glancy.backend.dto.LoginRequest;
 import com.glancy.backend.dto.LoginResponse;
 import com.glancy.backend.dto.ThirdPartyAccountRequest;
@@ -45,6 +48,24 @@ public class UserController {
     }
 
     /**
+     * Request an email verification code for registration or login.
+     */
+    @PostMapping("/email/verification-code")
+    public ResponseEntity<Void> sendVerificationCode(@Valid @RequestBody EmailVerificationCodeRequest req) {
+        userService.sendVerificationCode(req);
+        return ResponseEntity.accepted().build();
+    }
+
+    /**
+     * Register a user account after validating an email verification code.
+     */
+    @PostMapping("/register/email")
+    public ResponseEntity<UserResponse> registerWithEmail(@Valid @RequestBody EmailRegistrationRequest req) {
+        UserResponse resp = userService.registerWithEmailVerification(req);
+        return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+
+    /**
      * Delete (logically) an existing user account.
      */
     @DeleteMapping("/{id}")
@@ -68,6 +89,15 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
         LoginResponse resp = userService.login(req);
+        return new ResponseEntity<>(resp, HttpStatus.OK);
+    }
+
+    /**
+     * Authenticate using an email verification code instead of a password.
+     */
+    @PostMapping("/login/email")
+    public ResponseEntity<LoginResponse> loginWithEmail(@Valid @RequestBody EmailLoginRequest req) {
+        LoginResponse resp = userService.loginWithEmailCode(req);
         return new ResponseEntity<>(resp, HttpStatus.OK);
     }
 

--- a/backend/src/main/java/com/glancy/backend/dto/EmailLoginRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/EmailLoginRequest.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request payload for logging in with an email verification code.
+ */
+public record EmailLoginRequest(
+    @NotBlank(message = "邮箱不能为空") @Email(message = "邮箱格式不正确") String email,
+    @NotBlank(message = "验证码不能为空") String code,
+    String deviceInfo
+) {}

--- a/backend/src/main/java/com/glancy/backend/dto/EmailRegistrationRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/EmailRegistrationRequest.java
@@ -1,0 +1,17 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Payload submitted when registering via email verification.
+ */
+public record EmailRegistrationRequest(
+    @NotBlank(message = "邮箱不能为空") @Email(message = "邮箱格式不正确") String email,
+    @NotBlank(message = "验证码不能为空") String code,
+    @NotBlank(message = "用户名不能为空") @Size(min = 3, max = 50, message = "用户名长度需在3到50之间") String username,
+    @NotBlank(message = "密码不能为空") @Size(min = 6, message = "密码长度至少为6位") String password,
+    String avatar,
+    @NotBlank(message = "手机号不能为空") String phone
+) {}

--- a/backend/src/main/java/com/glancy/backend/dto/EmailVerificationCodeRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/EmailVerificationCodeRequest.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.dto;
+
+import com.glancy.backend.entity.EmailVerificationPurpose;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request payload for triggering a verification code email.
+ */
+public record EmailVerificationCodeRequest(
+    @NotBlank(message = "邮箱不能为空") @Email(message = "邮箱格式不正确") String email,
+    @NotNull(message = "验证码用途不能为空") EmailVerificationPurpose purpose
+) {}

--- a/backend/src/main/java/com/glancy/backend/entity/EmailVerificationCode.java
+++ b/backend/src/main/java/com/glancy/backend/entity/EmailVerificationCode.java
@@ -1,0 +1,44 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Verification code issued to confirm ownership of an email address for
+ * authentication related flows.
+ */
+@Entity
+@Table(
+    name = "email_verification_codes",
+    indexes = {
+        @Index(name = "idx_email_purpose_active", columnList = "email, purpose, expiresAt"),
+        @Index(name = "idx_email_created", columnList = "email, createdAt")
+    }
+)
+@Getter
+@Setter
+public class EmailVerificationCode extends BaseEntity {
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 10)
+    private String code;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EmailVerificationPurpose purpose;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private Boolean used = false;
+}

--- a/backend/src/main/java/com/glancy/backend/entity/EmailVerificationPurpose.java
+++ b/backend/src/main/java/com/glancy/backend/entity/EmailVerificationPurpose.java
@@ -1,0 +1,9 @@
+package com.glancy.backend.entity;
+
+/**
+ * Supported business contexts for email verification codes.
+ */
+public enum EmailVerificationPurpose {
+    REGISTER,
+    LOGIN
+}

--- a/backend/src/main/java/com/glancy/backend/repository/EmailVerificationCodeRepository.java
+++ b/backend/src/main/java/com/glancy/backend/repository/EmailVerificationCodeRepository.java
@@ -1,0 +1,38 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.EmailVerificationCode;
+import com.glancy.backend.entity.EmailVerificationPurpose;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository for persisting issued email verification codes.
+ */
+@Repository
+public interface EmailVerificationCodeRepository extends JpaRepository<EmailVerificationCode, Long> {
+
+    Optional<EmailVerificationCode> findTopByEmailAndPurposeAndCodeAndDeletedFalseOrderByCreatedAtDesc(
+        String email,
+        EmailVerificationPurpose purpose,
+        String code
+    );
+
+    List<EmailVerificationCode> findByEmailAndPurposeAndUsedFalseAndDeletedFalse(String email, EmailVerificationPurpose purpose);
+
+    @Modifying
+    @Query(
+        "update EmailVerificationCode c set c.used = true " +
+        "where c.email = :email and c.purpose = :purpose and c.used = false and c.deleted = false and c.expiresAt < :now"
+    )
+    int markExpiredAsUsed(
+        @Param("email") String email,
+        @Param("purpose") EmailVerificationPurpose purpose,
+        @Param("now") LocalDateTime now
+    );
+}

--- a/backend/src/main/java/com/glancy/backend/service/EmailVerificationService.java
+++ b/backend/src/main/java/com/glancy/backend/service/EmailVerificationService.java
@@ -1,0 +1,138 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.config.EmailVerificationProperties;
+import com.glancy.backend.entity.EmailVerificationCode;
+import com.glancy.backend.entity.EmailVerificationPurpose;
+import com.glancy.backend.exception.InvalidRequestException;
+import com.glancy.backend.repository.EmailVerificationCodeRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Handles issuing and validating email verification codes for authentication flows.
+ */
+@Slf4j
+@Service
+public class EmailVerificationService {
+
+    private final EmailVerificationCodeRepository repository;
+    private final EmailVerificationProperties properties;
+    private final JavaMailSender mailSender;
+    private final Clock clock;
+    private final SecureRandom random = new SecureRandom();
+
+    public EmailVerificationService(
+        EmailVerificationCodeRepository repository,
+        EmailVerificationProperties properties,
+        JavaMailSender mailSender,
+        Clock clock
+    ) {
+        this.repository = repository;
+        this.properties = properties;
+        this.mailSender = mailSender;
+        this.clock = clock;
+    }
+
+    /**
+     * Issue a new verification code for the given email and invalidate previous active codes.
+     */
+    @Transactional
+    public void issueCode(String email, EmailVerificationPurpose purpose) {
+        String normalizedEmail = normalize(email);
+        LocalDateTime now = LocalDateTime.now(clock);
+        invalidateExisting(normalizedEmail, purpose, now);
+
+        EmailVerificationCode code = new EmailVerificationCode();
+        code.setEmail(normalizedEmail);
+        code.setPurpose(purpose);
+        code.setCode(generateCode());
+        code.setExpiresAt(now.plus(properties.getTtl()));
+        repository.save(code);
+
+        dispatchEmail(normalizedEmail, purpose, code.getCode());
+    }
+
+    /**
+     * Validate and consume a verification code.
+     */
+    @Transactional
+    public void consumeCode(String email, String code, EmailVerificationPurpose purpose) {
+        String normalizedEmail = normalize(email);
+        LocalDateTime now = LocalDateTime.now(clock);
+        repository.markExpiredAsUsed(normalizedEmail, purpose, now);
+        EmailVerificationCode latest =
+            repository
+                .findTopByEmailAndPurposeAndCodeAndDeletedFalseOrderByCreatedAtDesc(normalizedEmail, purpose, code)
+                .orElseThrow(() -> new InvalidRequestException("验证码无效或已过期"));
+
+        if (Boolean.TRUE.equals(latest.getUsed()) || latest.getExpiresAt().isBefore(now)) {
+            latest.setUsed(true);
+            repository.save(latest);
+            throw new InvalidRequestException("验证码无效或已过期");
+        }
+
+        latest.setUsed(true);
+        repository.save(latest);
+    }
+
+    private void invalidateExisting(String email, EmailVerificationPurpose purpose, LocalDateTime now) {
+        repository.markExpiredAsUsed(email, purpose, now);
+        List<EmailVerificationCode> active = repository.findByEmailAndPurposeAndUsedFalseAndDeletedFalse(email, purpose);
+        if (active.isEmpty()) {
+            return;
+        }
+        active.forEach(code -> code.setUsed(true));
+        repository.saveAll(active);
+    }
+
+    private String normalize(String email) {
+        if (email == null) {
+            throw new InvalidRequestException("邮箱不能为空");
+        }
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String generateCode() {
+        int length = properties.getCodeLength();
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            builder.append(random.nextInt(10));
+        }
+        return builder.toString();
+    }
+
+    private void dispatchEmail(String email, EmailVerificationPurpose purpose, String code) {
+        EmailVerificationProperties.Template template = properties.getTemplates().get(purpose);
+        if (template == null) {
+            throw new IllegalStateException("Missing email template configuration for purpose " + purpose);
+        }
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setFrom(properties.getFrom());
+            helper.setTo(email);
+            helper.setSubject(template.getSubject());
+            helper.setText(renderBody(template.getBody(), code), false);
+            mailSender.send(message);
+            log.info("Dispatched {} verification code to {}", purpose, email);
+        } catch (MessagingException e) {
+            log.error("Failed to compose verification email", e);
+            throw new IllegalStateException("邮件发送失败，请稍后重试");
+        }
+    }
+
+    private String renderBody(String body, String code) {
+        long ttlMinutes = properties.getTtl().toMinutes();
+        return body.replace("{{code}}", code).replace("{{ttlMinutes}}", String.valueOf(ttlMinutes));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,8 +4,16 @@ spring:
   messages:
     basename: messages
   mail:
-    host: localhost
-    port: 1025
+    host: smtpdm.aliyun.com
+    port: 465
+    username: no-reply@mail.glancy.xyz
+    password: ${GLANCY_SMTP_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
   datasource:
     url: jdbc:mysql://localhost:3306/glancy_db?useSSL=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8
     username: glancy_user
@@ -75,3 +83,16 @@ tts:
     api-url: https://openspeech.bytedance.com/api/v1/tts
     # Interval for proactive health checks to Volcengine TTS.
     health-interval: PT10M
+
+mail:
+  verification:
+    from: no-reply@mail.glancy.xyz
+    code-length: 6
+    ttl: PT10M
+    templates:
+      register:
+        subject: "Glancy 注册验证码"
+        body: "您的注册验证码为 {{code}}，请在 {{ttlMinutes}} 分钟内完成验证。"
+      login:
+        subject: "Glancy 登录验证码"
+        body: "您的登录验证码为 {{code}}，请在 {{ttlMinutes}} 分钟内完成登录。"


### PR DESCRIPTION
## Summary
- add dedicated email verification entities, repository, and service to issue and consume email codes
- expose endpoints for sending verification codes plus registering and logging in via email codes
- configure SMTP credentials and templated messages for 10-minute verification codes

## Testing
- mvn spotless:apply *(fails: unable to reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cabf812d3c8332abb0ec4f2c0d2bdc