### PR TITLE
feat: support versioned entries in streaming flow

### DIFF
--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -1,39 +1,39 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{js,jsx}'],
+    files: ["**/*.{js,jsx}"],
     extends: [
       js.configs.recommended,
-      reactHooks.configs['recommended-latest'],
+      reactHooks.configs["recommended-latest"],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {
-        ecmaVersion: 'latest',
+        ecmaVersion: "latest",
         ecmaFeatures: { jsx: true },
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
     rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      "no-unused-vars": ["error", { varsIgnorePattern: "^[A-Z_]" }],
     },
   },
   {
-    files: ['server/**/*.js'],
+    files: ["server/**/*.js"],
     languageOptions: {
       globals: globals.node,
     },
   },
   {
-    files: ['**/__tests__/**/*.{js,jsx,ts,tsx}', '**/*.test.{js,jsx,ts,tsx}'],
+    files: ["**/__tests__/**/*.{js,jsx,ts,tsx}", "**/*.test.{js,jsx,ts,tsx}"],
     languageOptions: {
       globals: {
         ...globals.node,
@@ -41,4 +41,4 @@ export default defineConfig([
       },
     },
   },
-])
+]);

--- a/website/jest.config.js
+++ b/website/jest.config.js
@@ -1,23 +1,23 @@
 export default {
-  testEnvironment: 'jsdom',
+  testEnvironment: "jsdom",
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-    '^(\\.{1,2}/.*)\\.js$': '$1',
-    '^.+\\.css$': 'identity-obj-proxy',
-    '^.+\\.(svg)$': '<rootDir>/test/__mocks__/fileMock.cjs'
+    "^@/(.*)$": "<rootDir>/src/$1",
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^.+\\.css$": "identity-obj-proxy",
+    "^.+\\.(svg)$": "<rootDir>/test/__mocks__/fileMock.cjs",
   },
-  extensionsToTreatAsEsm: ['.jsx', '.ts', '.tsx'],
+  extensionsToTreatAsEsm: [".jsx", ".ts", ".tsx"],
   transform: {
-    '^.+\\.(t|j)sx?$': [
-      'babel-jest',
+    "^.+\\.(t|j)sx?$": [
+      "babel-jest",
       {
         presets: [
-          ['@babel/preset-react', { runtime: 'automatic' }],
-          '@babel/preset-typescript'
-        ]
-      }
-    ]
+          ["@babel/preset-react", { runtime: "automatic" }],
+          "@babel/preset-typescript",
+        ],
+      },
+    ],
   },
-  setupFilesAfterEnv: ['@testing-library/jest-dom'],
-  collectCoverage: false
-}
+  setupFilesAfterEnv: ["@testing-library/jest-dom"],
+  collectCoverage: false,
+};

--- a/website/public/error.html
+++ b/website/public/error.html
@@ -1,17 +1,26 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Server Error</title>
-  <style>
-    body {font-family: Arial, sans-serif;text-align: center;padding: 2rem;}
-    h1 {font-size: 2rem; color: #333;}
-    p {color: #666;}
-  </style>
-</head>
-<body>
-  <h1>Something went wrong</h1>
-  <p>The server encountered an error. Please try again later.</p>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Server Error</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        text-align: center;
+        padding: 2rem;
+      }
+      h1 {
+        font-size: 2rem;
+        color: #333;
+      }
+      p {
+        color: #666;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Something went wrong</h1>
+    <p>The server encountered an error. Please try again later.</p>
+  </body>
 </html>

--- a/website/public/sw.js
+++ b/website/public/sw.js
@@ -1,19 +1,21 @@
-const CACHE_NAME = 'icon-cache-v1';
+const CACHE_NAME = "icon-cache-v1";
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   const { request } = event;
-  if (request.destination === 'image') {
+  if (request.destination === "image") {
     event.respondWith(
-      caches.match(request).then(cached => {
+      caches.match(request).then((cached) => {
         if (cached) {
           return cached;
         }
-        return fetch(request).then(resp => {
+        return fetch(request).then((resp) => {
           const respClone = resp.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(request, respClone));
+          caches
+            .open(CACHE_NAME)
+            .then((cache) => cache.put(request, respClone));
           return resp;
         });
-      })
+      }),
     );
   }
 });

--- a/website/server/config/countryLanguageMap.js
+++ b/website/server/config/countryLanguageMap.js
@@ -1,7 +1,6 @@
 export const COUNTRY_LANGUAGE_MAP = {
-  CN: 'zh',
-  US: 'en',
-  GB: 'en',
+  CN: "zh",
+  US: "en",
+  GB: "en",
   // Other countries default to English
-}
-
+};

--- a/website/server/index.js
+++ b/website/server/index.js
@@ -1,34 +1,34 @@
-import express from 'express'
-import path from 'path'
-import { fileURLToPath } from 'url'
-import geoip from 'geoip-lite'
-import { COUNTRY_LANGUAGE_MAP } from './config/countryLanguageMap.js'
+import express from "express";
+import path from "path";
+import { fileURLToPath } from "url";
+import geoip from "geoip-lite";
+import { COUNTRY_LANGUAGE_MAP } from "./config/countryLanguageMap.js";
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
-const app = express()
-const port = process.env.PORT || 3000
+const app = express();
+const port = process.env.PORT || 3000;
 
-app.use(express.static(path.join(__dirname, '../dist')))
+app.use(express.static(path.join(__dirname, "../dist")));
 
-app.set('trust proxy', true)
+app.set("trust proxy", true);
 
-app.get('/api/locale', (req, res) => {
+app.get("/api/locale", (req, res) => {
   const ip =
-    (req.headers['x-forwarded-for'] || '').split(',').shift() ||
+    (req.headers["x-forwarded-for"] || "").split(",").shift() ||
     req.socket?.remoteAddress ||
-    '127.0.0.1'
-  const geo = geoip.lookup(ip)
-  const country = geo?.country || 'US'
-  const lang = COUNTRY_LANGUAGE_MAP[country] || 'en'
-  res.json({ country, lang })
-})
+    "127.0.0.1";
+  const geo = geoip.lookup(ip);
+  const country = geo?.country || "US";
+  const lang = COUNTRY_LANGUAGE_MAP[country] || "en";
+  res.json({ country, lang });
+});
 
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '../dist', 'index.html'))
-})
+app.get("*", (req, res) => {
+  res.sendFile(path.join(__dirname, "../dist", "index.html"));
+});
 
 app.listen(port, () => {
-  console.log(`Server is running at http://localhost:${port}`)
-})
+  console.log(`Server is running at http://localhost:${port}`);
+});

--- a/website/src/__tests__/Register.test.jsx
+++ b/website/src/__tests__/Register.test.jsx
@@ -1,50 +1,52 @@
 /* eslint-env jest */
-import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { jest } from '@jest/globals'
-import { API_PATHS } from '@/config/api.js'
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import { API_PATHS } from "@/config/api.js";
 
-const mockSetUser = jest.fn()
+const mockSetUser = jest.fn();
 const mockRequest = jest
   .fn()
   .mockResolvedValueOnce(undefined)
-  .mockResolvedValueOnce({ id: '1', token: 't' })
-const mockNavigate = jest.fn()
+  .mockResolvedValueOnce({ id: "1", token: "t" });
+const mockNavigate = jest.fn();
 
-jest.unstable_mockModule('@/context', () => ({
-  useUser: () => ({ setUser: mockSetUser })
-}))
-jest.unstable_mockModule('@/hooks', () => ({
-  useApi: () => ({ request: mockRequest })
-}))
-jest.unstable_mockModule('@/context', () => ({
-  useTheme: () => ({ resolvedTheme: 'light' })
-}))
-jest.unstable_mockModule('react-router-dom', async () => {
-  const actual = await import('react-router-dom')
-  return { ...actual, useNavigate: () => mockNavigate }
-})
+jest.unstable_mockModule("@/context", () => ({
+  useUser: () => ({ setUser: mockSetUser }),
+}));
+jest.unstable_mockModule("@/hooks", () => ({
+  useApi: () => ({ request: mockRequest }),
+}));
+jest.unstable_mockModule("@/context", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+jest.unstable_mockModule("react-router-dom", async () => {
+  const actual = await import("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
-const router = await import('react-router-dom')
-const { MemoryRouter } = router
-const { default: Register } = await import('@/pages/auth/Register')
+const router = await import("react-router-dom");
+const { MemoryRouter } = router;
+const { default: Register } = await import("@/pages/auth/Register");
 
-test('registers and logs in user', async () => {
+test("registers and logs in user", async () => {
   render(
     <MemoryRouter>
       <Register />
-    </MemoryRouter>
-  )
-  fireEvent.change(screen.getByPlaceholderText('Phone number'), {
-    target: { value: '1234567' }
-  })
-  fireEvent.change(screen.getByPlaceholderText('Code'), {
-    target: { value: '0000' }
-  })
-  fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-  await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2))
-  expect(mockRequest.mock.calls[0][0]).toBe(API_PATHS.register)
-  expect(mockRequest.mock.calls[1][0]).toBe(API_PATHS.login)
-  await waitFor(() => expect(mockSetUser).toHaveBeenCalledWith({ id: '1', token: 't' }))
-  expect(mockNavigate).toHaveBeenCalledWith('/')
-})
+    </MemoryRouter>,
+  );
+  fireEvent.change(screen.getByPlaceholderText("Phone number"), {
+    target: { value: "1234567" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("Code"), {
+    target: { value: "0000" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+  expect(mockRequest.mock.calls[0][0]).toBe(API_PATHS.register);
+  expect(mockRequest.mock.calls[1][0]).toBe(API_PATHS.login);
+  await waitFor(() =>
+    expect(mockSetUser).toHaveBeenCalledWith({ id: "1", token: "t" }),
+  );
+  expect(mockNavigate).toHaveBeenCalledWith("/");
+});

--- a/website/src/api/__tests__/chat.test.js
+++ b/website/src/api/__tests__/chat.test.js
@@ -1,12 +1,15 @@
-import { createChatApi } from '@/api/chat.js'
-import { API_PATHS } from '@/config/api.js'
-import { jest } from '@jest/globals'
+import { createChatApi } from "@/api/chat.js";
+import { API_PATHS } from "@/config/api.js";
+import { jest } from "@jest/globals";
 
-test('sendChatMessage posts to chat endpoint', async () => {
-  const request = jest.fn().mockResolvedValue('ok')
-  const api = createChatApi(request)
-  await api.sendChatMessage('hi')
-  expect(request).toHaveBeenCalledWith(API_PATHS.chat, expect.objectContaining({
-    method: 'POST'
-  }))
-})
+test("sendChatMessage posts to chat endpoint", async () => {
+  const request = jest.fn().mockResolvedValue("ok");
+  const api = createChatApi(request);
+  await api.sendChatMessage("hi");
+  expect(request).toHaveBeenCalledWith(
+    API_PATHS.chat,
+    expect.objectContaining({
+      method: "POST",
+    }),
+  );
+});

--- a/website/src/api/__tests__/client.test.js
+++ b/website/src/api/__tests__/client.test.js
@@ -1,53 +1,55 @@
 /* eslint-env jest */
-import { jest } from "@jest/globals"
-import { createApiClient, ApiError } from '@/api/client.js'
+import { jest } from "@jest/globals";
+import { createApiClient, ApiError } from "@/api/client.js";
 
-describe('apiRequest error handling', () => {
+describe("apiRequest error handling", () => {
   afterEach(() => {
-    jest.restoreAllMocks()
-    delete global.fetch
-  })
+    jest.restoreAllMocks();
+    delete global.fetch;
+  });
 
-  test('throws message from JSON body on non-ok response', async () => {
+  test("throws message from JSON body on non-ok response", async () => {
     const resp = {
       ok: false,
-      text: jest.fn().mockResolvedValue(JSON.stringify({ message: 'Bad request' })),
-      headers: { get: () => 'application/json' },
-    }
-    global.fetch = jest.fn().mockResolvedValue(resp)
-    const apiRequest = createApiClient()
-    await expect(apiRequest('/api')).rejects.toThrow('Bad request')
-  })
+      text: jest
+        .fn()
+        .mockResolvedValue(JSON.stringify({ message: "Bad request" })),
+      headers: { get: () => "application/json" },
+    };
+    global.fetch = jest.fn().mockResolvedValue(resp);
+    const apiRequest = createApiClient();
+    await expect(apiRequest("/api")).rejects.toThrow("Bad request");
+  });
 
-  test('throws plain text message on non-ok response', async () => {
+  test("throws plain text message on non-ok response", async () => {
     const resp = {
       ok: false,
-      text: jest.fn().mockResolvedValue('Server error'),
-      headers: { get: () => 'text/plain' },
-    }
-    global.fetch = jest.fn().mockResolvedValue(resp)
-    const apiRequest = createApiClient()
-    await expect(apiRequest('/api')).rejects.toThrow('Server error')
-  })
+      text: jest.fn().mockResolvedValue("Server error"),
+      headers: { get: () => "text/plain" },
+    };
+    global.fetch = jest.fn().mockResolvedValue(resp);
+    const apiRequest = createApiClient();
+    await expect(apiRequest("/api")).rejects.toThrow("Server error");
+  });
 
-  test('includes status code in thrown error', async () => {
+  test("includes status code in thrown error", async () => {
     const resp = {
       ok: false,
       status: 403,
-      text: jest.fn().mockResolvedValue('Forbidden'),
-      headers: { get: () => 'text/plain' }
-    }
-    global.fetch = jest.fn().mockResolvedValue(resp)
-    const apiRequest = createApiClient()
-    await expect(apiRequest('/api')).rejects.toMatchObject({ status: 403 })
-  })
+      text: jest.fn().mockResolvedValue("Forbidden"),
+      headers: { get: () => "text/plain" },
+    };
+    global.fetch = jest.fn().mockResolvedValue(resp);
+    const apiRequest = createApiClient();
+    await expect(apiRequest("/api")).rejects.toMatchObject({ status: 403 });
+  });
 
-  test('throws unified message on network failure', async () => {
-    const error = new Error('network down')
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
-    global.fetch = jest.fn().mockRejectedValue(error)
-    const apiRequest = createApiClient()
-    await expect(apiRequest('/api')).rejects.toThrow('Network error')
-    expect(spy).toHaveBeenCalledWith(error)
-  })
-})
+  test("throws unified message on network failure", async () => {
+    const error = new Error("network down");
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = jest.fn().mockRejectedValue(error);
+    const apiRequest = createApiClient();
+    await expect(apiRequest("/api")).rejects.toThrow("Network error");
+    expect(spy).toHaveBeenCalledWith(error);
+  });
+});

--- a/website/src/api/__tests__/locale.test.js
+++ b/website/src/api/__tests__/locale.test.js
@@ -1,10 +1,10 @@
-import { createLocaleApi } from '@/api/locale.js'
-import { API_PATHS } from '@/config/api.js'
-import { jest } from '@jest/globals'
+import { createLocaleApi } from "@/api/locale.js";
+import { API_PATHS } from "@/config/api.js";
+import { jest } from "@jest/globals";
 
-test('getLocale fetches locale endpoint', async () => {
-  const request = jest.fn().mockResolvedValue({})
-  const api = createLocaleApi(request)
-  await api.getLocale()
-  expect(request).toHaveBeenCalledWith(API_PATHS.locale)
-})
+test("getLocale fetches locale endpoint", async () => {
+  const request = jest.fn().mockResolvedValue({});
+  const api = createLocaleApi(request);
+  await api.getLocale();
+  expect(request).toHaveBeenCalledWith(API_PATHS.locale);
+});

--- a/website/src/api/__tests__/users.test.js
+++ b/website/src/api/__tests__/users.test.js
@@ -1,14 +1,14 @@
-import { createUsersApi } from '@/api/users.js'
-import { API_PATHS } from '@/config/api.js'
-import { jest } from '@jest/globals'
+import { createUsersApi } from "@/api/users.js";
+import { API_PATHS } from "@/config/api.js";
+import { jest } from "@jest/globals";
 
-test('uploadAvatar posts FormData', async () => {
-  const request = jest.fn().mockResolvedValue({})
-  const api = createUsersApi(request)
-  const file = new Blob(['x'], { type: 'text/plain' })
-  await api.uploadAvatar({ userId: '1', token: 't', file })
-  const [url, options] = request.mock.calls[0]
-  expect(url).toBe(`${API_PATHS.users}/1/avatar-file`)
-  expect(options.method).toBe('POST')
-  expect(options.body).toBeInstanceOf(FormData)
-})
+test("uploadAvatar posts FormData", async () => {
+  const request = jest.fn().mockResolvedValue({});
+  const api = createUsersApi(request);
+  const file = new Blob(["x"], { type: "text/plain" });
+  await api.uploadAvatar({ userId: "1", token: "t", file });
+  const [url, options] = request.mock.calls[0];
+  expect(url).toBe(`${API_PATHS.users}/1/avatar-file`);
+  expect(options.method).toBe("POST");
+  expect(options.body).toBeInstanceOf(FormData);
+});

--- a/website/src/api/client.js
+++ b/website/src/api/client.js
@@ -1,4 +1,4 @@
-import { extractMessage } from '@/utils/json.js'
+import { extractMessage } from "@/utils/json.js";
 
 /**
  * Error thrown by the API client for non-ok HTTP responses.
@@ -7,9 +7,9 @@ import { extractMessage } from '@/utils/json.js'
  */
 export class ApiError extends Error {
   constructor(status, message, headers) {
-    super(message)
-    this.status = status
-    this.headers = headers
+    super(message);
+    this.status = status;
+    this.headers = headers;
   }
 }
 
@@ -22,41 +22,45 @@ export class ApiError extends Error {
  * @param {Function} [config.onUnauthorized] callback when response is 401
  * @returns {Function} request function
  */
-export function createApiClient({ token, headers: defaultHeaders = {}, onUnauthorized } = {}) {
+export function createApiClient({
+  token,
+  headers: defaultHeaders = {},
+  onUnauthorized,
+} = {}) {
   return async function apiRequest(
     url,
-    { token: reqToken, headers = {}, ...options } = {}
+    { token: reqToken, headers = {}, ...options } = {},
   ) {
-    const mergedHeaders = { ...defaultHeaders, ...headers }
-    const authToken = reqToken ?? token
-    if (authToken) mergedHeaders['X-USER-TOKEN'] = authToken
+    const mergedHeaders = { ...defaultHeaders, ...headers };
+    const authToken = reqToken ?? token;
+    if (authToken) mergedHeaders["X-USER-TOKEN"] = authToken;
 
-    let resp
+    let resp;
     try {
-      resp = await fetch(url, { ...options, headers: mergedHeaders })
+      resp = await fetch(url, { ...options, headers: mergedHeaders });
     } catch (err) {
-      console.error(err)
-      throw new Error('Network error')
+      console.error(err);
+      throw new Error("Network error");
     }
     if (!resp.ok) {
-      if (resp.status === 401) onUnauthorized?.()
+      if (resp.status === 401) onUnauthorized?.();
       const text = await resp.text().catch((err) => {
-        console.error(err)
-        return ''
-      })
-      const message = extractMessage(text) || 'Request failed'
-      throw new ApiError(resp.status, message, resp.headers)
+        console.error(err);
+        return "";
+      });
+      const message = extractMessage(text) || "Request failed";
+      throw new ApiError(resp.status, message, resp.headers);
     }
-    const contentType = resp.headers.get('content-type') || ''
-    if (contentType.includes('application/json')) {
-      return resp.json()
+    const contentType = resp.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      return resp.json();
     }
-    return resp
-  }
+    return resp;
+  };
 }
 
 // default instance without preset headers
