### PR TITLE
feat: improve streaming dictionary markdown rendering

### DIFF
--- a/website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
@@ -1,6 +1,7 @@
 import { useLanguage } from "@/context";
 import { TtsButton, PronounceableWord } from "@/components";
-import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
+import DictionaryMarkdown from "./DictionaryMarkdown.jsx";
+import { polishDictionaryMarkdown } from "@/utils";
 import styles from "./DictionaryEntry.module.css";
 
 function tryParseJson(text) {
@@ -22,9 +23,10 @@ function DictionaryEntry({ entry }) {
     if (parsed) {
       return <DictionaryEntry entry={parsed} />;
     }
+    const polished = polishDictionaryMarkdown(entry.markdown);
     return (
       <article className={styles["dictionary-entry"]}>
-        <MarkdownRenderer>{entry.markdown}</MarkdownRenderer>
+        <DictionaryMarkdown>{polished}</DictionaryMarkdown>
       </article>
     );
   }
@@ -55,7 +57,7 @@ function DictionaryEntry({ entry }) {
             <ol>
               {definitions.map((d, i) => (
                 <li key={i}>
-                  <MarkdownRenderer>{d}</MarkdownRenderer>
+                  <DictionaryMarkdown>{d}</DictionaryMarkdown>
                 </li>
               ))}
             </ol>
@@ -69,7 +71,7 @@ function DictionaryEntry({ entry }) {
               【{t.exampleLabel}】
             </h2>
             <blockquote>
-              <MarkdownRenderer>{example}</MarkdownRenderer>
+              <DictionaryMarkdown>{example}</DictionaryMarkdown>
               <TtsButton text={example} lang={lang} scope="sentence" />
             </blockquote>
           </section>

--- a/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.jsx
@@ -1,0 +1,114 @@
+import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
+import styles from "./DictionaryMarkdown.module.css";
+
+function joinClassNames(...tokens) {
+  return tokens.filter(Boolean).join(" ");
+}
+
+const headingFactory = (level) => {
+  const className =
+    level === 1
+      ? styles["heading-primary"]
+      : level === 2
+        ? styles["heading-secondary"]
+        : styles["heading-tertiary"];
+  return function Heading({ className: incoming, children, ...props }) {
+    const Tag = `h${level}`;
+    return (
+      <Tag
+        {...props}
+        className={joinClassNames(className, styles.heading, incoming)}
+      >
+        {children}
+      </Tag>
+    );
+  };
+};
+
+const components = {
+  h1: headingFactory(1),
+  h2: headingFactory(2),
+  h3: headingFactory(3),
+  h4: headingFactory(4),
+  h5: headingFactory(5),
+  h6: headingFactory(6),
+  p({ className, children, ...props }) {
+    return (
+      <p {...props} className={joinClassNames(styles.paragraph, className)}>
+        {children}
+      </p>
+    );
+  },
+  ol({ className, children, ...props }) {
+    return (
+      <ol
+        {...props}
+        className={joinClassNames(styles["ordered-list"], className)}
+      >
+        {children}
+      </ol>
+    );
+  },
+  ul({ className, children, ...props }) {
+    return (
+      <ul
+        {...props}
+        className={joinClassNames(styles["unordered-list"], className)}
+      >
+        {children}
+      </ul>
+    );
+  },
+  li({ className, children, ...props }) {
+    return (
+      <li {...props} className={joinClassNames(styles["list-item"], className)}>
+        {children}
+      </li>
+    );
+  },
+  blockquote({ className, children, ...props }) {
+    return (
+      <blockquote
+        {...props}
+        className={joinClassNames(styles.blockquote, className)}
+      >
+        {children}
+      </blockquote>
+    );
+  },
+  strong({ className, children, ...props }) {
+    return (
+      <strong {...props} className={joinClassNames(styles.strong, className)}>
+        {children}
+      </strong>
+    );
+  },
+  em({ className, children, ...props }) {
+    return (
+      <em {...props} className={joinClassNames(styles.emphasis, className)}>
+        {children}
+      </em>
+    );
+  },
+  code({ className, children, ...props }) {
+    return (
+      <code {...props} className={joinClassNames(styles.code, className)}>
+        {children}
+      </code>
+    );
+  },
+  hr({ className, ...props }) {
+    return (
+      <hr {...props} className={joinClassNames(styles.divider, className)} />
+    );
+  },
+};
+
+export default function DictionaryMarkdown({ children }) {
+  if (!children) return null;
+  return (
+    <div className={styles.wrapper}>
+      <MarkdownRenderer components={components}>{children}</MarkdownRenderer>
+    </div>
+  );
+}

--- a/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.module.css
@@ -1,0 +1,81 @@
+.wrapper {
+  display: grid;
+  gap: var(--space-3, 16px);
+  text-align: left;
+  color: var(--app-color);
+}
+
+.heading {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+}
+
+.heading-primary {
+  font-size: 1.5rem;
+  margin: 0;
+  text-align: center;
+}
+
+.heading-secondary {
+  font-size: 1.25rem;
+  margin: var(--space-4, 24px) 0 var(--space-2, 8px);
+}
+
+.heading-tertiary {
+  font-size: 1.125rem;
+  margin: var(--space-3, 16px) 0 var(--space-2, 8px);
+}
+
+.paragraph {
+  margin: 0;
+  line-height: 1.75;
+  font-size: 1rem;
+  color: inherit;
+}
+
+.ordered-list,
+.unordered-list {
+  margin: 0;
+  padding-left: var(--space-5, 32px);
+  display: grid;
+  gap: var(--space-2, 8px);
+}
+
+.list-item {
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+.blockquote {
+  margin: 0;
+  padding: var(--space-2, 8px) var(--space-3, 16px);
+  border-left: 3px solid var(--color-surface-alt);
+  color: var(--color-text-secondary);
+  font-style: italic;
+  background: color-mix(in srgb, var(--color-surface) 80%, transparent);
+  border-radius: var(--radius-md, 8px);
+}
+
+.strong {
+  font-weight: 600;
+}
+
+.emphasis {
+  font-style: italic;
+}
+
+.code {
+  font-family: var(--font-mono, "Fira Code", monospace);
+  font-size: 0.95rem;
+  background: var(--color-surface-muted);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm, 6px);
+}
+
+.divider {
+  border: none;
+  border-top: 1px solid
+    color-mix(in srgb, var(--color-text-tertiary) 20%, transparent);
+  margin: var(--space-4, 24px) 0;
+}

--- a/website/src/utils/__tests__/markdown.test.js
+++ b/website/src/utils/__tests__/markdown.test.js
@@ -1,0 +1,19 @@
+import { polishDictionaryMarkdown } from "../markdown.js";
+
+describe("polishDictionaryMarkdown", () => {
+  test("inserts missing spaces after heading markers", () => {
+    const input = "#标题\n##子标题";
+    expect(polishDictionaryMarkdown(input)).toContain("# 标题");
+    expect(polishDictionaryMarkdown(input)).toContain("## 子标题");
+  });
+
+  test("adds padding before adjacent headings", () => {
+    const input = "段落\n## 标题";
+    expect(polishDictionaryMarkdown(input)).toBe("段落\n\n## 标题");
+  });
+
+  test("ensures ordered list markers preserve spacing", () => {
+    const input = "1.第一条\n2)第二条";
+    expect(polishDictionaryMarkdown(input)).toBe("1. 第一条\n2) 第二条");
+  });
+});

--- a/website/src/utils/index.js
+++ b/website/src/utils/index.js
@@ -10,4 +10,7 @@ export { decodeTtsAudio } from "./audio.js";
 export { createCachedFetcher } from "./cache.js";
 export { parseSse } from "./sse.js";
 export { setCookie, deleteCookie, hasCookie, getCookie } from "./cookies.js";
-export { extractMarkdownPreview } from "./markdown.js";
+export {
+  extractMarkdownPreview,
+  polishDictionaryMarkdown,
+} from "./markdown.js";


### PR DESCRIPTION
## Summary
- add a dedicated DictionaryMarkdown presentation layer so streaming previews mirror the final entry layout
- normalize streamed markdown content to recover heading and list spacing before rendering
- cover the new markdown polishing utility with focused unit tests

## Testing
- npx eslint src/components/ui/DictionaryEntry/DictionaryEntry.jsx src/components/ui/DictionaryEntry/DictionaryMarkdown.jsx src/utils/markdown.js src/utils/index.js src/utils/__tests__/markdown.test.js --fix
- npx stylelint "src/components/ui/DictionaryEntry/*.css" --fix
- npx prettier -w src/components/ui/DictionaryEntry/DictionaryEntry.jsx src/components/ui/DictionaryEntry/DictionaryMarkdown.jsx src/components/ui/DictionaryEntry/DictionaryMarkdown.module.css src/utils/markdown.js src/utils/index.js src/utils/__tests__/markdown.test.js
- npm run test -- src/utils/__tests__/markdown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cc399a7bb083329047a44943df67cf