### PR TITLE
Fix email OTP login flow

### DIFF
--- a/website/src/config/api.js
+++ b/website/src/config/api.js
@@ -5,6 +5,7 @@ export const API_PATHS = {
   chat: `${API_BASE}/chat`,
   users: `${API_BASE}/users`,
   login: `${API_BASE}/users/login`,
+  loginWithEmail: `${API_BASE}/users/login/email`,
   register: `${API_BASE}/users/register`,
   ping: `${API_BASE}/ping`,
   locale: `${API_BASE}/locale`,


### PR DESCRIPTION
## Summary
- add the dedicated API endpoint constant for email code authentication
- route email login submissions through the email OTP endpoint and send the trimmed verification code

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/config/api.js src/pages/auth/Login/index.jsx

------
https://chatgpt.com/codex/tasks/task_e_68cbb46290dc8332b3b30ed80773033d