-export const apiRequest = createApiClient()
+export const apiRequest = createApiClient();
 
 /**
  * Create a helper for JSON-based requests.
@@ -67,17 +71,17 @@ export const apiRequest = createApiClient()
 export function createJsonRequest(request = apiRequest) {
   return function jsonRequest(
     url,
-    { token, method = 'POST', body, headers = {}, ...options } = {},
+    { token, method = "POST", body, headers = {}, ...options } = {},
   ) {
     return request(url, {
       ...options,
       token,
       method,
-      headers: { 'Content-Type': 'application/json', ...headers },
+      headers: { "Content-Type": "application/json", ...headers },
       body: body !== undefined ? JSON.stringify(body) : undefined,
-    })
-  }
+    });
+  };
 }
 
 // default JSON request instance
-export const jsonRequest = createJsonRequest()
+export const jsonRequest = createJsonRequest();

--- a/website/src/api/locale.js
+++ b/website/src/api/locale.js
@@ -1,14 +1,14 @@
-import { API_PATHS } from '@/config/api.js'
-import { apiRequest } from './client.js'
-import { useApi } from '@/hooks'
+import { API_PATHS } from "@/config/api.js";
+import { apiRequest } from "./client.js";
+import { useApi } from "@/hooks";
 
 export function createLocaleApi(request = apiRequest) {
-  const getLocale = () => request(API_PATHS.locale)
-  return { getLocale }
+  const getLocale = () => request(API_PATHS.locale);
+  return { getLocale };
 }
 
-export const { getLocale } = createLocaleApi()
+export const { getLocale } = createLocaleApi();
 
 export function useLocaleApi() {
-  return useApi().locale
+  return useApi().locale;
 }

--- a/website/src/components/Brand/index.jsx
+++ b/website/src/components/Brand/index.jsx
@@ -1,15 +1,15 @@
-import { useLanguage } from '@/context'
-import ThemeIcon from '@/components/ui/Icon'
-import { UserMenu } from '@/components/Header'
-import { getBrandText } from '@/utils'
+import { useLanguage } from "@/context";
+import ThemeIcon from "@/components/ui/Icon";
+import { UserMenu } from "@/components/Header";
+import { getBrandText } from "@/utils";
 
 function Brand() {
-  const { lang } = useLanguage()
-  const brandText = getBrandText(lang)
+  const { lang } = useLanguage();
+  const brandText = getBrandText(lang);
 
   const handleClick = () => {
-    window.location.reload()
-  }
+    window.location.reload();
+  };
 
   return (
     <div className="sidebar-brand">
@@ -21,7 +21,7 @@ function Brand() {
         <UserMenu size={28} />
       </div>
     </div>
-  )
+  );
 }
 
-export default Brand
+export default Brand;

--- a/website/src/components/Header/ProTag.jsx
+++ b/website/src/components/Header/ProTag.jsx
@@ -1,9 +1,9 @@
-import ThemeIcon from '@/components/ui/Icon'
-import styles from './Header.module.css'
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./Header.module.css";
 
 function ProTag({ small }) {
-  const className = small ? styles['pro-tag-small'] : styles['pro-tag']
-  return <ThemeIcon name="pro-tag" className={className} />
+  const className = small ? styles["pro-tag-small"] : styles["pro-tag"];
+  return <ThemeIcon name="pro-tag" className={className} />;
 }
 
-export default ProTag
+export default ProTag;

--- a/website/src/components/Header/UserMenuButton.jsx
+++ b/website/src/components/Header/UserMenuButton.jsx
@@ -1,14 +1,20 @@
-import { useOutsideToggle } from '@/hooks'
-import Avatar from '@/components/ui/Avatar'
-import ProTag from './ProTag.jsx'
-import styles from './Header.module.css'
+import { useOutsideToggle } from "@/hooks";
+import Avatar from "@/components/ui/Avatar";
+import ProTag from "./ProTag.jsx";
+import styles from "./Header.module.css";
 
 function UserMenuButton({ size, showName, isPro, username, children }) {
-  const { open, setOpen, ref: menuRef } = useOutsideToggle(false)
+  const { open, setOpen, ref: menuRef } = useOutsideToggle(false);
 
   return (
-    <div className={`${styles['header-section']} ${styles['user-menu']}`} ref={menuRef}>
-      <button onClick={() => setOpen(!open)} className={showName ? styles['with-name'] : ''}>
+    <div
+      className={`${styles["header-section"]} ${styles["user-menu"]}`}
+      ref={menuRef}
+    >
+      <button
+        onClick={() => setOpen(!open)}
+        className={showName ? styles["with-name"] : ""}
+      >
         <Avatar width={size} height={size} />
         {showName ? (
           <div className={styles.info}>
@@ -21,7 +27,7 @@ function UserMenuButton({ size, showName, isPro, username, children }) {
       </button>
       {children({ open, setOpen })}
     </div>
-  )
+  );
 }
 
-export default UserMenuButton
+export default UserMenuButton;

--- a/website/src/components/Header/index.js
+++ b/website/src/components/Header/index.js
@@ -1,5 +1,5 @@
-export { default as ProTag } from './ProTag.jsx'
-export { default as UserMenu } from './UserMenu.jsx'
-export { default as UserMenuButton } from './UserMenuButton.jsx'
-export { default as UserMenuDropdown } from './UserMenuDropdown.jsx'
-export { default as UserMenuModals } from './UserMenuModals.jsx'
+export { default as ProTag } from "./ProTag.jsx";
+export { default as UserMenu } from "./UserMenu.jsx";
+export { default as UserMenuButton } from "./UserMenuButton.jsx";
+export { default as UserMenuDropdown } from "./UserMenuDropdown.jsx";
+export { default as UserMenuModals } from "./UserMenuModals.jsx";

--- a/website/src/components/Layout/index.jsx
+++ b/website/src/components/Layout/index.jsx
@@ -1,13 +1,18 @@
-import { useState } from 'react'
-import Sidebar from '@/components/Sidebar'
-import DesktopTopBar from '@/components/TopBar/DesktopTopBar.jsx'
-import MobileTopBar from '@/components/TopBar/MobileTopBar.jsx'
-import { useIsMobile } from '@/utils'
-import styles from './Layout.module.css'
+import { useState } from "react";
+import Sidebar from "@/components/Sidebar";
+import DesktopTopBar from "@/components/TopBar/DesktopTopBar.jsx";
+import MobileTopBar from "@/components/TopBar/MobileTopBar.jsx";
+import { useIsMobile } from "@/utils";
+import styles from "./Layout.module.css";
 
-function Layout({ children, sidebarProps = {}, topBarProps = {}, bottomContent = null }) {
-  const isMobile = useIsMobile()
-  const [sidebarOpen, setSidebarOpen] = useState(false)
+function Layout({
+  children,
+  sidebarProps = {},
+  topBarProps = {},
+  bottomContent = null,
+}) {
+  const isMobile = useIsMobile();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
     <div className={styles.container}>
@@ -18,7 +23,7 @@ function Layout({ children, sidebarProps = {}, topBarProps = {}, bottomContent =
         isMobile={isMobile}
       />
       <div className={styles.main}>
-        <div className={styles['main-top']}>
+        <div className={styles["main-top"]}>
           {isMobile ? (
             <MobileTopBar
               {...topBarProps}
@@ -28,11 +33,11 @@ function Layout({ children, sidebarProps = {}, topBarProps = {}, bottomContent =
             <DesktopTopBar {...topBarProps} />
           )}
         </div>
-        <div className={styles['main-middle']}>{children}</div>
-        <div className={styles['main-bottom']}>{bottomContent}</div>
+        <div className={styles["main-middle"]}>{children}</div>
+        <div className={styles["main-bottom"]}>{bottomContent}</div>
       </div>
     </div>
-  )
+  );
 }
 
-export default Layout
+export default Layout;

--- a/website/src/components/Sidebar/Sidebar.jsx
+++ b/website/src/components/Sidebar/Sidebar.jsx
@@ -1,23 +1,25 @@
-import Brand from '@/components/Brand'
-import SidebarFunctions from './SidebarFunctions.jsx'
-import SidebarUser from './SidebarUser.jsx'
-import { useIsMobile } from '@/utils'
+import Brand from "@/components/Brand";
+import SidebarFunctions from "./SidebarFunctions.jsx";
+import SidebarUser from "./SidebarUser.jsx";
+import { useIsMobile } from "@/utils";
 
 function Sidebar({
   isMobile: mobileProp,
   open = false,
   onClose,
   onToggleFavorites,
-  onSelectHistory
+  onSelectHistory,
 }) {
-  const defaultMobile = useIsMobile()
-  const isMobile = mobileProp ?? defaultMobile
+  const defaultMobile = useIsMobile();
+  const isMobile = mobileProp ?? defaultMobile;
   return (
     <>
       {isMobile && open && (
         <div className="sidebar-overlay" onClick={onClose} />
       )}
-      <aside className={`sidebar${isMobile ? (open ? ' mobile-open' : '') : ''}`}>
+      <aside
+        className={`sidebar${isMobile ? (open ? " mobile-open" : "") : ""}`}
+      >
         <Brand />
         <SidebarFunctions
           onToggleFavorites={onToggleFavorites}
@@ -26,7 +28,7 @@ function Sidebar({
         <SidebarUser />
       </aside>
     </>
-  )
+  );
 }
 
-export default Sidebar
+export default Sidebar;

--- a/website/src/components/Sidebar/SidebarFunctions.jsx
+++ b/website/src/components/Sidebar/SidebarFunctions.jsx
@@ -1,16 +1,16 @@
-import Favorites from './Favorites.jsx'
-import HistoryList from './HistoryList.jsx'
-import { useUser } from '@/context'
-import styles from './Sidebar.module.css'
+import Favorites from "./Favorites.jsx";
+import HistoryList from "./HistoryList.jsx";
+import { useUser } from "@/context";
+import styles from "./Sidebar.module.css";
 
 function SidebarFunctions({ onToggleFavorites, onSelectHistory }) {
-  const { user } = useUser()
+  const { user } = useUser();
   return (
-    <div className={styles['sidebar-functions']}>
+    <div className={styles["sidebar-functions"]}>
       {user && <Favorites onToggle={onToggleFavorites} />}
       <HistoryList onSelect={onSelectHistory} />
     </div>
-  )
+  );
 }
 
-export default SidebarFunctions
+export default SidebarFunctions;

--- a/website/src/components/Sidebar/index.js
+++ b/website/src/components/Sidebar/index.js
@@ -1,5 +1,5 @@
-export { default } from './Sidebar.jsx'
-export { default as Favorites } from './Favorites.jsx'
-export { default as HistoryList } from './HistoryList.jsx'
-export { default as SidebarFunctions } from './SidebarFunctions.jsx'
-export { default as SidebarUser } from './SidebarUser.jsx'
+export { default } from "./Sidebar.jsx";
+export { default as Favorites } from "./Favorites.jsx";
+export { default as HistoryList } from "./HistoryList.jsx";
+export { default as SidebarFunctions } from "./SidebarFunctions.jsx";
+export { default as SidebarUser } from "./SidebarUser.jsx";

--- a/website/src/components/TopBar/DesktopTopBar.jsx
+++ b/website/src/components/TopBar/DesktopTopBar.jsx
@@ -1,8 +1,9 @@
+import PropTypes from "prop-types";
 import styles from "./DesktopTopBar.module.css";
 import common from "./TopBarCommon.module.css";
 import TopBarActions from "./TopBarActions.jsx";
-import { TtsButton } from "@/components";
 import ThemeIcon from "@/components/ui/Icon";
+import OutputToolbar from "./OutputToolbar.jsx";
 import { useLanguage } from "@/context";
 
 function DesktopTopBar({
@@ -13,37 +14,100 @@ function DesktopTopBar({
   favorited = false,
   onToggleFavorite,
   canFavorite = false,
+  canReoutput = false,
+  onReoutput,
+  versions = [],
+  activeVersionId,
+  onNavigateVersion,
+  isLoading = false,
+  toolbarComponent = OutputToolbar,
+  toolbarProps = {},
+  ttsComponent,
 }) {
   const { t } = useLanguage();
+  const ToolbarComponent = toolbarComponent;
 
   return (
     <header className={styles["desktop-topbar"]}>
-      <button
-        type="button"
-        className={`${common["back-btn"]} ${showBack ? styles.visible : styles.hidden}`}
-        onClick={onBack}
-        aria-label={t.back}
-      >
-        <ThemeIcon
-          name="arrow-left"
-          alt=""
-          width={24}
-          height={24}
-          aria-hidden="true"
+      <div className={styles.left}>
+        <button
+          type="button"
+          className={`${common["back-btn"]} ${showBack ? styles.visible : styles.hidden}`}
+          onClick={onBack}
+          aria-label={t.back}
+        >
+          <ThemeIcon
+            name="arrow-left"
+            alt=""
+            width={24}
+            height={24}
+            aria-hidden="true"
+          />
+        </button>
+        {term && (
+          <div className={`${common["term-text"]} ${styles["term-text"]}`}>
+            <span>{term}</span>
+          </div>
+        )}
+      </div>
+      <div className={styles.right}>
+        <ToolbarComponent
+          term={term}
+          lang={lang}
+          onReoutput={onReoutput}
+          disabled={!canReoutput || isLoading}
+          versions={versions}
+          activeVersionId={activeVersionId}
+          onNavigate={onNavigateVersion}
+          ttsComponent={ttsComponent}
+          {...toolbarProps}
         />
-      </button>
-      {term && (
-        <div className={`${common["term-text"]} ${styles["term-text"]}`}>
-          <TtsButton text={term} lang={lang} size={20} />
-        </div>
-      )}
-      <TopBarActions
-        favorited={favorited}
-        onToggleFavorite={onToggleFavorite}
-        canFavorite={canFavorite}
-      />
+        <TopBarActions
+          favorited={favorited}
+          onToggleFavorite={onToggleFavorite}
+          canFavorite={canFavorite}
+        />
+      </div>
     </header>
   );
 }
+
+DesktopTopBar.propTypes = {
+  term: PropTypes.string,
+  lang: PropTypes.string,
+  showBack: PropTypes.bool,
+  onBack: PropTypes.func,
+  favorited: PropTypes.bool,
+  onToggleFavorite: PropTypes.func,
+  canFavorite: PropTypes.bool,
+  canReoutput: PropTypes.bool,
+  onReoutput: PropTypes.func,
+  versions: PropTypes.arrayOf(PropTypes.object),
+  activeVersionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onNavigateVersion: PropTypes.func,
+  isLoading: PropTypes.bool,
+  toolbarComponent: PropTypes.elementType,
+  toolbarProps: PropTypes.object,
+  ttsComponent: PropTypes.elementType,
+};
+
+DesktopTopBar.defaultProps = {
+  term: "",
+  lang: "en",
+  showBack: false,
+  onBack: undefined,
+  favorited: false,
+  onToggleFavorite: undefined,
+  canFavorite: false,
+  canReoutput: false,
+  onReoutput: undefined,
+  versions: [],
+  activeVersionId: undefined,
+  onNavigateVersion: undefined,
+  isLoading: false,
+  toolbarComponent: OutputToolbar,
+  toolbarProps: {},
+  ttsComponent: undefined,
+};
 
 export default DesktopTopBar;

--- a/website/src/components/TopBar/DesktopTopBar.module.css
+++ b/website/src/components/TopBar/DesktopTopBar.module.css
@@ -16,12 +16,37 @@
   gap: 8px;
 }
 
+.left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .term-text {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
   text-align: center;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.term-text span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .topbar-right .favorite-toggle {

--- a/website/src/components/TopBar/MobileTopBar.jsx
+++ b/website/src/components/TopBar/MobileTopBar.jsx
@@ -1,9 +1,10 @@
+import PropTypes from "prop-types";
 import ThemeIcon from "@/components/ui/Icon";
 import TopBarActions from "./TopBarActions.jsx";
 import common from "./TopBarCommon.module.css";
 import styles from "./MobileTopBar.module.css";
 import { getBrandText } from "@/utils";
-import { TtsButton } from "@/components";
+import OutputToolbar from "./OutputToolbar.jsx";
 import { useLanguage } from "@/context";
 
 function MobileTopBar({
@@ -14,10 +15,20 @@ function MobileTopBar({
   favorited = false,
   onToggleFavorite,
   canFavorite = false,
+  canReoutput = false,
+  onReoutput,
+  versions = [],
+  activeVersionId,
+  onNavigateVersion,
+  isLoading = false,
   onOpenSidebar,
+  toolbarComponent = OutputToolbar,
+  toolbarProps = {},
+  ttsComponent,
 }) {
   const brandText = getBrandText(lang);
   const { t } = useLanguage();
+  const ToolbarComponent = toolbarComponent;
 
   return (
     <header className={styles["mobile-topbar"]}>
@@ -40,16 +51,69 @@ function MobileTopBar({
       </button>
       {term && (
         <div className={`${common["term-text"]} ${styles["term-text"]}`}>
-          <TtsButton text={term} lang={lang} size={20} />
+          <span>{term}</span>
         </div>
       )}
-      <TopBarActions
-        favorited={favorited}
-        onToggleFavorite={onToggleFavorite}
-        canFavorite={canFavorite}
-      />
+      <div className={styles.right}>
+        <ToolbarComponent
+          term={term}
+          lang={lang}
+          onReoutput={onReoutput}
+          disabled={!canReoutput || isLoading}
+          versions={versions}
+          activeVersionId={activeVersionId}
+          onNavigate={onNavigateVersion}
+          ttsComponent={ttsComponent}
+          {...toolbarProps}
+        />
+        <TopBarActions
+          favorited={favorited}
+          onToggleFavorite={onToggleFavorite}
+          canFavorite={canFavorite}
+        />
+      </div>
     </header>
   );
 }
+
+MobileTopBar.propTypes = {
+  term: PropTypes.string,
+  lang: PropTypes.string,
+  showBack: PropTypes.bool,
+  onBack: PropTypes.func,
+  favorited: PropTypes.bool,
+  onToggleFavorite: PropTypes.func,
+  canFavorite: PropTypes.bool,
+  canReoutput: PropTypes.bool,
+  onReoutput: PropTypes.func,
+  versions: PropTypes.arrayOf(PropTypes.object),
+  activeVersionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onNavigateVersion: PropTypes.func,
+  isLoading: PropTypes.bool,
+  onOpenSidebar: PropTypes.func,
+  toolbarComponent: PropTypes.elementType,
+  toolbarProps: PropTypes.object,
+  ttsComponent: PropTypes.elementType,
+};
+
+MobileTopBar.defaultProps = {
+  term: "",
+  lang: "en",
+  showBack: false,
+  onBack: undefined,
+  favorited: false,
+  onToggleFavorite: undefined,
+  canFavorite: false,
+  canReoutput: false,
+  onReoutput: undefined,
+  versions: [],
+  activeVersionId: undefined,
+  onNavigateVersion: undefined,
+  isLoading: false,
+  onOpenSidebar: undefined,
+  toolbarComponent: OutputToolbar,
+  toolbarProps: {},
+  ttsComponent: undefined,
+};
 
 export default MobileTopBar;

--- a/website/src/components/TopBar/MobileTopBar.module.css
+++ b/website/src/components/TopBar/MobileTopBar.module.css
@@ -22,6 +22,17 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.term-text span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mobile-topbar {
@@ -31,4 +42,11 @@
   padding: 0 12px;
   gap: 8px;
   border-bottom: 1px solid var(--border-color);
+}
+
+.right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }

--- a/website/src/components/TopBar/OutputToolbar.jsx
+++ b/website/src/components/TopBar/OutputToolbar.jsx
@@ -1,0 +1,118 @@
+import PropTypes from "prop-types";
+import { memo, useMemo } from "react";
+import { TtsButton } from "@/components";
+import ThemeIcon from "@/components/ui/Icon";
+import { useLanguage } from "@/context";
+import styles from "./OutputToolbar.module.css";
+
+function OutputToolbar({
+  term,
+  lang,
+  onReoutput,
+  disabled,
+  versions,
+  activeVersionId,
+  onNavigate,
+  ttsComponent = TtsButton,
+}) {
+  const { t } = useLanguage();
+  const TtsComponent = ttsComponent;
+  const { currentIndex, total } = useMemo(() => {
+    if (!Array.isArray(versions) || versions.length === 0) {
+      return { currentIndex: 0, total: 0 };
+    }
+    const resolvedIndex = versions.findIndex(
+      (item) => String(item.id) === String(activeVersionId),
+    );
+    const index = resolvedIndex >= 0 ? resolvedIndex + 1 : versions.length;
+    return { currentIndex: index, total: versions.length };
+  }, [versions, activeVersionId]);
+
+  const hasPrevious = total > 1 && currentIndex > 1;
+  const hasNext = total > 1 && currentIndex < total;
+  const indicator = total
+    ? (t.versionIndicator || "{current}/{total}")
+        .replace("{current}", String(currentIndex))
+        .replace("{total}", String(total))
+    : t.versionIndicatorEmpty || "0/0";
+  const speakableTerm = typeof term === "string" ? term.trim() : term;
+  const showTts = Boolean(speakableTerm);
+
+  return (
+    <div className={styles.toolbar} data-testid="output-toolbar">
+      {showTts ? (
+        <TtsComponent
+          text={term}
+          lang={lang}
+          size={20}
+          disabled={!speakableTerm}
+        />
+      ) : null}
+      <button
+        type="button"
+        className={styles.replay}
+        onClick={onReoutput}
+        disabled={disabled || !speakableTerm}
+        aria-label={t.reoutput}
+      >
+        <ThemeIcon name="refresh" width={16} height={16} aria-hidden="true" />
+        <span>{t.reoutput}</span>
+      </button>
+      <div className={styles["version-controls"]}>
+        <button
+          type="button"
+          className={styles["nav-button"]}
+          onClick={() => onNavigate?.("previous")}
+          disabled={!hasPrevious}
+          aria-label={t.previousVersion}
+        >
+          <ThemeIcon
+            name="arrow-left"
+            width={14}
+            height={14}
+            aria-hidden="true"
+          />
+        </button>
+        <span className={styles.indicator}>{indicator}</span>
+        <button
+          type="button"
+          className={styles["nav-button"]}
+          onClick={() => onNavigate?.("next")}
+          disabled={!hasNext}
+          aria-label={t.nextVersion}
+        >
+          <ThemeIcon
+            name="arrow-right"
+            width={14}
+            height={14}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+OutputToolbar.propTypes = {
+  term: PropTypes.string,
+  lang: PropTypes.string,
+  onReoutput: PropTypes.func,
+  disabled: PropTypes.bool,
+  versions: PropTypes.arrayOf(PropTypes.object),
+  activeVersionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onNavigate: PropTypes.func,
+  ttsComponent: PropTypes.elementType,
+};
+
+OutputToolbar.defaultProps = {
+  term: "",
+  lang: "en",
+  onReoutput: undefined,
+  disabled: false,
+  versions: [],
+  activeVersionId: undefined,
+  onNavigate: undefined,
+  ttsComponent: TtsButton,
+};
+
+export default memo(OutputToolbar);

--- a/website/src/components/TopBar/OutputToolbar.module.css
+++ b/website/src/components/TopBar/OutputToolbar.module.css
@@ -1,0 +1,96 @@
+.toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-surface-alt) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+  box-shadow: 0 6px 18px
+    color-mix(in srgb, var(--shadow-color) 20%, transparent);
+}
+
+.replay {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: none;
+  background: var(--primary-bg);
+  color: var(--primary-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
+  box-shadow: 0 6px 16px
+    color-mix(in srgb, var(--shadow-color) 18%, transparent);
+}
+
+.replay:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+}
+
+.replay:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.version-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-button {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 90%, transparent);
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.nav-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+  transform: none;
+}
+
+.nav-button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.indicator {
+  min-width: 52px;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+@media (width <= 768px) {
+  .toolbar {
+    gap: 8px;
+    padding: 6px 10px;
+  }
+
+  .replay span {
+    display: none;
+  }
+
+  .indicator {
+    min-width: 40px;
+  }
+}

--- a/website/src/components/TopBar/__tests__/DesktopTopBar.test.jsx
+++ b/website/src/components/TopBar/__tests__/DesktopTopBar.test.jsx
@@ -1,46 +1,114 @@
-/* eslint-env jest */
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import { jest } from "@jest/globals";
 
