### PR TITLE
feat: enhance streaming dictionary view

### DIFF
--- a/website/src/components/ui/DictionaryEntry/DictionaryEntryPlaceholder.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntryPlaceholder.jsx
@@ -1,0 +1,33 @@
+import MarkdownStream from "@/components/ui/MarkdownStream";
+import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
+import layoutStyles from "./DictionaryEntry.module.css";
+import styles from "./DictionaryEntryPlaceholder.module.css";
+import DictionaryEntrySkeleton from "./DictionaryEntrySkeleton.jsx";
+
+function PreviewRenderer({ children }) {
+  return (
+    <MarkdownRenderer className={styles["preview-text"]}>
+      {children}
+    </MarkdownRenderer>
+  );
+}
+
+function DictionaryEntryPlaceholder({ preview, isLoading }) {
+  if (preview) {
+    return (
+      <article
+        className={`${layoutStyles["dictionary-entry"]} ${styles.preview}`}
+      >
+        <MarkdownStream text={preview} renderer={PreviewRenderer} />
+      </article>
+    );
+  }
+
+  if (isLoading) {
+    return <DictionaryEntrySkeleton />;
+  }
+
+  return null;
+}
+
+export default DictionaryEntryPlaceholder;

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntryPlaceholder.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntryPlaceholder.module.css
@@ -1,0 +1,24 @@
+.preview {
+  margin: 0 2cm;
+  padding: 24px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.preview-text {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--color-text);
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+.preview-text p {
+  margin: 0 0 16px;
+}
+
+.preview-text p:last-child {
+  margin-bottom: 0;
+}

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntrySkeleton.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntrySkeleton.jsx
@@ -1,0 +1,33 @@
+import layoutStyles from "./DictionaryEntry.module.css";
+import styles from "./DictionaryEntrySkeleton.module.css";
+
+function SkeletonSection({ lines = 2 }) {
+  return (
+    <div className={styles.section}>
+      <div className={styles.label} />
+      <div className={styles.lines}>
+        {Array.from({ length: lines }).map((_, index) => (
+          <div key={index} className={styles.line} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DictionaryEntrySkeleton() {
+  return (
+    <article
+      className={`${layoutStyles["dictionary-entry"]} ${styles.skeleton}`}
+    >
+      <div className={styles.header}>
+        <div className={styles.title} />
+        <div className={styles.phonetic} />
+      </div>
+      <SkeletonSection lines={3} />
+      <SkeletonSection lines={2} />
+      <SkeletonSection lines={4} />
+    </article>
+  );
+}
+
+export default DictionaryEntrySkeleton;

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntrySkeleton.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntrySkeleton.module.css
@@ -1,0 +1,77 @@
+.skeleton {
+  margin: 0 2cm;
+  padding: 24px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title,
+.phonetic,
+.label,
+.line {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted);
+}
+
+.title {
+  height: 36px;
+  max-width: 320px;
+}
+
+.phonetic {
+  height: 20px;
+  max-width: 200px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.label {
+  height: 20px;
+  max-width: 120px;
+}
+
+.lines {
+  display: grid;
+  gap: 12px;
+}
+
+.line {
+  height: 16px;
+  width: 100%;
+}
+
+.title::after,
+.phonetic::after,
+.label::after,
+.line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--color-surface) 50%,
+    transparent 100%
+  );
+  animation: shimmer 1.8s infinite;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntryView.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntryView.jsx
@@ -1,0 +1,12 @@
+import DictionaryEntry from "./DictionaryEntry.jsx";
+import DictionaryEntryPlaceholder from "./DictionaryEntryPlaceholder.jsx";
+
+function DictionaryEntryView({ entry, preview, isLoading }) {
+  if (entry) {
+    return <DictionaryEntry entry={entry} />;
+  }
+
+  return <DictionaryEntryPlaceholder preview={preview} isLoading={isLoading} />;
+}
+
+export default DictionaryEntryView;

--- a/website/src/components/ui/DictionaryEntry/index.js
+++ b/website/src/components/ui/DictionaryEntry/index.js
@@ -1,1 +1,2 @@
-export { default } from './DictionaryEntry.jsx'
+export { default } from "./DictionaryEntry.jsx";
+export { default as DictionaryEntryView } from "./DictionaryEntryView.jsx";

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -3,7 +3,7 @@ import MessagePopup from "@/components/ui/MessagePopup";
 import { useHistory, useUser, useFavorites } from "@/context";
 import { useNavigate } from "react-router-dom";
 import { useTheme } from "@/context";
-import DictionaryEntry from "@/components/ui/DictionaryEntry";
+import { DictionaryEntryView } from "@/components/ui/DictionaryEntry";
 import { useLanguage } from "@/context";
 import { useStreamWord, useSpeechInput } from "@/hooks";
 import "./App.css";
@@ -13,8 +13,6 @@ import HistoryDisplay from "@/components/ui/HistoryDisplay";
 import ICP from "@/components/ui/ICP";
 import FavoritesView from "./FavoritesView.jsx";
 import { useAppShortcuts } from "@/hooks";
-import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
-import MarkdownStream from "@/components/ui/MarkdownStream";
 import Button from "@/components/ui/Button";
 import EmptyState from "@/components/ui/EmptyState";
 import { extractMarkdownPreview } from "@/utils";
@@ -274,16 +272,12 @@ function App() {
                 focusInput();
               }}
             />
-          ) : loading ? (
-            <MarkdownStream text={streamText || "..."} />
-          ) : entry ? (
-            <DictionaryEntry entry={entry} />
-          ) : finalText ? (
-            <MarkdownRenderer className="stream-text">
-              {finalText}
-            </MarkdownRenderer>
-          ) : streamText ? (
-            <MarkdownStream text={streamText} />
+          ) : entry || finalText || streamText || loading ? (
+            <DictionaryEntryView
+              entry={entry}
+              preview={finalText || streamText}
+              isLoading={loading}
+            />
           ) : (
             <EmptyState
               iconName="target"


### PR DESCRIPTION
## Summary
- add a streaming-aware dictionary entry view with preview and skeleton states so word searches keep the final layout while loading
- update the App display logic to delegate to the new view for both live results and cached entries

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cc322513848332b6ed22d7b54276ca