### PR TITLE
Normalize SVG registry paths for Windows

### DIFF
--- a/website/src/assets/__tests__/iconRegistry.test.js
+++ b/website/src/assets/__tests__/iconRegistry.test.js
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+import { buildDynamicRegistry } from "@/assets/icons.js";
+
+describe("buildDynamicRegistry", () => {
+  /**
+   * 验证基础用例：同名资源的不同主题后缀被聚合到统一的图标实体中，
+   * 确保在浅色与深色主题间切换时能够命中既有素材。
+   */
+  test("aggregates theme variants into a single registry entry", () => {
+    const registry = buildDynamicRegistry({
+      "./icons/eye-light.svg": "/assets/eye-light.svg",
+      "./icons/eye-dark.svg": "/assets/eye-dark.svg",
+      "./logos/wechat.svg": "/assets/wechat.svg",
+    });
+
+    expect(registry).toEqual({
+      eye: { light: "/assets/eye-light.svg", dark: "/assets/eye-dark.svg" },
+      wechat: { single: "/assets/wechat.svg" },
+    });
+  });
+
+  /**
+   * 验证跨平台场景：当打包环境使用 Windows 风格路径分隔符时，
+   * 仍能提取出正确的图标名称并关联到原始 SVG 素材，避免回退占位符。
+   */
+  test("normalises windows style paths to keep original svg assets", () => {
+    const registry = buildDynamicRegistry({
+      ".\\icons\\send-button-light.svg": "/assets/send-button-light.svg",
+      ".\\icons\\send-button-dark.svg": "/assets/send-button-dark.svg",
+    });
+
+    expect(registry).toEqual({
+      "send-button": {
+        light: "/assets/send-button-light.svg",
+        dark: "/assets/send-button-dark.svg",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalise SVG registry path parsing so Windows builds keep the original themed assets instead of falling back to placeholders
- expose the dynamic registry builder and cover cross-platform path scenarios with focused unit tests

## Testing
- npx eslint --fix .
- npx stylelint --fix "src/**/*.css"
- npx prettier -w src/assets/icons.js src/assets/__tests__/iconRegistry.test.js
- npm test -- --runTestsByPath src/assets/__tests__/iconRegistry.test.js
- npm test -- --runTestsByPath src/components/ui/Icon/__tests__/ThemeIcon.test.jsx
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cb7ef70c408332ac4054fc51099365