-// mock TtsButton to isolate top bar behaviour
-const TtsButton = jest.fn(() => <div data-testid="tts" />);
+const mockTtsButton = jest.fn(() => <button data-testid="tts" type="button" />);
 
-jest.unstable_mockModule("@/components", () => ({ TtsButton }));
+jest.unstable_mockModule("@/context", () => ({
+  useLanguage: () => ({
+    t: {
+      reoutput: "重新输出",
+      previousVersion: "上一版本",
+      nextVersion: "下一版本",
+      versionIndicator: "{current}/{total}",
+      versionIndicatorEmpty: "0/0",
+      back: "返回",
+      share: "分享",
+      report: "反馈",
+    },
+    lang: "zh",
+  }),
+  useTheme: () => ({ resolvedTheme: "light" }),
+  useUser: () => ({ user: { id: "u" } }),
+  useApiContext: () => ({}),
+}));
+
+jest.unstable_mockModule("@/components", () => ({
+  TtsButton: mockTtsButton,
+}));
 
 const { default: DesktopTopBar } = await import(
   "@/components/TopBar/DesktopTopBar.jsx"
 );
 
+const renderBar = (props = {}) =>
+  render(
+    <DesktopTopBar
+      term="term"
+      lang="en"
+      canReoutput
+      versions={[{ id: "v1" }, { id: "v2" }]}
+      activeVersionId="v1"
+      {...props}
+    />,
+  );
+
 describe("DesktopTopBar", () => {
-  afterEach(() => {
-    TtsButton.mockClear();
+  beforeEach(() => {
+    mockTtsButton.mockClear();
   });
 
   /**
-   * Renders play button when a term is provided.
+   * 确认在提供 term 时会渲染语音按钮且带入语言参数。
    */
-  test("renders tts button for term", () => {
-    render(<DesktopTopBar term="hello" lang="en" />);
-    expect(TtsButton).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "hello", lang: "en", size: 20 }),
-      {},
+  test("renders tts button when term provided", () => {
+    renderBar();
+    expect(mockTtsButton).toHaveBeenCalledTimes(1);
+    expect(mockTtsButton.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ text: "term", lang: "en" }),
     );
   });
 
   /**
-   * Omits play button when term is empty.
+   * 确认无 term 时不会渲染语音按钮，避免空调用。
    */
-  test("hides tts button without term", () => {
-    render(<DesktopTopBar term="" lang="en" />);
-    expect(TtsButton).not.toHaveBeenCalled();
+  test("omits tts button without term", () => {
+    renderBar({ term: "" });
+    expect(mockTtsButton).not.toHaveBeenCalled();
   });
 
   /**
-   * Applies accessible label on back button.
+   * 支持通过 props 注入定制 TTS 组件。
    */
-  test("back button has aria-label", () => {
-    const { getByLabelText } = render(<DesktopTopBar showBack />);
-    expect(getByLabelText("返回")).toBeInTheDocument();
+  test("respects injected tts component", () => {
+    const customTts = jest.fn(() => <div data-testid="custom-tts" />);
+    renderBar({ ttsComponent: customTts });
+    expect(customTts).toHaveBeenCalled();
+    expect(mockTtsButton).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 验证重新输出按钮可以触发回调。
+   */
+  test("fires reoutput callback", () => {
+    const onReoutput = jest.fn();
+    renderBar({ onReoutput });
+    fireEvent.click(screen.getByRole("button", { name: "重新输出" }));
+    expect(onReoutput).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 验证版本导航按钮会向上传递方向参数。
+   */
+  test("passes navigation intent", () => {
+    const onNavigate = jest.fn();
+    renderBar({ onNavigateVersion: onNavigate });
+    fireEvent.click(screen.getByRole("button", { name: "下一版本" }));
+    expect(onNavigate).toHaveBeenCalledWith("next");
+  });
+
+  /**
+   * 支持通过 toolbarComponent 覆盖默认工具栏。
+   */
+  test("allows toolbar injection", () => {
+    const ToolbarStub = jest.fn(() => <div data-testid="stub" />);
+    renderBar({
+      toolbarComponent: ToolbarStub,
+      toolbarProps: { tone: "warm" },
+    });
+    expect(ToolbarStub).toHaveBeenCalledTimes(1);
+    expect(ToolbarStub.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ term: "term", tone: "warm" }),
+    );
   });
 });

--- a/website/src/components/TopBar/__tests__/MobileTopBar.test.jsx
+++ b/website/src/components/TopBar/__tests__/MobileTopBar.test.jsx
@@ -1,48 +1,115 @@
-/* eslint-env jest */
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import { jest } from "@jest/globals";
 
-// mock TtsButton to isolate top bar behaviour
-const TtsButton = jest.fn(() => <div data-testid="tts" />);
+const mockTtsButton = jest.fn(() => <button data-testid="tts" type="button" />);
 
-jest.unstable_mockModule("@/components", () => ({ TtsButton }));
+jest.unstable_mockModule("@/context", () => ({
+  useLanguage: () => ({
+    t: {
+      reoutput: "重新输出",
+      previousVersion: "上一版本",
+      nextVersion: "下一版本",
+      versionIndicator: "{current}/{total}",
+      versionIndicatorEmpty: "0/0",
+      back: "返回",
+      share: "分享",
+      report: "反馈",
+    },
+    lang: "zh",
+  }),
+  useTheme: () => ({ resolvedTheme: "light" }),
+  useUser: () => ({ user: { id: "u" } }),
+  useApiContext: () => ({}),
+}));
+
+jest.unstable_mockModule("@/components", () => ({
+  TtsButton: mockTtsButton,
+}));
 
 const { default: MobileTopBar } = await import(
   "@/components/TopBar/MobileTopBar.jsx"
 );
 
+const renderBar = (props = {}) =>
+  render(
+    <MobileTopBar
+      term="mobile"
+      lang="en"
+      canReoutput
+      versions={[{ id: "v1" }, { id: "v2" }]}
+      activeVersionId="v2"
+      onOpenSidebar={jest.fn()}
+      {...props}
+    />,
+  );
+
 describe("MobileTopBar", () => {
-  afterEach(() => {
-    TtsButton.mockClear();
+  beforeEach(() => {
+    mockTtsButton.mockClear();
   });
 
   /**
-   * Renders play button when a term is provided.
+   * 确保 term 存在时渲染 TTS 按钮。
    */
-  test("renders tts button for term", () => {
-    render(<MobileTopBar term="world" lang="en" />);
-    expect(TtsButton).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "world", lang: "en", size: 20 }),
-      {},
+  test("renders tts button when term provided", () => {
+    renderBar();
+    expect(mockTtsButton).toHaveBeenCalledTimes(1);
+    expect(mockTtsButton.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ text: "mobile", lang: "en" }),
     );
   });
 
   /**
-   * Omits play button when term is empty.
+   * 确保 term 为空时不会渲染 TTS 按钮。
    */
-  test("hides tts button without term", () => {
-    render(<MobileTopBar term="" lang="en" />);
-    expect(TtsButton).not.toHaveBeenCalled();
+  test("omits tts button without term", () => {
+    renderBar({ term: "" });
+    expect(mockTtsButton).not.toHaveBeenCalled();
   });
 
   /**
-   * Applies accessible label on back button.
+   * 验证重新输出按钮响应点击。
    */
-  test("back button has aria-label", () => {
-    const { getByLabelText } = render(
-      <MobileTopBar showBack onOpenSidebar={() => {}} />,
+  test("fires reoutput callback", () => {
+    const onReoutput = jest.fn();
+    renderBar({ onReoutput });
+    fireEvent.click(screen.getByRole("button", { name: "重新输出" }));
+    expect(onReoutput).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 验证导航按钮传递方向。
+   */
+  test("passes navigation intent", () => {
+    const onNavigate = jest.fn();
+    renderBar({ onNavigateVersion: onNavigate });
+    fireEvent.click(screen.getByRole("button", { name: "上一版本" }));
+    expect(onNavigate).toHaveBeenCalledWith("previous");
+  });
+
+  /**
+   * 支持注入自定义工具栏。
+   */
+  test("allows toolbar injection", () => {
+    const ToolbarStub = jest.fn(() => <div data-testid="stub" />);
+    renderBar({
+      toolbarComponent: ToolbarStub,
+      toolbarProps: { accent: "bold" },
+    });
+    expect(ToolbarStub).toHaveBeenCalledTimes(1);
+    expect(ToolbarStub.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ term: "mobile", accent: "bold" }),
     );
-    expect(getByLabelText("返回")).toBeInTheDocument();
+  });
+
+  /**
+   * 支持通过 props 注入定制 TTS 组件。
+   */
+  test("respects injected tts component", () => {
+    const customTts = jest.fn(() => <div data-testid="custom-tts" />);
+    renderBar({ ttsComponent: customTts });
+    expect(customTts).toHaveBeenCalled();
+    expect(mockTtsButton).not.toHaveBeenCalled();
   });
 });

--- a/website/src/components/TopBar/__tests__/OutputToolbar.test.jsx
+++ b/website/src/components/TopBar/__tests__/OutputToolbar.test.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+const mockTtsButton = jest.fn(() => <button data-testid="tts" type="button" />);
+
+jest.unstable_mockModule("@/context", () => ({
+  useLanguage: () => ({
+    t: {
+      reoutput: "重新输出",
+      previousVersion: "上一版本",
+      nextVersion: "下一版本",
+      versionIndicator: "{current}/{total}",
+      versionIndicatorEmpty: "0/0",
+    },
+    lang: "zh",
+  }),
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+jest.unstable_mockModule("@/components", () => ({
+  TtsButton: mockTtsButton,
+}));
+
+const { default: OutputToolbar } = await import(
+  "@/components/TopBar/OutputToolbar.jsx"
+);
+
+describe("OutputToolbar", () => {
+  beforeEach(() => {
+    mockTtsButton.mockClear();
+  });
+
+  /**
+   * 验证语音按钮仅在 term 存在时渲染，并保留 reoutput 功能。
+   */
+  test("renders tts when term provided and handles reoutput", () => {
+    const onReoutput = jest.fn();
+    render(
+      <OutputToolbar
+        term="hello"
+        lang="en"
+        onReoutput={onReoutput}
+        versions={[{ id: "v1" }]}
+      />,
+    );
+
+    expect(mockTtsButton).toHaveBeenCalledTimes(1);
+    expect(mockTtsButton.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ text: "hello", lang: "en" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "重新输出" }));
+    expect(onReoutput).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 验证无 term 时不会渲染语音按钮且导航禁用。
+   */
+  test("hides tts without term and disables navigation", () => {
+    render(<OutputToolbar term="" versions={[]} />);
+
+    expect(mockTtsButton).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "上一版本" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "下一版本" })).toBeDisabled();
+    expect(screen.getByText("0/0")).toBeInTheDocument();
+  });
+
+  /**
+   * 验证版本指示器展示正确且导航回调带方向。
+   */
+  test("shows indicator and emits navigation intent", () => {
+    const onNavigate = jest.fn();
+    render(
+      <OutputToolbar
+        term="hello"
+        versions={[{ id: "a" }, { id: "b" }, { id: "c" }]}
+        activeVersionId="b"
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.getByText("2/3")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "下一版本" }));
+    expect(onNavigate).toHaveBeenCalledWith("next");
+    fireEvent.click(screen.getByRole("button", { name: "上一版本" }));
+    expect(onNavigate).toHaveBeenCalledWith("previous");
+  });
+
+  /**
+   * 验证注入自定义 TTS 组件时不会调用默认组件。
+   */
+  test("prefers injected tts component", () => {
+    const customTts = jest.fn(() => <div data-testid="custom-tts" />);
+    render(
+      <OutputToolbar
+        term="hello"
+        versions={[{ id: "v1" }]}
+        ttsComponent={customTts}
+      />,
+    );
+
+    expect(customTts).toHaveBeenCalled();
+    expect(mockTtsButton).not.toHaveBeenCalled();
+  });
+});

--- a/website/src/components/__tests__/ErrorBoundary.test.js
+++ b/website/src/components/__tests__/ErrorBoundary.test.js
@@ -1,26 +1,26 @@
-import { render, screen } from '@testing-library/react'
-import { jest } from '@jest/globals'
-import ErrorBoundary from '@/components/ui/ErrorBoundary'
-import React from 'react'
+import { render, screen } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import ErrorBoundary from "@/components/ui/ErrorBoundary";
+import React from "react";
 
 function ProblemChild() {
-  throw new Error('boom')
+  throw new Error("boom");
 }
 
 beforeEach(() => {
-  jest.spyOn(console, 'error').mockImplementation(() => {})
-})
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
 
 afterEach(() => {
-  console.error.mockRestore()
-})
+  console.error.mockRestore();
+});
 
-test('displays fallback UI on error', () => {
+test("displays fallback UI on error", () => {
   const { asFragment } = render(
     <ErrorBoundary fallback={<div>Fallback</div>}>
       <ProblemChild />
-    </ErrorBoundary>
-  )
-  expect(screen.getByText('Fallback')).toBeInTheDocument()
-  expect(asFragment()).toMatchSnapshot()
-})
+    </ErrorBoundary>,
+  );
+  expect(screen.getByText("Fallback")).toBeInTheDocument();
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/website/src/components/form/AgeStepper/AgeStepper.jsx
+++ b/website/src/components/form/AgeStepper/AgeStepper.jsx
@@ -1,26 +1,36 @@
-import React from 'react'
-import styles from './AgeStepper.module.css'
+import React from "react";
+import styles from "./AgeStepper.module.css";
 
 function AgeStepper({ value = 0, onChange }) {
   const handleInput = (e) => {
-    const num = parseInt(e.target.value, 10)
-    if (onChange) onChange(Number.isNaN(num) ? '' : num)
-  }
+    const num = parseInt(e.target.value, 10);
+    if (onChange) onChange(Number.isNaN(num) ? "" : num);
+  };
   const dec = () => {
-    const num = parseInt(value, 10) || 0
-    if (onChange) onChange(num > 0 ? num - 1 : 0)
-  }
+    const num = parseInt(value, 10) || 0;
+    if (onChange) onChange(num > 0 ? num - 1 : 0);
+  };
   const inc = () => {
-    const num = parseInt(value, 10) || 0
-    if (onChange) onChange(num + 1)
-  }
+    const num = parseInt(value, 10) || 0;
+    if (onChange) onChange(num + 1);
+  };
   return (
     <div className={styles.stepper}>
-      <button type="button" className={styles.control} onClick={dec}>-</button>
-      <input type="number" min="0" value={value} onChange={handleInput} className={styles.input} />
-      <button type="button" className={styles.control} onClick={inc}>+</button>
+      <button type="button" className={styles.control} onClick={dec}>
+        -
+      </button>
+      <input
+        type="number"
+        min="0"
+        value={value}
+        onChange={handleInput}
+        className={styles.input}
+      />
+      <button type="button" className={styles.control} onClick={inc}>
+        +
+      </button>
     </div>
-  )
+  );
 }
 
-export default AgeStepper
+export default AgeStepper;

--- a/website/src/components/form/EditableField/EditableField.jsx
+++ b/website/src/components/form/EditableField/EditableField.jsx
@@ -1,27 +1,29 @@
-import { useState, useEffect } from 'react'
-import styles from './EditableField.module.css'
+import { useState, useEffect } from "react";
+import styles from "./EditableField.module.css";
 
 function EditableField({
   value,
   onChange,
-  placeholder = '',
+  placeholder = "",
   disabled = true,
-  className = '',
-  inputClassName = '',
-  buttonClassName = '',
-  buttonText = 'Edit'
+  className = "",
+  inputClassName = "",
+  buttonClassName = "",
+  buttonText = "Edit",
 }) {
-  const [editing, setEditing] = useState(!disabled)
+  const [editing, setEditing] = useState(!disabled);
 
   useEffect(() => {
-    setEditing(!disabled)
-  }, [disabled])
+    setEditing(!disabled);
+  }, [disabled]);
 
-  const containerCls = [styles.field, className].filter(Boolean).join(' ')
-  const inputCls = [styles.input, inputClassName].filter(Boolean).join(' ')
-  const btnCls = [styles['edit-btn'], buttonClassName].filter(Boolean).join(' ')
+  const containerCls = [styles.field, className].filter(Boolean).join(" ");
+  const inputCls = [styles.input, inputClassName].filter(Boolean).join(" ");
+  const btnCls = [styles["edit-btn"], buttonClassName]
+    .filter(Boolean)
+    .join(" ");
 
-  const enableEdit = () => setEditing(true)
+  const enableEdit = () => setEditing(true);
 
   return (
     <div className={containerCls}>
@@ -38,7 +40,7 @@ function EditableField({
         </button>
       )}
     </div>
-  )
+  );
 }
 
-export default EditableField
+export default EditableField;

--- a/website/src/components/form/FormField.jsx
+++ b/website/src/components/form/FormField.jsx
@@ -1,12 +1,12 @@
-import { cloneElement, isValidElement } from 'react'
-import styles from './FormField.module.css'
+import { cloneElement, isValidElement } from "react";
+import styles from "./FormField.module.css";
 
-function FormField({ label, id, children, className = '' }) {
-  const cls = [styles.field, className].filter(Boolean).join(' ')
+function FormField({ label, id, children, className = "" }) {
+  const cls = [styles.field, className].filter(Boolean).join(" ");
   const content =
     isValidElement(children) && !children.props.id
       ? cloneElement(children, { id })
-      : children
+      : children;
   return (
     <div className={cls}>
       {label && (
@@ -16,7 +16,7 @@ function FormField({ label, id, children, className = '' }) {
       )}
       {content}
     </div>
-  )
+  );
 }
 
-export default FormField
+export default FormField;

--- a/website/src/components/form/FormRow.jsx
+++ b/website/src/components/form/FormRow.jsx
@@ -1,12 +1,12 @@
-import { cloneElement, isValidElement } from 'react'
-import styles from './Form.module.css'
+import { cloneElement, isValidElement } from "react";
+import styles from "./Form.module.css";
 
-function FormRow({ label, id, children, className = '' }) {
-  const cls = [styles.row, className].filter(Boolean).join(' ')
+function FormRow({ label, id, children, className = "" }) {
+  const cls = [styles.row, className].filter(Boolean).join(" ");
   const content =
     isValidElement(children) && id && !children.props.id
       ? cloneElement(children, { id })
-      : children
+      : children;
 
   return (
     <div className={cls}>
@@ -17,7 +17,7 @@ function FormRow({ label, id, children, className = '' }) {
       )}
       {content}
     </div>
-  )
+  );
 }
 
-export default FormRow
+export default FormRow;

--- a/website/src/components/form/GenderSelect/GenderSelect.jsx
+++ b/website/src/components/form/GenderSelect/GenderSelect.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import { useLanguage } from '@/context'
-import styles from './GenderSelect.module.css'
+import React from "react";
+import { useLanguage } from "@/context";
+import styles from "./GenderSelect.module.css";
 
-const OPTIONS = ['male', 'female', 'none']
+const OPTIONS = ["male", "female", "none"];
 
-function GenderSelect({ value = '', onChange }) {
-  const { t } = useLanguage()
+function GenderSelect({ value = "", onChange }) {
+  const { t } = useLanguage();
   return (
     <div className={styles.group}>
       {OPTIONS.map((opt) => (
@@ -16,11 +16,13 @@ function GenderSelect({ value = '', onChange }) {
             checked={value === opt}
             onChange={() => onChange && onChange(opt)}
           />
-          <span>{t[`gender${opt.charAt(0).toUpperCase() + opt.slice(1)}`]}</span>
+          <span>
+            {t[`gender${opt.charAt(0).toUpperCase() + opt.slice(1)}`]}
+          </span>
         </label>
       ))}
     </div>
-  )
+  );
 }
 
-export default GenderSelect
+export default GenderSelect;

--- a/website/src/components/form/SelectField.jsx
+++ b/website/src/components/form/SelectField.jsx
@@ -1,23 +1,38 @@
-import FormRow from './FormRow.jsx'
-import styles from './Form.module.css'
+import FormRow from "./FormRow.jsx";
+import styles from "./Form.module.css";
 
-function SelectField({ label, id, value, onChange, options = [], className = '', ...props }) {
-  const cls = [styles.select, className].filter(Boolean).join(' ')
+function SelectField({
+  label,
+  id,
+  value,
+  onChange,
+  options = [],
+  className = "",
+  ...props
+}) {
+  const cls = [styles.select, className].filter(Boolean).join(" ");
   const handleChange = (e) => {
-    onChange && onChange(e.target.value)
-  }
+    onChange && onChange(e.target.value);
+  };
   const selectEl = (
-    <select id={id} className={cls} value={value} onChange={handleChange} {...props}>
+    <select
+      id={id}
+      className={cls}
+      value={value}
+      onChange={handleChange}
+      {...props}
+    >
       {options.map((opt) => {
-        const option = typeof opt === 'string' ? { value: opt, label: opt } : opt
+        const option =
+          typeof opt === "string" ? { value: opt, label: opt } : opt;
         return (
           <option key={option.value} value={option.value}>
             {option.label}
           </option>
-        )
+        );
       })}
     </select>
-  )
+  );
 
   return label ? (
     <FormRow label={label} id={id}>
@@ -25,7 +40,7 @@ function SelectField({ label, id, value, onChange, options = [], className = '',
     </FormRow>
   ) : (
     selectEl
-  )
+  );
 }
 
-export default SelectField
+export default SelectField;

--- a/website/src/components/modals/LogoutConfirmModal.jsx
+++ b/website/src/components/modals/LogoutConfirmModal.jsx
@@ -1,28 +1,36 @@
-import BaseModal from './BaseModal.jsx'
-import styles from './LogoutConfirmModal.module.css'
-import { useLanguage } from '@/context'
+import BaseModal from "./BaseModal.jsx";
+import styles from "./LogoutConfirmModal.module.css";
+import { useLanguage } from "@/context";
 
 function LogoutConfirmModal({ open, onConfirm, onCancel, email }) {
-  const { t } = useLanguage()
-  const message = t.logoutConfirmMessage.replace('{email}', email)
+  const { t } = useLanguage();
+  const message = t.logoutConfirmMessage.replace("{email}", email);
   return (
     <BaseModal
       open={open}
       onClose={onCancel}
-      className={`modal-content ${styles['logout-modal']}`}
+      className={`modal-content ${styles["logout-modal"]}`}
     >
       <h3>{t.logoutConfirmTitle}</h3>
       <p className={styles.message}>{message}</p>
       <div className={styles.actions}>
-        <button type="button" className={styles['logout-btn']} onClick={onConfirm}>
+        <button
+          type="button"
+          className={styles["logout-btn"]}
+          onClick={onConfirm}
+        >
           {t.logout}
         </button>
-        <button type="button" className={styles['cancel-btn']} onClick={onCancel}>
+        <button
+          type="button"
+          className={styles["cancel-btn"]}
+          onClick={onCancel}
+        >
           {t.cancelButton}
         </button>
       </div>
     </BaseModal>
-  )
+  );
 }
 
