### PR TITLE
feat: allow updating profile identity

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/UserController.java
@@ -10,6 +10,8 @@ import com.glancy.backend.dto.LoginRequest;
 import com.glancy.backend.dto.LoginResponse;
 import com.glancy.backend.dto.ThirdPartyAccountRequest;
 import com.glancy.backend.dto.ThirdPartyAccountResponse;
+import com.glancy.backend.dto.UserContactRequest;
+import com.glancy.backend.dto.UserContactResponse;
 import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.dto.UsernameRequest;
@@ -167,6 +169,18 @@ public class UserController {
         @Valid @RequestBody UsernameRequest req
     ) {
         UsernameResponse resp = userService.updateUsername(id, req.getUsername());
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Update the email and phone for a user.
+     */
+    @PutMapping("/{id}/contact")
+    public ResponseEntity<UserContactResponse> updateContact(
+        @PathVariable Long id,
+        @Valid @RequestBody UserContactRequest req
+    ) {
+        UserContactResponse resp = userService.updateContact(id, req.email(), req.phone());
         return ResponseEntity.ok(resp);
     }
 

--- a/backend/src/main/java/com/glancy/backend/dto/UserContactRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserContactRequest.java
@@ -1,0 +1,19 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 请求更新用户邮箱与手机号的载体。
+ */
+public record UserContactRequest(
+    /** 用户联系邮箱。 */
+    @NotBlank(message = "邮箱不能为空")
+    @Email(message = "邮箱格式不正确")
+    String email,
+    /** 用户联系手机号，采用国际区号+号码格式或纯数字。 */
+    @NotBlank(message = "手机号不能为空")
+    @Pattern(regexp = "^\\+?[0-9]{3,}$", message = "手机号格式不正确")
+    String phone
+) {}

--- a/backend/src/main/java/com/glancy/backend/dto/UserContactResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserContactResponse.java
@@ -1,0 +1,9 @@
+package com.glancy.backend.dto;
+
+/**
+ * 返回用户最新的联系方式。
+ */
+public record UserContactResponse(
+    /** 已更新的用户邮箱。 */ String email,
+    /** 已更新的用户手机号。 */ String phone
+) {}

--- a/backend/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -195,6 +195,27 @@ class UserControllerTest {
     }
 
     /**
+     * 测试 updateContact 接口
+     */
+    @Test
+    void updateContact() throws Exception {
+        UserContactResponse resp = new UserContactResponse("changed@example.com", "7654321");
+        when(userService.updateContact(eq(1L), eq("changed@example.com"), eq("7654321"))).thenReturn(resp);
+
+        UserContactRequest req = new UserContactRequest("changed@example.com", "7654321");
+
+        mockMvc
+            .perform(
+                put("/api/users/1/contact")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.email").value("changed@example.com"))
+            .andExpect(jsonPath("$.phone").value("7654321"));
+    }
+
+    /**
      * 测试 uploadAvatar 接口
      */
     @Test

--- a/backend/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.glancy.backend.dto.AvatarResponse;
 import com.glancy.backend.dto.LoginRequest;
+import com.glancy.backend.dto.UserContactResponse;
 import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.entity.LoginDevice;
@@ -163,6 +164,28 @@ class UserServiceTest {
             userService.register(req2);
         });
         assertEquals("手机号已被使用", ex.getMessage());
+    }
+
+    /**
+     * 测试 updateContact 能更新用户的邮箱和手机号并持久化。
+     */
+    @Test
+    void testUpdateContact() {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("contactUser");
+        req.setPassword("pass123");
+        req.setEmail("contact@example.com");
+        req.setPhone("1234567");
+        UserResponse created = userService.register(req);
+
+        UserContactResponse updated = userService.updateContact(created.getId(), "changed@example.com", "7654321");
+
+        assertEquals("changed@example.com", updated.email());
+        assertEquals("7654321", updated.phone());
+
+        User persisted = userRepository.findById(created.getId()).orElseThrow();
+        assertEquals("changed@example.com", persisted.getEmail());
+        assertEquals("7654321", persisted.getPhone());
     }
 
     /**

--- a/website/src/api/users.js
+++ b/website/src/api/users.js
@@ -1,23 +1,39 @@
-import { API_PATHS } from '@/config/api.js'
-import { apiRequest } from './client.js'
-import { useApi } from '@/hooks'
+import { API_PATHS } from "@/config/api.js";
+import { apiRequest, createJsonRequest } from "./client.js";
+import { useApi } from "@/hooks";
 
 export function createUsersApi(request = apiRequest) {
-  const uploadAvatar = async ({ userId, file, token }) => {
-    const formData = new FormData()
-    formData.append('file', file)
-    return request(`${API_PATHS.users}/${userId}/avatar-file`, {
-      method: 'POST',
-      body: formData,
-      token
-    })
-  }
+  const jsonRequest = createJsonRequest(request);
 
-  return { uploadAvatar }
+  const uploadAvatar = async ({ userId, file, token }) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    return request(`${API_PATHS.users}/${userId}/avatar-file`, {
+      method: "POST",
+      body: formData,
+      token,
+    });
+  };
+
+  const updateUsername = ({ userId, username, token }) =>
+    jsonRequest(`${API_PATHS.users}/${userId}/username`, {
+      method: "PUT",
+      token,
+      body: { username },
+    });
+
+  const updateContact = ({ userId, email, phone, token }) =>
+    jsonRequest(`${API_PATHS.users}/${userId}/contact`, {
+      method: "PUT",
+      token,
+      body: { email, phone },
+    });
+
+  return { uploadAvatar, updateUsername, updateContact };
 }
 
-export const { uploadAvatar } = createUsersApi()
+export const { uploadAvatar, updateUsername, updateContact } = createUsersApi();
 
 export function useUsersApi() {
-  return useApi().users
+  return useApi().users;
 }


### PR DESCRIPTION
## Summary
- expose a dedicated endpoint to update user email and phone alongside new DTOs
- cover the new contact update flow with controller and service tests
- update the profile page to persist username/email/phone edits via the users API and keep the UI in sync

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .
- npx prettier -w src/api/users.js src/pages/profile/index.jsx
- mvn spotless:apply *(fails: network unreachable)*
- ./mvnw spotless:apply *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68caf13850908332b2056684fefd1bb2