### PR TITLE
feat: improve icloud bounce diagnostics and policy

### DIFF
--- a/backend/src/main/java/com/glancy/backend/service/email/MailboxProviderFailureResolver.java
+++ b/backend/src/main/java/com/glancy/backend/service/email/MailboxProviderFailureResolver.java
@@ -1,0 +1,46 @@
+package com.glancy.backend.service.email;
+
+import com.glancy.backend.entity.EmailSuppressionStatus;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Detects mailbox provider specific diagnostics to provide actionable suppression guidance.
+ */
+@Component
+public class MailboxProviderFailureResolver {
+
+    private static final Pattern APPLE_STATUS_PATTERN = Pattern.compile("\\[(CS01|HM07|HM08)\\]");
+
+    public Optional<EmailDeliveryFailure> resolve(String diagnostic) {
+        if (!StringUtils.hasText(diagnostic)) {
+            return Optional.empty();
+        }
+        Matcher matcher = APPLE_STATUS_PATTERN.matcher(diagnostic.toUpperCase(Locale.ROOT));
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        String code = matcher.group(1);
+        return Optional.of(
+            new EmailDeliveryFailure(true, EmailSuppressionStatus.MANUAL, code, buildAppleDescription(code, diagnostic))
+        );
+    }
+
+    private String buildAppleDescription(String code, String diagnostic) {
+        String hint = switch (code) {
+            case "CS01" ->
+                "iCloud 拒收代码 CS01，通常意味着内容或身份认证存在风险，请核对 DMARC、SPF、PTR 并保持验证码邮件内容极简";
+            case "HM07" ->
+                "iCloud 拒收代码 HM07，通常关联发送速率或信誉问题，请降低重试频率并按照 Apple 建议逐步预热专用域/IP";
+            case "HM08" ->
+                "iCloud 拒收代码 HM08，通常指向反向解析或域名对齐缺失，请确认 PTR、From 域与 DKIM 一致";
+            default -> "iCloud 拒收代码 " + code + "，请结合退信原文排查";
+        };
+        String normalized = StringUtils.hasText(diagnostic) ? diagnostic : "无详细诊断信息";
+        return hint + " | 原始诊断：" + normalized;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -100,6 +100,13 @@ mail:
     deliverability:
       feedback-id-prefix: glancy-txn
       entity-ref-id-prefix: glancy-verification
+      mailbox-provider-policies:
+        icloud:
+          domains:
+            - icloud.com
+            - me.com
+            - mac.com
+          complaints-mailto: complaints@mail.glancy.xyz
     infrastructure:
       reverse-dns-domain: mail.glancy.xyz
       spf-record: "v=spf1 include:spf.mail.glancy.xyz ~all"

--- a/backend/src/test/java/com/glancy/backend/service/email/EmailDeliveryFailureClassifierTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/email/EmailDeliveryFailureClassifierTest.java
@@ -1,0 +1,47 @@
+package com.glancy.backend.service.email;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.glancy.backend.entity.EmailSuppressionStatus;
+import jakarta.mail.MessagingException;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.MailSendException;
+
+class EmailDeliveryFailureClassifierTest {
+
+    /**
+     * 验证在遇到 iCloud CS01 退信时，分类器会交由解析器判定为需人工处理的永久失败。
+     */
+    @Test
+    void classifyShouldDelegateToResolverForAppleCodes() {
+        EmailDeliveryFailureClassifier classifier = new EmailDeliveryFailureClassifier(new MailboxProviderFailureResolver());
+        Map<Object, Exception> failures = Collections.singletonMap(new Object(), new MessagingException("5.7.1 [CS01]"));
+        MailSendException exception = new MailSendException("smtp error", failures);
+
+        EmailDeliveryFailure failure = classifier.classify(exception);
+
+        assertTrue(failure.permanent());
+        assertEquals(EmailSuppressionStatus.MANUAL, failure.suppressionStatus());
+        assertEquals("CS01", failure.diagnosticCode());
+    }
+
+    /**
+     * 验证普通的 SMTP 退信会沿用通用策略并识别为软退信。
+     */
+    @Test
+    void classifyShouldFallbackToGenericStrategy() {
+        EmailDeliveryFailureClassifier classifier = new EmailDeliveryFailureClassifier(new MailboxProviderFailureResolver());
+        Map<Object, Exception> failures = Collections.singletonMap(new Object(), new MessagingException("451 4.7.0 try again later"));
+        MailSendException exception = new MailSendException("temporary failure", failures);
+
+        EmailDeliveryFailure failure = classifier.classify(exception);
+
+        assertFalse(failure.permanent());
+        assertEquals(EmailSuppressionStatus.SOFT_BOUNCE, failure.suppressionStatus());
+        assertEquals("451", failure.diagnosticCode());
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/service/email/MailboxProviderFailureResolverTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/email/MailboxProviderFailureResolverTest.java
@@ -1,0 +1,55 @@
+package com.glancy.backend.service.email;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.glancy.backend.entity.EmailSuppressionStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MailboxProviderFailureResolverTest {
+
+    /**
+     * 验证当退信诊断包含 iCloud 的 CS01 代码时，解析器能够识别为需人工处理的永久拒收并提供排查建议。
+     */
+    @Test
+    void resolveShouldDetectAppleCs01Bounce() {
+        MailboxProviderFailureResolver resolver = new MailboxProviderFailureResolver();
+
+        Optional<EmailDeliveryFailure> result = resolver.resolve("5.7.1 [CS01] Message rejected");
+
+        assertTrue(result.isPresent());
+        EmailDeliveryFailure failure = result.get();
+        assertTrue(failure.permanent());
+        assertEquals(EmailSuppressionStatus.MANUAL, failure.suppressionStatus());
+        assertEquals("CS01", failure.diagnosticCode());
+        assertTrue(failure.description().contains("iCloud 拒收代码 CS01"));
+    }
+
+    /**
+     * 验证 HM07 代码能够触发同样的人工处理策略，并给出信誉与速率相关的排查提示。
+     */
+    @Test
+    void resolveShouldDetectAppleHm07Bounce() {
+        MailboxProviderFailureResolver resolver = new MailboxProviderFailureResolver();
+
+        Optional<EmailDeliveryFailure> result = resolver.resolve("Diagnostic: 5.7.1 [HM07] excessive rate");
+
+        assertTrue(result.isPresent());
+        EmailDeliveryFailure failure = result.get();
+        assertEquals("HM07", failure.diagnosticCode());
+        assertTrue(failure.description().contains("HM07"));
+    }
+
+    /**
+     * 验证在缺少特定提供商代码时解析器保持空结果，不会误判普通退信。
+     */
+    @Test
+    void resolveShouldReturnEmptyWhenCodeMissing() {
+        MailboxProviderFailureResolver resolver = new MailboxProviderFailureResolver();
+
+        Optional<EmailDeliveryFailure> result = resolver.resolve("421 4.7.0 Temporary failure");
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a mailbox provider failure resolver to recognize Apple-specific bounce diagnostics and escalate manual remediation
- integrate the resolver into the email failure classifier and configure an iCloud policy so transactional headers satisfy Apple requirements
- add focused unit tests covering the resolver and classifier behavior

## Testing
- mvn spotless:apply *(fails: dependency versions missing because spring-boot BOM cannot be resolved in the sandbox)*
- mvn test *(fails: dependency versions missing because spring-boot BOM cannot be resolved in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cbff3f8ff083329f6530a2a88cebe2