-export default LogoutConfirmModal
+export default LogoutConfirmModal;

--- a/website/src/components/modals/PaymentModal.jsx
+++ b/website/src/components/modals/PaymentModal.jsx
@@ -1,25 +1,25 @@
-import BaseModal from './BaseModal.jsx'
-import styles from './PaymentModal.module.css'
-import { useLanguage } from '@/context'
+import BaseModal from "./BaseModal.jsx";
+import styles from "./PaymentModal.module.css";
+import { useLanguage } from "@/context";
 
 function PaymentModal({ open, onClose }) {
-  const { t } = useLanguage()
+  const { t } = useLanguage();
   return (
     <BaseModal
       open={open}
       onClose={onClose}
-      className={`modal-content ${styles['payment-modal']}`}
+      className={`modal-content ${styles["payment-modal"]}`}
     >
       <h3>{t.paymentTitle}</h3>
       <div className={styles.methods}>
         <button type="button">{t.alipay}</button>
         <button type="button">{t.wechat}</button>
       </div>
-      <button type="button" onClick={onClose} className={styles['close-btn']}>
+      <button type="button" onClick={onClose} className={styles["close-btn"]}>
         {t.close}
       </button>
     </BaseModal>
-  )
+  );
 }
 
-export default PaymentModal
+export default PaymentModal;

--- a/website/src/components/modals/PaymentModal.module.css
+++ b/website/src/components/modals/PaymentModal.module.css
@@ -1,4 +1,4 @@
-@import url('./ModalContent.module.css');
+@import url("./ModalContent.module.css");
 
 .payment-modal {
   width: 300px;

--- a/website/src/components/modals/ProfileModal.jsx
+++ b/website/src/components/modals/ProfileModal.jsx
@@ -1,17 +1,17 @@
-import Profile from '@/pages/profile'
-import BaseModal from './BaseModal.jsx'
-import styles from './ProfileModal.module.css'
+import Profile from "@/pages/profile";
+import BaseModal from "./BaseModal.jsx";
+import styles from "./ProfileModal.module.css";
 
 function ProfileModal({ open, onClose }) {
   return (
     <BaseModal
       open={open}
       onClose={onClose}
-      className={`modal-content ${styles['profile-modal']}`}
+      className={`modal-content ${styles["profile-modal"]}`}
     >
       <Profile onCancel={onClose} />
     </BaseModal>
-  )
+  );
 }
 
-export default ProfileModal
+export default ProfileModal;

--- a/website/src/components/modals/ProfileModal.module.css
+++ b/website/src/components/modals/ProfileModal.module.css
@@ -1,4 +1,4 @@
-@import url('./ModalContent.module.css');
+@import url("./ModalContent.module.css");
 
 .profile-modal {
   max-width: 400px;

--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -1,17 +1,17 @@
-import Preferences from '@/pages/preferences'
-import BaseModal from './BaseModal.jsx'
-import styles from './SettingsModal.module.css'
+import Preferences from "@/pages/preferences";
+import BaseModal from "./BaseModal.jsx";
+import styles from "./SettingsModal.module.css";
 
 function SettingsModal({ open, onClose }) {
   return (
     <BaseModal
       open={open}
       onClose={onClose}
-      className={`modal-content ${styles['auth-modal']}`}
+      className={`modal-content ${styles["auth-modal"]}`}
     >
       <Preferences />
     </BaseModal>
-  )
+  );
 }
 
-export default SettingsModal
+export default SettingsModal;

--- a/website/src/components/modals/SettingsModal.module.css
+++ b/website/src/components/modals/SettingsModal.module.css
@@ -1,4 +1,4 @@
-@import url('./ModalContent.module.css');
+@import url("./ModalContent.module.css");
 
 .auth-modal {
   max-width: 400px;
@@ -40,6 +40,6 @@
   color: var(--app-color);
 }
 
-.auth-modal button[type='submit'] {
+.auth-modal button[type="submit"] {
   width: 100%;
 }

--- a/website/src/components/modals/ShortcutsModal.module.css
+++ b/website/src/components/modals/ShortcutsModal.module.css
@@ -1,4 +1,4 @@
-@import url('./ModalContent.module.css');
+@import url("./ModalContent.module.css");
 
 .shortcuts-modal {
   width: 400px;

--- a/website/src/components/modals/UpgradeModal.jsx
+++ b/website/src/components/modals/UpgradeModal.jsx
@@ -1,49 +1,53 @@
-import { useState, useEffect } from 'react'
-import { useUser } from '@/context'
-import PaymentModal from './PaymentModal.jsx'
-import Modal from './Modal.jsx'
-import styles from './UpgradeModal.module.css'
-import { useLanguage } from '@/context'
+import { useState, useEffect } from "react";
+import { useUser } from "@/context";
+import PaymentModal from "./PaymentModal.jsx";
+import Modal from "./Modal.jsx";
+import styles from "./UpgradeModal.module.css";
+import { useLanguage } from "@/context";
 
 function UpgradeModal({ open, onClose }) {
-  const { user } = useUser()
-  const currentPlan = user?.plan || 'free'
-  const [selected, setSelected] = useState(currentPlan)
-  const [payOpen, setPayOpen] = useState(false)
-  const { t } = useLanguage()
+  const { user } = useUser();
+  const currentPlan = user?.plan || "free";
+  const [selected, setSelected] = useState(currentPlan);
+  const [payOpen, setPayOpen] = useState(false);
+  const { t } = useLanguage();
 
   useEffect(() => {
     if (open) {
-      setSelected(currentPlan)
+      setSelected(currentPlan);
     }
-  }, [open, currentPlan])
+  }, [open, currentPlan]);
 
-  if (!open) return null
+  if (!open) return null;
 
   const plans = [
-    { id: 'free', label: 'Free' },
-    { id: 'month', label: 'Monthly \u00a520' },
-    { id: 'quarter', label: 'Quarterly \u00a550' },
-    { id: 'year', label: 'Yearly \u00a5180' }
-  ]
+    { id: "free", label: "Free" },
+    { id: "month", label: "Monthly \u00a520" },
+    { id: "quarter", label: "Quarterly \u00a550" },
+    { id: "year", label: "Yearly \u00a5180" },
+  ];
 
   const confirm = () => {
     if (selected !== currentPlan) {
-      setPayOpen(true)
+      setPayOpen(true);
     } else {
-      onClose()
+      onClose();
     }
-  }
+  };
 
   return (
-    <Modal onClose={onClose} className={`modal-content ${styles['upgrade-modal']}`}>
+    <Modal
+      onClose={onClose}
+      className={`modal-content ${styles["upgrade-modal"]}`}
+    >
       <h3>{t.choosePlan}</h3>
       <div className={styles.plans}>
         {plans.map((p) => (
           <div
             key={p.id}
-            className={`${styles.plan}${p.id === currentPlan ? ` ${styles.current}` : ''}${
-              selected === p.id ? ` ${styles.selected}` : ''}`}
+            className={`${styles.plan}${p.id === currentPlan ? ` ${styles.current}` : ""}${
+              selected === p.id ? ` ${styles.selected}` : ""
+            }`}
             onClick={() => setSelected(p.id)}
           >
             {p.label}
@@ -51,18 +55,22 @@ function UpgradeModal({ open, onClose }) {
         ))}
       </div>
       <div className={styles.actions}>
-        <button type="button" onClick={confirm}>{t.confirm}</button>
-        <button type="button" onClick={onClose}>{t.cancelButton}</button>
+        <button type="button" onClick={confirm}>
+          {t.confirm}
+        </button>
+        <button type="button" onClick={onClose}>
+          {t.cancelButton}
+        </button>
       </div>
       <PaymentModal
         open={payOpen}
         onClose={() => {
-          setPayOpen(false)
-          onClose()
+          setPayOpen(false);
+          onClose();
         }}
       />
     </Modal>
-  )
+  );
 }
 
-export default UpgradeModal
+export default UpgradeModal;

--- a/website/src/components/modals/UpgradeModal.module.css
+++ b/website/src/components/modals/UpgradeModal.module.css
@@ -1,4 +1,4 @@
-@import url('./ModalContent.module.css');
+@import url("./ModalContent.module.css");
 
 .upgrade-modal {
   width: 320px;

--- a/website/src/components/ui/Avatar/index.js
+++ b/website/src/components/ui/Avatar/index.js
@@ -1,1 +1,1 @@
-export { default } from './Avatar.jsx'
+export { default } from "./Avatar.jsx";

--- a/website/src/components/ui/Button/Button.jsx
+++ b/website/src/components/ui/Button/Button.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import styles from './Button.module.css'
+import React from "react";
+import styles from "./Button.module.css";
 
-function Button({ className = '', children, ...props }) {
+function Button({ className = "", children, ...props }) {
   return (
     <button className={`${styles.button} ${className}`.trim()} {...props}>
       {children}
     </button>
-  )
+  );
 }
 
-export default Button
+export default Button;

--- a/website/src/components/ui/Button/Button.module.css
+++ b/website/src/components/ui/Button/Button.module.css
@@ -1,5 +1,5 @@
-@import url('@/theme/colors.css');
-@import url('@/theme/variables.css');
+@import url("@/theme/colors.css");
+@import url("@/theme/variables.css");
 
 .button {
   border-radius: var(--radius-md);

--- a/website/src/components/ui/Button/index.js
+++ b/website/src/components/ui/Button/index.js
@@ -1,1 +1,1 @@
-export { default } from './Button.jsx'
+export { default } from "./Button.jsx";

--- a/website/src/components/ui/ErrorBoundary/ErrorBoundary.jsx
+++ b/website/src/components/ui/ErrorBoundary/ErrorBoundary.jsx
@@ -1,30 +1,30 @@
-import React, { Component } from 'react'
-import styles from './ErrorBoundary.module.css'
+import React, { Component } from "react";
+import styles from "./ErrorBoundary.module.css";
 
 class ErrorBoundary extends Component {
   constructor(props) {
-    super(props)
-    this.state = { hasError: false }
+    super(props);
+    this.state = { hasError: false };
   }
 
   componentDidCatch(error, info) {
     // report the error and update state
-    console.error('ErrorBoundary caught an error', error, info)
-    this.setState({ hasError: true })
+    console.error("ErrorBoundary caught an error", error, info);
+    this.setState({ hasError: true });
   }
 
   render() {
-    const { hasError } = this.state
-    const { fallback, children } = this.props
+    const { hasError } = this.state;
+    const { fallback, children } = this.props;
     if (hasError) {
       return (
-        <div className={styles['error-boundary']}>
-          {fallback || 'Something went wrong.'}
+        <div className={styles["error-boundary"]}>
+          {fallback || "Something went wrong."}
         </div>
-      )
+      );
     }
-    return children
+    return children;
   }
 }
 
-export default ErrorBoundary
+export default ErrorBoundary;

--- a/website/src/components/ui/ErrorBoundary/index.js
+++ b/website/src/components/ui/ErrorBoundary/index.js
@@ -1,1 +1,1 @@
-export { default } from './ErrorBoundary.jsx'
+export { default } from "./ErrorBoundary.jsx";

--- a/website/src/components/ui/HistoryDisplay/index.js
+++ b/website/src/components/ui/HistoryDisplay/index.js
@@ -1,1 +1,1 @@
-export { default } from './HistoryDisplay.jsx'
+export { default } from "./HistoryDisplay.jsx";

--- a/website/src/components/ui/ICP/ICP.jsx
+++ b/website/src/components/ui/ICP/ICP.jsx
@@ -1,15 +1,15 @@
-import { ICP_INFO } from '@/config/icp.js'
-import styles from './ICP.module.css'
+import { ICP_INFO } from "@/config/icp.js";
+import styles from "./ICP.module.css";
 
 function ICP() {
-  const { link, text } = ICP_INFO
+  const { link, text } = ICP_INFO;
   return (
     <div className={styles.icp}>
       <a href={link} target="_blank" rel="noopener">
         {text}
       </a>
     </div>
-  )
+  );
 }
 
-export default ICP
+export default ICP;

--- a/website/src/components/ui/ICP/index.js
+++ b/website/src/components/ui/ICP/index.js
@@ -1,1 +1,1 @@
-export { default } from './ICP.jsx'
+export { default } from "./ICP.jsx";

--- a/website/src/components/ui/ItemMenu/index.js
+++ b/website/src/components/ui/ItemMenu/index.js
@@ -1,1 +1,1 @@
-export { default } from './ItemMenu.jsx'
+export { default } from "./ItemMenu.jsx";

--- a/website/src/components/ui/ListItem/ListItem.jsx
+++ b/website/src/components/ui/ListItem/ListItem.jsx
@@ -1,13 +1,24 @@
-import React from 'react'
-import styles from './ListItem.module.css'
+import React from "react";
+import styles from "./ListItem.module.css";
 
-function ListItem({ text, onClick, actions, className = '', textClassName = '' }) {
+function ListItem({
+  text,
+  onClick,
+  actions,
+  className = "",
+  textClassName = "",
+}) {
   return (
-    <li className={[styles.item, className].filter(Boolean).join(' ')} onClick={onClick}>
-      <span className={[styles.text, textClassName].filter(Boolean).join(' ')}>{text}</span>
+    <li
+      className={[styles.item, className].filter(Boolean).join(" ")}
+      onClick={onClick}
+    >
+      <span className={[styles.text, textClassName].filter(Boolean).join(" ")}>
+        {text}
+      </span>
       {actions ? <div className={styles.actions}>{actions}</div> : null}
     </li>
-  )
+  );
 }
 
-export default ListItem
+export default ListItem;

--- a/website/src/components/ui/ListItem/index.js
+++ b/website/src/components/ui/ListItem/index.js
@@ -1,1 +1,1 @@
-export { default } from './ListItem.jsx'
+export { default } from "./ListItem.jsx";

--- a/website/src/components/ui/Loader/index.js
+++ b/website/src/components/ui/Loader/index.js
@@ -1,1 +1,1 @@
-export { default } from './Loader.jsx'
+export { default } from "./Loader.jsx";

--- a/website/src/components/ui/MessagePopup/MessagePopup.jsx
+++ b/website/src/components/ui/MessagePopup/MessagePopup.jsx
@@ -1,30 +1,26 @@
-import styles from './MessagePopup.module.css'
-import { useEscapeKey } from '@/hooks'
-import { withStopPropagation } from '@/utils/stopPropagation.js'
+import styles from "./MessagePopup.module.css";
+import { useEscapeKey } from "@/hooks";
+import { withStopPropagation } from "@/utils/stopPropagation.js";
 
 /**
  * Generic popup for transient messages.
  * Accepts optional children for action buttons.
  */
 function MessagePopup({ open, message, onClose, children }) {
-  useEscapeKey(onClose, open)
+  useEscapeKey(onClose, open);
 
-  if (!open) return null
+  if (!open) return null;
   return (
-    <div className={styles['popup-overlay']} onClick={onClose}>
+    <div className={styles["popup-overlay"]} onClick={onClose}>
       <div className={styles.popup} onClick={withStopPropagation()}>
         <div>{message}</div>
         {children && <div className={styles.actions}>{children}</div>}
-        <button
-          type="button"
-          onClick={onClose}
-          className={styles['close-btn']}
-        >
+        <button type="button" onClick={onClose} className={styles["close-btn"]}>
           Close
         </button>
       </div>
     </div>
-  )
+  );
 }
 
-export default MessagePopup
+export default MessagePopup;

--- a/website/src/components/ui/MessagePopup/index.js
+++ b/website/src/components/ui/MessagePopup/index.js
@@ -1,1 +1,1 @@
-export { default } from './MessagePopup.jsx'
+export { default } from "./MessagePopup.jsx";

--- a/website/src/components/ui/Toast/Toast.jsx
+++ b/website/src/components/ui/Toast/Toast.jsx
@@ -1,20 +1,20 @@
-import { useEffect } from 'react'
-import styles from './Toast.module.css'
+import { useEffect } from "react";
+import styles from "./Toast.module.css";
 
 /**
  * Minimal toast message. Auto hides after duration.
  */
 function Toast({ open, message, duration = 3000, onClose }) {
   useEffect(() => {
-    if (!open) return
+    if (!open) return;
     const timer = setTimeout(() => {
-      onClose?.()
-    }, duration)
-    return () => clearTimeout(timer)
-  }, [open, duration, onClose])
+      onClose?.();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [open, duration, onClose]);
 
-  if (!open) return null
-  return <div className={styles.toast}>{message}</div>
+  if (!open) return null;
+  return <div className={styles.toast}>{message}</div>;
 }
 
-export default Toast
+export default Toast;

--- a/website/src/components/ui/Toast/index.js
+++ b/website/src/components/ui/Toast/index.js
@@ -1,1 +1,1 @@
-export { default } from './Toast.jsx'
+export { default } from "./Toast.jsx";

--- a/website/src/components/ui/Tooltip/index.jsx
+++ b/website/src/components/ui/Tooltip/index.jsx
@@ -1,14 +1,18 @@
-import React from 'react'
-import ThemeIcon from '@/components/ui/Icon'
-import styles from './Tooltip.module.css'
+import React from "react";
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./Tooltip.module.css";
 
 function Tooltip({ icon, text, children }) {
   return (
     <span className={styles.tooltip}>
-      {icon ? <ThemeIcon name={icon} className={styles.icon} width={16} height={16} /> : children}
+      {icon ? (
+        <ThemeIcon name={icon} className={styles.icon} width={16} height={16} />
+      ) : (
+        children
+      )}
       <span className={styles.content}>{text}</span>
     </span>
-  )
+  );
 }
 
-export default Tooltip
+export default Tooltip;

--- a/website/src/config/icp.js
+++ b/website/src/config/icp.js
@@ -1,4 +1,4 @@
 export const ICP_INFO = {
-  link: 'https://beian.miit.gov.cn/',
-  text: '京ICP备2025135702号-1'
-}
+  link: "https://beian.miit.gov.cn/",
+  text: "京ICP备2025135702号-1",
+};

--- a/website/src/config/languages.js
+++ b/website/src/config/languages.js
@@ -1,1 +1,1 @@
-export const LANGUAGES = ['zh', 'en']
+export const LANGUAGES = ["zh", "en"];

--- a/website/src/context/AppContext.jsx
+++ b/website/src/context/AppContext.jsx
@@ -1,32 +1,28 @@
-import { createContext, useContext } from 'react'
-import {
-  useUserStore,
-  useHistoryStore,
-  useFavoritesStore
-} from '@/store'
+import { createContext, useContext } from "react";
+import { useUserStore, useHistoryStore, useFavoritesStore } from "@/store";
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const AppContext = createContext({
   user: null,
   history: null,
   favorites: null,
-})
+});
 
 export function AppProvider({ children }) {
-  const user = useUserStore()
-  const history = useHistoryStore()
-  const favorites = useFavoritesStore()
+  const user = useUserStore();
+  const history = useHistoryStore();
+  const favorites = useFavoritesStore();
 
   return (
     <AppContext.Provider value={{ user, history, favorites }}>
       {children}
     </AppContext.Provider>
-  )
+  );
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const useUser = () => useContext(AppContext).user
+export const useUser = () => useContext(AppContext).user;
 // eslint-disable-next-line react-refresh/only-export-components
-export const useHistory = () => useContext(AppContext).history
+export const useHistory = () => useContext(AppContext).history;
 // eslint-disable-next-line react-refresh/only-export-components
-export const useFavorites = () => useContext(AppContext).favorites
+export const useFavorites = () => useContext(AppContext).favorites;

--- a/website/src/context/LanguageContext.jsx
+++ b/website/src/context/LanguageContext.jsx
@@ -1,48 +1,50 @@
-import { createContext, useContext, useState, useEffect } from 'react'
-import translations from '@/i18n/index.js'
-import { useLocale } from './LocaleContext.jsx'
+import { createContext, useContext, useState, useEffect } from "react";
+import translations from "@/i18n/index.js";
+import { useLocale } from "./LocaleContext.jsx";
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const LanguageContext = createContext({
-  lang: 'zh',
+  lang: "zh",
   t: translations.zh,
-  setLang: () => {}
-})
+  setLang: () => {},
+});
 
 export function LanguageProvider({ children }) {
-  const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'zh')
-  const [t, setT] = useState(() => translations[localStorage.getItem('lang')] || translations.zh)
+  const [lang, setLang] = useState(() => localStorage.getItem("lang") || "zh");
+  const [t, setT] = useState(
+    () => translations[localStorage.getItem("lang")] || translations.zh,
+  );
 
-  const { locale } = useLocale()
+  const { locale } = useLocale();
 
   useEffect(() => {
-    if (localStorage.getItem('lang') || !locale) return
+    if (localStorage.getItem("lang") || !locale) return;
     if (translations[locale.lang]) {
-      setLang(locale.lang)
-      setT(translations[locale.lang])
-      localStorage.setItem('lang', locale.lang)
+      setLang(locale.lang);
+      setT(translations[locale.lang]);
+      localStorage.setItem("lang", locale.lang);
     }
-  }, [locale])
+  }, [locale]);
 
   useEffect(() => {
-    document.title = t.welcomeTitle
-    document.documentElement.lang = lang
-  }, [lang, t])
+    document.title = t.welcomeTitle;
+    document.documentElement.lang = lang;
+  }, [lang, t]);
 
   const changeLanguage = (l) => {
     if (translations[l]) {
-      setLang(l)
-      setT(translations[l])
-      localStorage.setItem('lang', l)
+      setLang(l);
+      setT(translations[l]);
+      localStorage.setItem("lang", l);
     }
-  }
+  };
 
   return (
     <LanguageContext.Provider value={{ lang, t, setLang: changeLanguage }}>
       {children}
     </LanguageContext.Provider>
-  )
+  );
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const useLanguage = () => useContext(LanguageContext)
+export const useLanguage = () => useContext(LanguageContext);

--- a/website/src/context/LocaleContext.jsx
+++ b/website/src/context/LocaleContext.jsx
@@ -1,37 +1,38 @@
-import { createContext, useContext, useEffect, useState } from 'react'
-import { useApi } from '@/hooks'
+import { createContext, useContext, useEffect, useState } from "react";
+import { useApi } from "@/hooks";
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const LocaleContext = createContext({
   locale: null,
-  setLocale: () => {}
-})
+  setLocale: () => {},
+});
 
 export function LocaleProvider({ children }) {
   const [locale, setLocale] = useState(() => {
-    const stored = localStorage.getItem('locale')
-    return stored ? JSON.parse(stored) : null
-  })
-  const api = useApi()
+    const stored = localStorage.getItem("locale");
+    return stored ? JSON.parse(stored) : null;
+  });
+  const api = useApi();
 
   useEffect(() => {
-    if (locale) return
-    api.locale.getLocale()
+    if (locale) return;
+    api.locale
+      .getLocale()
       .then((data) => {
-        setLocale(data)
-        localStorage.setItem('locale', JSON.stringify(data))
+        setLocale(data);
+        localStorage.setItem("locale", JSON.stringify(data));
       })
       .catch((err) => {
-        console.error(err)
-      })
-  }, [locale, api])
+        console.error(err);
+      });
+  }, [locale, api]);
 
   return (
     <LocaleContext.Provider value={{ locale, setLocale }}>
       {children}
     </LocaleContext.Provider>
-  )
+  );
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const useLocale = () => useContext(LocaleContext)
+export const useLocale = () => useContext(LocaleContext);

--- a/website/src/hooks/__tests__/useSpeechInput.test.js
+++ b/website/src/hooks/__tests__/useSpeechInput.test.js
@@ -1,44 +1,44 @@
 /* eslint-env jest */
-import { renderHook, act } from '@testing-library/react'
-import { jest } from '@jest/globals'
-import useSpeechInput from '../useSpeechInput.js'
+import { renderHook, act } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import useSpeechInput from "../useSpeechInput.js";
 
 const recognitionMock = {
   start: jest.fn(),
-  lang: '',
+  lang: "",
   interimResults: false,
   maxAlternatives: 1,
   onresult: null,
-}
+};
 
 global.webkitSpeechRecognition = function () {
-  return recognitionMock
-}
+  return recognitionMock;
+};
 
-describe('useSpeechInput', () => {
+describe("useSpeechInput", () => {
   afterEach(() => {
-    recognitionMock.start.mockClear()
-    recognitionMock.onresult = null
-  })
+    recognitionMock.start.mockClear();
+    recognitionMock.onresult = null;
+  });
 
   afterAll(() => {
-    delete global.webkitSpeechRecognition
-  })
+    delete global.webkitSpeechRecognition;
+  });
 
-  test('invokes SpeechRecognition and callback', () => {
-    const onResult = jest.fn()
-    const { result } = renderHook(() => useSpeechInput({ onResult }))
+  test("invokes SpeechRecognition and callback", () => {
+    const onResult = jest.fn();
+    const { result } = renderHook(() => useSpeechInput({ onResult }));
 
     act(() => {
-      result.current.start('en-US')
-    })
+      result.current.start("en-US");
+    });
 
-    expect(recognitionMock.start).toHaveBeenCalled()
+    expect(recognitionMock.start).toHaveBeenCalled();
 
-    const event = { results: [[{ transcript: 'hello' }]] }
+    const event = { results: [[{ transcript: "hello" }]] };
     act(() => {
-      recognitionMock.onresult(event)
-    })
-    expect(onResult).toHaveBeenCalledWith('hello')
-  })
-})
+      recognitionMock.onresult(event);
+    });
+    expect(onResult).toHaveBeenCalledWith("hello");
+  });
+});

--- a/website/src/hooks/useApi.js
+++ b/website/src/hooks/useApi.js
@@ -1,5 +1,5 @@
-import { useApiContext } from '@/context'
+import { useApiContext } from "@/context";
 
 export function useApi() {
-  return useApiContext()
+  return useApiContext();
 }

--- a/website/src/hooks/useAppShortcuts.js
+++ b/website/src/hooks/useAppShortcuts.js
@@ -1,5 +1,5 @@
-import { useEffect, useCallback } from 'react'
-import translations from '@/i18n/index.js'
+import { useEffect, useCallback } from "react";
+import translations from "@/i18n/index.js";
 
 export function useAppShortcuts({
   inputRef,
@@ -10,79 +10,81 @@ export function useAppShortcuts({
   entry,
   showFavorites,
   showHistory,
-  toggleFavorite
+  toggleFavorite,
 }) {
   const focusInput = useCallback(() => {
-    inputRef.current?.focus()
-  }, [inputRef])
+    inputRef.current?.focus();
+  }, [inputRef]);
 
   const cycleLanguage = useCallback(() => {
-    const langs = Object.keys(translations)
-    const next = langs[(langs.indexOf(lang) + 1) % langs.length]
-    setLang(next)
-  }, [lang, setLang])
+    const langs = Object.keys(translations);
+    const next = langs[(langs.indexOf(lang) + 1) % langs.length];
+    setLang(next);
+  }, [lang, setLang]);
 
   const cycleTheme = useCallback(() => {
-    const seq = { dark: 'light', light: 'system', system: 'dark' }
-    setTheme(seq[theme] || 'light')
-  }, [theme, setTheme])
+    const seq = { dark: "light", light: "system", system: "dark" };
+    setTheme(seq[theme] || "light");
+  }, [theme, setTheme]);
 
   const toggleFavoriteEntry = useCallback(() => {
     if (entry && !showFavorites && !showHistory) {
-      toggleFavorite(entry.term)
+      toggleFavorite(entry.term);
     }
-  }, [entry, showFavorites, showHistory, toggleFavorite])
+  }, [entry, showFavorites, showHistory, toggleFavorite]);
 
   const openShortcuts = useCallback(() => {
-    document.dispatchEvent(new Event('open-shortcuts'))
-  }, [])
+    document.dispatchEvent(new Event("open-shortcuts"));
+  }, []);
 
   useEffect(() => {
     function handleShortcut(e) {
       const platform =
-        navigator.userAgentData?.platform || navigator.platform || ''
-      const mod = /Mac|iPhone|iPod|iPad/i.test(platform) ? e.metaKey : e.ctrlKey
-      if (!mod || !e.shiftKey) return
+        navigator.userAgentData?.platform || navigator.platform || "";
+      const mod = /Mac|iPhone|iPod|iPad/i.test(platform)
+        ? e.metaKey
+        : e.ctrlKey;
+      if (!mod || !e.shiftKey) return;
       switch (e.key.toLowerCase()) {
-        case 'f':
-          e.preventDefault()
-          focusInput()
-          break
-        case 'l':
-          e.preventDefault()
-          cycleLanguage()
-          break
-        case 'm':
-          e.preventDefault()
-          cycleTheme()
-          break
-        case 'b':
-          e.preventDefault()
-          toggleFavoriteEntry()
-          break
-        case 'k':
-          e.preventDefault()
-          openShortcuts()
-          break
+        case "f":
+          e.preventDefault();
+          focusInput();
+          break;
+        case "l":
+          e.preventDefault();
+          cycleLanguage();
+          break;
+        case "m":
+          e.preventDefault();
+          cycleTheme();
+          break;
+        case "b":
+          e.preventDefault();
+          toggleFavoriteEntry();
+          break;
+        case "k":
+          e.preventDefault();
+          openShortcuts();
+          break;
         default:
-          break
+          break;
       }
     }
-    document.addEventListener('keydown', handleShortcut)
-    return () => document.removeEventListener('keydown', handleShortcut)
+    document.addEventListener("keydown", handleShortcut);
+    return () => document.removeEventListener("keydown", handleShortcut);
   }, [
     focusInput,
     cycleLanguage,
     cycleTheme,
     toggleFavoriteEntry,
-    openShortcuts
-  ])
+    openShortcuts,
+  ]);
 
   return {
     focusInput,
     cycleLanguage,
     cycleTheme,
     toggleFavoriteEntry,
-    openShortcuts
-  }
+    openShortcuts,
+  };
 }

--- a/website/src/hooks/useEscapeKey.js
+++ b/website/src/hooks/useEscapeKey.js
@@ -1,13 +1,12 @@
-import { useEffect } from 'react'
+import { useEffect } from "react";
 
 export default function useEscapeKey(handler, active = true) {
   useEffect(() => {
-    if (!active) return undefined
+    if (!active) return undefined;
     const onKeyDown = (e) => {
-      if (e.key === 'Escape') handler(e)
-    }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [handler, active])
+      if (e.key === "Escape") handler(e);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [handler, active]);
 }
-

--- a/website/src/hooks/useMediaQuery.js
+++ b/website/src/hooks/useMediaQuery.js
@@ -1,27 +1,27 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react";
 
 export default function useMediaQuery(query) {
   const getMatches = () =>
-    typeof window !== 'undefined' ? window.matchMedia(query).matches : false
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false;
 
-  const [matches, setMatches] = useState(getMatches)
+  const [matches, setMatches] = useState(getMatches);
 
   useEffect(() => {
-    const mediaQueryList = window.matchMedia(query)
-    const handleChange = (e) => setMatches(e.matches)
+    const mediaQueryList = window.matchMedia(query);
+    const handleChange = (e) => setMatches(e.matches);
 
     mediaQueryList.addEventListener
-      ? mediaQueryList.addEventListener('change', handleChange)
-      : mediaQueryList.addListener(handleChange)
+      ? mediaQueryList.addEventListener("change", handleChange)
+      : mediaQueryList.addListener(handleChange);
 
-    setMatches(mediaQueryList.matches)
+    setMatches(mediaQueryList.matches);
 
     return () => {
       mediaQueryList.removeEventListener
-        ? mediaQueryList.removeEventListener('change', handleChange)
-        : mediaQueryList.removeListener(handleChange)
-    }
-  }, [query])
+        ? mediaQueryList.removeEventListener("change", handleChange)
+        : mediaQueryList.removeListener(handleChange);
+    };
+  }, [query]);
 
-  return matches
+  return matches;
 }

--- a/website/src/hooks/useOutsideToggle.js
+++ b/website/src/hooks/useOutsideToggle.js
@@ -1,32 +1,32 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect } from "react";
 
 export default function useOutsideToggle(initialOpen = false) {
-  const [open, setOpen] = useState(initialOpen)
-  const ref = useRef(null)
+  const [open, setOpen] = useState(initialOpen);
+  const ref = useRef(null);
 
   useEffect(() => {
     function handlePointerDown(e) {
       if (ref.current && !ref.current.contains(e.target)) {
-        setOpen(false)
+        setOpen(false);
       }
     }
 
     function handleKeyDown(e) {
-      if (e.key === 'Escape') {
-        setOpen(false)
+      if (e.key === "Escape") {
+        setOpen(false);
       }
     }
 
     if (open) {
-      document.addEventListener('pointerdown', handlePointerDown)
-      document.addEventListener('keydown', handleKeyDown)
+      document.addEventListener("pointerdown", handlePointerDown);
+      document.addEventListener("keydown", handleKeyDown);
     }
 
     return () => {
-      document.removeEventListener('pointerdown', handlePointerDown)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [open])
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
 
-  return { open, setOpen, ref }
+  return { open, setOpen, ref };
 }

--- a/website/src/hooks/useSpeechInput.js
+++ b/website/src/hooks/useSpeechInput.js
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback } from "react";
 
 /**
  * Hook to capture speech input using the Web Speech API.
@@ -9,24 +9,24 @@ import { useCallback } from 'react'
  */
 export default function useSpeechInput({ onResult } = {}) {
   const start = useCallback(
-    (language = 'en-US') => {
+    (language = "en-US") => {
       const SpeechRecognition =
-        window.SpeechRecognition || window.webkitSpeechRecognition
-      if (!SpeechRecognition) return
-      const recognition = new SpeechRecognition()
-      recognition.lang = language
-      recognition.interimResults = false
-      recognition.maxAlternatives = 1
+        window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognition) return;
+      const recognition = new SpeechRecognition();
+      recognition.lang = language;
+      recognition.interimResults = false;
+      recognition.maxAlternatives = 1;
       recognition.onresult = (event) => {
         const transcript = Array.from(event.results)
           .map((r) => r[0]?.transcript)
-          .join('')
-        if (transcript && onResult) onResult(transcript)
-      }
-      recognition.start()
+          .join("");
+        if (transcript && onResult) onResult(transcript);
+      };
+      recognition.start();
     },
     [onResult],
-  )
+  );
 
-  return { start }
+  return { start };
 }

--- a/website/src/i18n/__tests__/index.test.js
+++ b/website/src/i18n/__tests__/index.test.js
@@ -1,24 +1,24 @@
-import translations from '@/i18n/index.js';
+import translations from "@/i18n/index.js";
 
-test('en translations include navigation keys', () => {
-  expect(translations.en.navHome).toBe('Home');
+test("en translations include navigation keys", () => {
+  expect(translations.en.navHome).toBe("Home");
 });
 
-test('zh translations include navigation keys', () => {
-  expect(translations.zh.navHome).toBe('首页');
+test("zh translations include navigation keys", () => {
+  expect(translations.zh.navHome).toBe("首页");
 });
 
-test('auth translations are merged', () => {
-  expect(translations.en.loginTitle).toBe('User Login');
-  expect(translations.zh.loginTitle).toBe('用户登录');
+test("auth translations are merged", () => {
+  expect(translations.en.loginTitle).toBe("User Login");
+  expect(translations.zh.loginTitle).toBe("用户登录");
 });
 
-test('profile translations are merged', () => {
-  expect(translations.en.profileTitle).toBe('Profile');
-  expect(translations.zh.profileTitle).toBe('个人资料');
+test("profile translations are merged", () => {
+  expect(translations.en.profileTitle).toBe("Profile");
+  expect(translations.zh.profileTitle).toBe("个人资料");
 });
 
-test('common translations are preserved', () => {
-  expect(translations.en.searchButton).toBe('Search');
-  expect(translations.zh.searchButton).toBe('搜索');
+test("common translations are preserved", () => {
+  expect(translations.en.searchButton).toBe("Search");
+  expect(translations.zh.searchButton).toBe("搜索");
 });

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -122,5 +122,10 @@ export default {
   cookieConsentDecline: "Maybe later",
   playWordAudio: "Play pronunciation",
   playSentenceAudio: "Play example audio",
+  reoutput: "Regenerate",
+  previousVersion: "Previous version",
+  nextVersion: "Next version",
+  versionIndicator: "Version {current}/{total}",
+  versionIndicatorEmpty: "No versions",
   favoriteRemove: "Remove from favorites",
 };

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -119,5 +119,10 @@ export default {
   cookieConsentDecline: "暂不授权",
   playWordAudio: "播放发音",
   playSentenceAudio: "播放例句发音",
+  reoutput: "重新输出",
+  previousVersion: "上一版本",
+  nextVersion: "下一版本",
+  versionIndicator: "版本 {current}/{total}",
+  versionIndicatorEmpty: "暂无版本",
   favoriteRemove: "取消收藏",
 };

--- a/website/src/i18n/index.js
+++ b/website/src/i18n/index.js
@@ -1,11 +1,11 @@
-import authEn from './auth/en.js';
-import authZh from './auth/zh.js';
-import navigationEn from './navigation/en.js';
-import navigationZh from './navigation/zh.js';
-import profileEn from './profile/en.js';
-import profileZh from './profile/zh.js';
-import commonEn from './common/en.js';
-import commonZh from './common/zh.js';
+import authEn from "./auth/en.js";
+import authZh from "./auth/zh.js";
+import navigationEn from "./navigation/en.js";
+import navigationZh from "./navigation/zh.js";
+import profileEn from "./profile/en.js";
+import profileZh from "./profile/zh.js";
+import commonEn from "./common/en.js";
+import commonZh from "./common/zh.js";
 
 const en = {
   ...navigationEn,

--- a/website/src/i18n/profile/en.js
+++ b/website/src/i18n/profile/en.js
@@ -1,8 +1,8 @@
 export default {
-  profileTitle: 'Profile',
-  avatar: 'Avatar',
-  avatarHint: 'Click to change avatar',
-  saveButton: 'Save',
-  saveSuccess: 'Save success',
-  cancelButton: 'Cancel'
+  profileTitle: "Profile",
+  avatar: "Avatar",
+  avatarHint: "Click to change avatar",
+  saveButton: "Save",
+  saveSuccess: "Save success",
+  cancelButton: "Cancel",
 };

--- a/website/src/i18n/profile/zh.js
+++ b/website/src/i18n/profile/zh.js
@@ -1,8 +1,8 @@
 export default {
-  profileTitle: '个人资料',
-  avatar: '头像',
-  avatarHint: '点击更换头像',
-  saveButton: '保存',
-  saveSuccess: '保存成功',
-  cancelButton: '取消'
+  profileTitle: "个人资料",
+  avatar: "头像",
+  avatarHint: "点击更换头像",
+  saveButton: "保存",
+  saveSuccess: "保存成功",
+  cancelButton: "取消",
 };

--- a/website/src/store/__tests__/favoritesStore.test.js
+++ b/website/src/store/__tests__/favoritesStore.test.js
@@ -1,13 +1,13 @@
-import { act } from '@testing-library/react'
-import { useFavoritesStore } from '@/store'
+import { act } from "@testing-library/react";
+import { useFavoritesStore } from "@/store";
 
-describe('favoritesStore', () => {
-  beforeEach(() => localStorage.clear())
+describe("favoritesStore", () => {
+  beforeEach(() => localStorage.clear());
 
-  test('toggleFavorite adds and removes terms', () => {
-    act(() => useFavoritesStore.getState().toggleFavorite('hello'))
-    expect(useFavoritesStore.getState().favorites).toContain('hello')
-    act(() => useFavoritesStore.getState().toggleFavorite('hello'))
-    expect(useFavoritesStore.getState().favorites).not.toContain('hello')
-  })
-})
+  test("toggleFavorite adds and removes terms", () => {
+    act(() => useFavoritesStore.getState().toggleFavorite("hello"));
+    expect(useFavoritesStore.getState().favorites).toContain("hello");
+    act(() => useFavoritesStore.getState().toggleFavorite("hello"));
+    expect(useFavoritesStore.getState().favorites).not.toContain("hello");
+  });
+});

--- a/website/src/store/__tests__/userStore.test.js
+++ b/website/src/store/__tests__/userStore.test.js
@@ -1,20 +1,20 @@
-import { act } from '@testing-library/react'
-import { useUserStore } from '@/store'
+import { act } from "@testing-library/react";
+import { useUserStore } from "@/store";
 
-describe('userStore', () => {
+describe("userStore", () => {
   beforeEach(() => {
-    localStorage.clear()
-  })
+    localStorage.clear();
+  });
 
-  test('setUser and clearUser persist to storage', () => {
-    const user = { id: '1', token: 't' }
-    act(() => useUserStore.getState().setUser(user))
-    expect(useUserStore.getState().user).toEqual(user)
-    const stored = JSON.parse(localStorage.getItem('user'))
-    expect(stored.state.user).toEqual(user)
-    act(() => useUserStore.getState().clearUser())
-    expect(useUserStore.getState().user).toBeNull()
-    const cleared = JSON.parse(localStorage.getItem('user'))
-    expect(cleared.state.user).toBeNull()
-  })
-})
+  test("setUser and clearUser persist to storage", () => {
+    const user = { id: "1", token: "t" };
+    act(() => useUserStore.getState().setUser(user));
+    expect(useUserStore.getState().user).toEqual(user);
+    const stored = JSON.parse(localStorage.getItem("user"));
+    expect(stored.state.user).toEqual(user);
+    act(() => useUserStore.getState().clearUser());
+    expect(useUserStore.getState().user).toBeNull();
+    const cleared = JSON.parse(localStorage.getItem("user"));
+    expect(cleared.state.user).toBeNull();
+  });
+});

--- a/website/src/store/__tests__/voiceStore.test.js
+++ b/website/src/store/__tests__/voiceStore.test.js
@@ -1,16 +1,16 @@
-import { act } from '@testing-library/react'
-import { useVoiceStore } from '@/store'
+import { act } from "@testing-library/react";
+import { useVoiceStore } from "@/store";
 
 /**
  * Voice store persistence and retrieval.
  */
-describe('voiceStore', () => {
-  beforeEach(() => localStorage.clear())
+describe("voiceStore", () => {
+  beforeEach(() => localStorage.clear());
 
-  test('setVoice persists voice per language', () => {
-    act(() => useVoiceStore.getState().setVoice('en', 'v1'))
-    expect(useVoiceStore.getState().getVoice('en')).toBe('v1')
-    const stored = JSON.parse(localStorage.getItem('ttsVoicePrefs'))
-    expect(stored.state.voices.en).toBe('v1')
-  })
-})
+  test("setVoice persists voice per language", () => {
+    act(() => useVoiceStore.getState().setVoice("en", "v1"));
+    expect(useVoiceStore.getState().getVoice("en")).toBe("v1");
+    const stored = JSON.parse(localStorage.getItem("ttsVoicePrefs"));
+    expect(stored.state.voices.en).toBe("v1");
+  });
+});

--- a/website/src/store/__tests__/wordStore.test.js
+++ b/website/src/store/__tests__/wordStore.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import { useWordStore } from "../wordStore.js";
+
+/**
+ * 测试逻辑:
+ *  1. 通过 setVersions 写入多个版本并读取默认激活版本。
+ *  2. 切换激活版本后验证 getEntry 输出更新。
+ *  3. 移除版本时自动修正激活指针。
+ */
+describe("wordStore", () => {
+  beforeEach(() => {
+    useWordStore.getState().clear();
+  });
+
+  test("manages version lifecycle", () => {
+    const store = useWordStore.getState();
+    store.setVersions(
+      "term:en",
+      [
+        { id: "v1", markdown: "first" },
+        { versionId: "v2", markdown: "second" },
+      ],
+      { activeVersionId: "v1", metadata: { tone: "warm" } },
+    );
+
+    expect(useWordStore.getState().getEntry("term:en").markdown).toBe("first");
+    expect(useWordStore.getState().getRecord("term:en").metadata).toEqual({
+      tone: "warm",
+    });
+
+    store.setActiveVersion("term:en", "v2");
+    expect(useWordStore.getState().getEntry("term:en").markdown).toBe("second");
+
+    store.removeVersions("term:en", "v2");
+    const entry = useWordStore.getState().getEntry("term:en");
+    expect(entry.markdown).toBe("first");
+    expect(useWordStore.getState().getRecord("term:en").activeVersionId).toBe(
+      "v1",
+    );
+  });
+});

--- a/website/src/store/createPersistentStore.ts
+++ b/website/src/store/createPersistentStore.ts
@@ -1,23 +1,27 @@
-import { create } from 'zustand'
-import { persist, createJSONStorage, type PersistOptions } from 'zustand/middleware'
-import type { StateCreator, StoreApi, UseBoundStore } from 'zustand'
+import { create } from "zustand";
+import {
+  persist,
+  createJSONStorage,
+  type PersistOptions,
+} from "zustand/middleware";
+import type { StateCreator, StoreApi, UseBoundStore } from "zustand";
 
 interface Options<T> {
-  key: string
-  initializer: StateCreator<T>
-  persistOptions?: Omit<PersistOptions<T>, 'name' | 'storage'>
+  key: string;
+  initializer: StateCreator<T>;
+  persistOptions?: Omit<PersistOptions<T>, "name" | "storage">;
 }
 
 export function createPersistentStore<T>({
   key,
   initializer,
-  persistOptions
+  persistOptions,
 }: Options<T>): UseBoundStore<StoreApi<T>> {
   return create<T>()(
     persist(initializer, {
       name: key,
       storage: createJSONStorage(() => localStorage),
-      ...(persistOptions ?? {})
-    })
-  )
+      ...(persistOptions ?? {}),
+    }),
+  );
 }

--- a/website/src/store/favoritesStore.ts
+++ b/website/src/store/favoritesStore.ts
@@ -1,24 +1,24 @@
-import { createPersistentStore } from './createPersistentStore.js'
-import { pickState } from './persistUtils.js'
+import { createPersistentStore } from "./createPersistentStore.js";
+import { pickState } from "./persistUtils.js";
 
 interface FavoritesState {
-  favorites: string[]
-  toggleFavorite: (term: string) => void
+  favorites: string[];
+  toggleFavorite: (term: string) => void;
 }
 
 export const useFavoritesStore = createPersistentStore<FavoritesState>({
-  key: 'favorites',
+  key: "favorites",
   initializer: (set, get) => ({
     favorites: [],
     toggleFavorite: (term: string) => {
-      const list = get().favorites
+      const list = get().favorites;
       const updated = list.includes(term)
         ? list.filter((t) => t !== term)
-        : [...list, term]
-      set({ favorites: updated })
-    }
+        : [...list, term];
+      set({ favorites: updated });
+    },
   }),
   persistOptions: {
-    partialize: pickState(['favorites'])
-  }
-})
+    partialize: pickState(["favorites"]),
+  },
+});

--- a/website/src/store/persistUtils.ts
+++ b/website/src/store/persistUtils.ts
@@ -1,9 +1,9 @@
 export function pickState<T extends object, K extends keyof T>(keys: K[]) {
   return (state: T) => {
-    const result = {} as Pick<T, K>
+    const result = {} as Pick<T, K>;
     for (const key of keys) {
-      result[key] = state[key]
+      result[key] = state[key];
     }
-    return result
-  }
+    return result;
+  };
 }

--- a/website/src/store/userStore.ts
+++ b/website/src/store/userStore.ts
@@ -1,31 +1,31 @@
-import { createPersistentStore } from './createPersistentStore.js'
-import { pickState } from './persistUtils.js'
+import { createPersistentStore } from "./createPersistentStore.js";
+import { pickState } from "./persistUtils.js";
 
 export interface User {
-  id: string
-  token: string
-  avatar?: string
-  [key: string]: unknown
+  id: string;
+  token: string;
+  avatar?: string;
+  [key: string]: unknown;
 }
 
 interface UserState {
-  user: User | null
-  setUser: (user: User) => void
-  clearUser: () => void
+  user: User | null;
+  setUser: (user: User) => void;
+  clearUser: () => void;
 }
 
 export const useUserStore = createPersistentStore<UserState>({
-  key: 'user',
+  key: "user",
   initializer: (set) => ({
     user: null,
     setUser: (user: User) => {
-      set({ user })
+      set({ user });
     },
     clearUser: () => {
-      set({ user: null })
-    }
+      set({ user: null });
+    },
   }),
   persistOptions: {
-    partialize: pickState(['user'])
-  }
-})
+    partialize: pickState(["user"]),
+  },
+});

--- a/website/src/store/voiceStore.ts
+++ b/website/src/store/voiceStore.ts
@@ -1,14 +1,14 @@
-import { createPersistentStore } from './createPersistentStore.js'
-import { pickState } from './persistUtils.js'
+import { createPersistentStore } from "./createPersistentStore.js";
+import { pickState } from "./persistUtils.js";
 
 interface VoiceState {
-  voices: Record<string, string>
-  setVoice: (lang: string, voiceId: string) => void
-  getVoice: (lang: string) => string | undefined
+  voices: Record<string, string>;
+  setVoice: (lang: string, voiceId: string) => void;
+  getVoice: (lang: string) => string | undefined;
 }
 
 export const useVoiceStore = createPersistentStore<VoiceState>({
-  key: 'ttsVoicePrefs',
+  key: "ttsVoicePrefs",
   initializer: (set, get) => ({
     voices: {},
     setVoice: (lang: string, voiceId: string) =>
@@ -16,6 +16,6 @@ export const useVoiceStore = createPersistentStore<VoiceState>({
     getVoice: (lang: string) => get().voices[lang],
   }),
   persistOptions: {
-    partialize: pickState(['voices']),
+    partialize: pickState(["voices"]),
   },
-})
+});

--- a/website/src/store/wordStore.js
+++ b/website/src/store/wordStore.js
@@ -1,27 +1,149 @@
 import { createPersistentStore } from "./createPersistentStore.ts";
 import { pickState } from "./persistUtils.ts";
 
+const normalizeVersionId = (version) => {
+  if (!version) return undefined;
+  return (
+    version.id ??
+    version.versionId ??
+    version.metadata?.id ??
+    version.metadata?.versionId ??
+    undefined
+  );
+};
+
+const normalizeVersions = (versions = []) =>
+  versions.filter(Boolean).map((version, index) => {
+    const id = normalizeVersionId(version) ?? `auto-${index}`;
+    return { ...version, id };
+  });
+
+const resolveActiveVersionId = (currentEntry, versions, preferredId) => {
+  if (preferredId) return preferredId;
+  if (
+    currentEntry?.activeVersionId &&
+    versions.some((v) => v.id === currentEntry.activeVersionId)
+  ) {
+    return currentEntry.activeVersionId;
+  }
+  if (versions.length > 0) {
+    return (
+      versions[versions.length - 1].id ??
+      versions[versions.length - 1]?.versionId ??
+      null
+    );
+  }
+  return null;
+};
+
+const selectVersion = (entry, versionId) => {
+  if (!entry || !Array.isArray(entry.versions) || entry.versions.length === 0)
+    return undefined;
+  const targetId = versionId ?? entry.activeVersionId;
+  if (!targetId) return entry.versions[entry.versions.length - 1];
+  return entry.versions.find(
+    (version) => String(version.id) === String(targetId),
+  );
+};
+
 export const useWordStore = createPersistentStore({
   key: "wordCache",
   initializer: (set, get) => ({
     entries: {},
-    setEntry: (key, entry) =>
-      set((state) => ({ entries: { ...state.entries, [key]: entry } })),
-    getEntry: (key) => get().entries[key],
-    clear: () => set({ entries: {} }),
-    removeVersions: (termKey) =>
+    setVersions: (termKey, versions, { activeVersionId, metadata } = {}) =>
       set((state) => {
         if (!termKey) return {};
-        const prefix = `${termKey}:`;
-        const entries = Object.fromEntries(
-          Object.entries(state.entries).filter(
-            ([key]) => !key.startsWith(prefix),
-          ),
+        const normalized = normalizeVersions(versions);
+        if (normalized.length === 0) {
+          const { [termKey]: _removed, ...rest } = state.entries;
+          return { entries: rest };
+        }
+        const current = state.entries[termKey];
+        const nextActiveId = resolveActiveVersionId(
+          current,
+          normalized,
+          activeVersionId,
         );
-        return { entries };
+        return {
+          entries: {
+            ...state.entries,
+            [termKey]: {
+              versions: normalized,
+              activeVersionId: nextActiveId,
+              metadata: {
+                ...(current?.metadata ?? {}),
+                ...(metadata ?? {}),
+              },
+            },
+          },
+        };
       }),
+    setActiveVersion: (termKey, versionId) =>
+      set((state) => {
+        if (!termKey) return {};
+        const target = state.entries[termKey];
+        if (!target) return {};
+        if (target.activeVersionId === versionId) return {};
+        return {
+          entries: {
+            ...state.entries,
+            [termKey]: {
+              ...target,
+              activeVersionId: versionId,
+            },
+          },
+        };
+      }),
+    removeVersions: (termKey, versionIds) =>
+      set((state) => {
+        if (!termKey) return {};
+        const target = state.entries[termKey];
+        if (!target) return {};
+        if (!versionIds) {
+          const { [termKey]: _removed, ...rest } = state.entries;
+          return { entries: rest };
+        }
+        const ids = new Set(
+          (Array.isArray(versionIds) ? versionIds : [versionIds]).map(String),
+        );
+        const filtered = target.versions.filter(
+          (version) => !ids.has(String(version.id)),
+        );
+        if (filtered.length === 0) {
+          const { [termKey]: _removed, ...rest } = state.entries;
+          return { entries: rest };
+        }
+        const nextActiveId = ids.has(String(target.activeVersionId))
+          ? resolveActiveVersionId(
+              { ...target, activeVersionId: null },
+              filtered,
+            )
+          : target.activeVersionId;
+        return {
+          entries: {
+            ...state.entries,
+            [termKey]: {
+              ...target,
+              versions: filtered,
+              activeVersionId: nextActiveId,
+            },
+          },
+        };
+      }),
+    getEntry: (termKey, versionId) => {
+      const entry = get().entries[termKey];
+      return selectVersion(entry, versionId);
+    },
+    getRecord: (termKey) => get().entries[termKey],
+    clear: () => set({ entries: {} }),
   }),
   persistOptions: {
     partialize: pickState(["entries"]),
   },
 });
+
+export const __private__ = {
+  normalizeVersions,
+  resolveActiveVersionId,
+  selectVersion,
+};

--- a/website/src/theme/spacing.css
+++ b/website/src/theme/spacing.css
@@ -7,39 +7,123 @@
 }
 
 /* margin utilities */
-.m-1 { margin: var(--space-1); }
-.m-2 { margin: var(--space-2); }
-.m-3 { margin: var(--space-3); }
-.m-4 { margin: var(--space-4); }
-.m-5 { margin: var(--space-5); }
+.m-1 {
+  margin: var(--space-1);
+}
 
-.mt-1 { margin-top: var(--space-1); }
-.mt-2 { margin-top: var(--space-2); }
-.mt-3 { margin-top: var(--space-3); }
-.mt-4 { margin-top: var(--space-4); }
-.mt-5 { margin-top: var(--space-5); }
+.m-2 {
+  margin: var(--space-2);
+}
 
-.mb-1 { margin-bottom: var(--space-1); }
-.mb-2 { margin-bottom: var(--space-2); }
-.mb-3 { margin-bottom: var(--space-3); }
-.mb-4 { margin-bottom: var(--space-4); }
-.mb-5 { margin-bottom: var(--space-5); }
+.m-3 {
+  margin: var(--space-3);
+}
+
+.m-4 {
+  margin: var(--space-4);
+}
+
+.m-5 {
+  margin: var(--space-5);
+}
+
+.mt-1 {
+  margin-top: var(--space-1);
+}
+
+.mt-2 {
+  margin-top: var(--space-2);
+}
+
+.mt-3 {
+  margin-top: var(--space-3);
+}
+
+.mt-4 {
+  margin-top: var(--space-4);
+}
+
+.mt-5 {
+  margin-top: var(--space-5);
+}
+
+.mb-1 {
+  margin-bottom: var(--space-1);
+}
+
+.mb-2 {
+  margin-bottom: var(--space-2);
+}
+
+.mb-3 {
+  margin-bottom: var(--space-3);
+}
+
+.mb-4 {
+  margin-bottom: var(--space-4);
+}
+
+.mb-5 {
+  margin-bottom: var(--space-5);
+}
 
 /* padding utilities */
-.p-1 { padding: var(--space-1); }
-.p-2 { padding: var(--space-2); }
-.p-3 { padding: var(--space-3); }
-.p-4 { padding: var(--space-4); }
-.p-5 { padding: var(--space-5); }
+.p-1 {
+  padding: var(--space-1);
+}
 
-.pt-1 { padding-top: var(--space-1); }
-.pt-2 { padding-top: var(--space-2); }
-.pt-3 { padding-top: var(--space-3); }
-.pt-4 { padding-top: var(--space-4); }
-.pt-5 { padding-top: var(--space-5); }
+.p-2 {
+  padding: var(--space-2);
+}
 
-.pb-1 { padding-bottom: var(--space-1); }
-.pb-2 { padding-bottom: var(--space-2); }
-.pb-3 { padding-bottom: var(--space-3); }
-.pb-4 { padding-bottom: var(--space-4); }
-.pb-5 { padding-bottom: var(--space-5); }
+.p-3 {
+  padding: var(--space-3);
+}
+
+.p-4 {
+  padding: var(--space-4);
+}
+
+.p-5 {
+  padding: var(--space-5);
+}
+
+.pt-1 {
+  padding-top: var(--space-1);
+}
+
+.pt-2 {
+  padding-top: var(--space-2);
+}
+
+.pt-3 {
+  padding-top: var(--space-3);
+}
+
+.pt-4 {
+  padding-top: var(--space-4);
+}
+
+.pt-5 {
+  padding-top: var(--space-5);
+}
+
+.pb-1 {
+  padding-bottom: var(--space-1);
+}
+
+.pb-2 {
+  padding-bottom: var(--space-2);
+}
+
+.pb-3 {
+  padding-bottom: var(--space-3);
+}
+
+.pb-4 {
+  padding-bottom: var(--space-4);
+}
+
+.pb-5 {
+  padding-bottom: var(--space-5);
+}

--- a/website/src/utils/brand.js
+++ b/website/src/utils/brand.js
@@ -1,8 +1,8 @@
 export const BRAND_TEXT = {
-  zh: '格律词典',
-  en: 'Glancy'
-}
+  zh: "格律词典",
+  en: "Glancy",
+};
 
-export function getBrandText(lang = 'en') {
-  return BRAND_TEXT[lang] || BRAND_TEXT.en
+export function getBrandText(lang = "en") {
+  return BRAND_TEXT[lang] || BRAND_TEXT.en;
 }

--- a/website/src/utils/device.js
+++ b/website/src/utils/device.js
@@ -1,11 +1,13 @@
-import { useMediaQuery } from '@/hooks'
+import { useMediaQuery } from "@/hooks";
 
 export function getModifierKey() {
   const platform =
-    navigator.userAgentData?.platform || navigator.platform || ''
-  return /Mac|iPhone|iPod|iPad/i.test(platform) ? 'Command \u2318' : 'Ctrl \u2303'
+    navigator.userAgentData?.platform || navigator.platform || "";
+  return /Mac|iPhone|iPod|iPad/i.test(platform)
+    ? "Command \u2318"
+    : "Ctrl \u2303";
 }
 
 export function useIsMobile(maxWidth = 600) {
-  return useMediaQuery(`(max-width: ${maxWidth}px)`)
+  return useMediaQuery(`(max-width: ${maxWidth}px)`);
 }

--- a/website/src/utils/json.js
+++ b/website/src/utils/json.js
@@ -1,20 +1,20 @@
 export function extractMessage(text) {
-  if (!text) return ''
+  if (!text) return "";
   try {
-    const data = JSON.parse(text)
-    if (data && typeof data === 'object') {
-      return data.message || text
+    const data = JSON.parse(text);
+    if (data && typeof data === "object") {
+      return data.message || text;
     }
   } catch {
     // not JSON, ignore
   }
-  return text
+  return text;
 }
 
 export function safeJSONParse(str, defaultValue = null) {
   try {
-    return JSON.parse(str)
+    return JSON.parse(str);
   } catch {
-    return defaultValue
+    return defaultValue;
   }
 }

--- a/website/src/utils/language.js
+++ b/website/src/utils/language.js
@@ -3,7 +3,6 @@
  * @param {string} text
  * @returns {'CHINESE' | 'ENGLISH'}
  */
-export function detectWordLanguage(text = '') {
-  return /[\u4e00-\u9fff]/u.test(text) ? 'CHINESE' : 'ENGLISH'
+export function detectWordLanguage(text = "") {
+  return /[\u4e00-\u9fff]/u.test(text) ? "CHINESE" : "ENGLISH";
 }
-

--- a/website/src/utils/stopPropagation.js
+++ b/website/src/utils/stopPropagation.js
@@ -1,6 +1,6 @@
 export function withStopPropagation(handler = () => {}) {
   return function (event, ...args) {
-    event.stopPropagation()
-    return handler(event, ...args)
-  }
+    event.stopPropagation();
+    return handler(event, ...args);
+  };
 }

--- a/website/src/utils/validators.js
+++ b/website/src/utils/validators.js
@@ -1,16 +1,16 @@
-const EMAIL_REGEX = /.+@.+\..+/
-const PHONE_REGEX = /^\+?\d{6,15}$/
+const EMAIL_REGEX = /.+@.+\..+/;
+const PHONE_REGEX = /^\+?\d{6,15}$/;
 
 export function validateEmail(email) {
-  return EMAIL_REGEX.test(email)
+  return EMAIL_REGEX.test(email);
 }
 
 export function validatePhone(phone) {
-  return PHONE_REGEX.test(phone)
+  return PHONE_REGEX.test(phone);
 }
 
 export function validateAccount(account, method) {
-  if (method === 'email') return validateEmail(account)
-  if (method === 'phone') return validatePhone(account)
-  return true
+  if (method === "email") return validateEmail(account);
+  if (method === "phone") return validatePhone(account);
+  return true;
 }

--- a/website/src/utils/validators.test.js
+++ b/website/src/utils/validators.test.js
@@ -1,32 +1,36 @@
 /* eslint-env jest */
-import { validateEmail, validatePhone, validateAccount } from '@/utils/validators.js'
+import {
+  validateEmail,
+  validatePhone,
+  validateAccount,
+} from "@/utils/validators.js";
 
-describe('validateEmail', () => {
-  it('validates email format', () => {
-    expect(validateEmail('test@example.com')).toBe(true)
-    expect(validateEmail('invalid-email')).toBe(false)
-  })
-})
+describe("validateEmail", () => {
+  it("validates email format", () => {
+    expect(validateEmail("test@example.com")).toBe(true);
+    expect(validateEmail("invalid-email")).toBe(false);
+  });
+});
 
-describe('validatePhone', () => {
-  it('validates phone numbers', () => {
-    expect(validatePhone('+12345678901')).toBe(true)
-    expect(validatePhone('12345')).toBe(false)
-  })
-})
+describe("validatePhone", () => {
+  it("validates phone numbers", () => {
+    expect(validatePhone("+12345678901")).toBe(true);
+    expect(validatePhone("12345")).toBe(false);
+  });
+});
 
-describe('validateAccount', () => {
-  it('handles email method', () => {
-    expect(validateAccount('test@example.com', 'email')).toBe(true)
-    expect(validateAccount('bademail', 'email')).toBe(false)
-  })
+describe("validateAccount", () => {
+  it("handles email method", () => {
+    expect(validateAccount("test@example.com", "email")).toBe(true);
+    expect(validateAccount("bademail", "email")).toBe(false);
+  });
 
-  it('handles phone method', () => {
-    expect(validateAccount('+12345678901', 'phone')).toBe(true)
-    expect(validateAccount('12345', 'phone')).toBe(false)
-  })
+  it("handles phone method", () => {
+    expect(validateAccount("+12345678901", "phone")).toBe(true);
+    expect(validateAccount("12345", "phone")).toBe(false);
+  });
 
-  it('defaults to true for other methods', () => {
-    expect(validateAccount('anything', 'username')).toBe(true)
-  })
-})
+  it("defaults to true for other methods", () => {
+    expect(validateAccount("anything", "username")).toBe(true);
+  });
+});

--- a/website/stylelint.config.cjs
+++ b/website/stylelint.config.cjs
@@ -1,10 +1,10 @@
 module.exports = {
-  extends: ['stylelint-config-standard'],
+  extends: ["stylelint-config-standard"],
   rules: {
-    'selector-pseudo-class-no-unknown': [
+    "selector-pseudo-class-no-unknown": [
       true,
       {
-        ignorePseudoClasses: ['global'],
+        ignorePseudoClasses: ["global"],
       },
     ],
   },

--- a/website/test/__mocks__/fileMock.cjs
+++ b/website/test/__mocks__/fileMock.cjs
@@ -1,1 +1,1 @@
-module.exports = 'file-mock'
+module.exports = "file-mock";

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -1,23 +1,23 @@
-import { fileURLToPath, URL } from 'node:url'
-import path from 'node:path'
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import postcssImport from 'postcss-import'
+import { fileURLToPath, URL } from "node:url";
+import path from "node:path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import postcssImport from "postcss-import";
 
 // centralised directory references
-const srcDir = fileURLToPath(new URL('./src', import.meta.url))
-const assetsDir = fileURLToPath(new URL('./src/assets', import.meta.url))
+const srcDir = fileURLToPath(new URL("./src", import.meta.url));
+const assetsDir = fileURLToPath(new URL("./src/assets", import.meta.url));
 
 // alias map reused by both Vite and PostCSS
 const aliases = {
-  '@': srcDir,
-  '@assets': assetsDir
-}
+  "@": srcDir,
+  "@assets": assetsDir,
+};
 
 export default defineConfig({
-  base: './',
+  base: "./",
   resolve: {
-    alias: aliases
+    alias: aliases,
   },
   css: {
     postcss: {
@@ -26,19 +26,19 @@ export default defineConfig({
           resolve(id) {
             for (const [key, target] of Object.entries(aliases)) {
               if (id.startsWith(`${key}/`)) {
-                return path.resolve(target, id.slice(key.length + 1))
+                return path.resolve(target, id.slice(key.length + 1));
               }
             }
-            return undefined
-          }
-        })
-      ]
-    }
+            return undefined;
+          },
+        }),
+      ],
+    },
   },
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:8080'
-    }
-  }
-})
+      "/api": "http://localhost:8080",
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- refactor the word store to persist version lists, active version ids and metadata for each term key
- extend the streaming hook and API client to handle metadata events, force reruns, and hydrate cached versions
- add a dedicated output toolbar with injection points, wire it into desktop/mobile top bars, and teach the App and tests to navigate between cached versions

## Testing
- npm test -- --runTestsByPath src/components/TopBar/__tests__/OutputToolbar.test.jsx src/components/TopBar/__tests__/DesktopTopBar.test.jsx src/components/TopBar/__tests__/MobileTopBar.test.jsx src/pages/App/__tests__/streaming.test.jsx src/hooks/__tests__/useStreamWord.test.js src/store/__tests__/wordStore.test.js src/api/__tests__/words.stream.test.js
- npx eslint . --fix
- npx stylelint "src/**/*.{css,scss}" --fix
- npx prettier -w .
- mvn spotless:apply *(fails: offline Maven repository prevents dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e93ee7888332ba25f04b0812c546