### PR TITLE
feat: add search result version history support

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/SearchResultVersionController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/SearchResultVersionController.java
@@ -1,0 +1,71 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.config.auth.AuthenticatedUser;
+import com.glancy.backend.dto.SearchRecordVersionSummary;
+import com.glancy.backend.dto.SearchResultVersionResponse;
+import com.glancy.backend.entity.SearchResultVersion;
+import com.glancy.backend.service.SearchResultService;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes read-only access to search result versions for dictionary lookups.
+ */
+@RestController
+@RequestMapping("/api/words/{recordId}/versions")
+@Slf4j
+public class SearchResultVersionController {
+
+    private final SearchResultService searchResultService;
+
+    public SearchResultVersionController(SearchResultService searchResultService) {
+        this.searchResultService = searchResultService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SearchRecordVersionSummary>> listVersions(
+        @AuthenticatedUser Long userId,
+        @PathVariable Long recordId
+    ) {
+        log.info("Listing versions for user {} record {}", userId, recordId);
+        List<SearchRecordVersionSummary> summaries = searchResultService.listVersionSummaries(userId, recordId);
+        log.info("Found {} versions for user {} record {}", summaries.size(), userId, recordId);
+        return ResponseEntity.ok(summaries);
+    }
+
+    @GetMapping("/{versionId}")
+    public ResponseEntity<SearchResultVersionResponse> getVersion(
+        @AuthenticatedUser Long userId,
+        @PathVariable Long recordId,
+        @PathVariable Long versionId
+    ) {
+        log.info("Fetching version {} for user {} record {}", versionId, userId, recordId);
+        SearchResultVersion version = searchResultService.getVersionDetail(userId, recordId, versionId);
+        SearchResultVersionResponse response = new SearchResultVersionResponse(
+            version.getId(),
+            version.getSearchRecord().getId(),
+            version.getWord() != null ? version.getWord().getId() : null,
+            version.getUser() != null ? version.getUser().getId() : null,
+            version.getTerm(),
+            version.getLanguage(),
+            version.getVersionNumber(),
+            version.getModel(),
+            version.getPreview(),
+            version.getContent(),
+            version.getCreatedAt()
+        );
+        log.info(
+            "Returning version {} for record {} user {} with model {}",
+            response.id(),
+            response.recordId(),
+            response.userId(),
+            response.model()
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
@@ -14,6 +14,7 @@ public record SearchRecordResponse(
     Language language,
     LocalDateTime createdAt,
     Boolean favorite,
+    SearchRecordVersionSummary latestVersion,
     List<SearchRecordVersionSummary> versions
 ) {
 
@@ -21,7 +22,10 @@ public record SearchRecordResponse(
         versions = versions == null ? List.of() : List.copyOf(versions);
     }
 
-    public SearchRecordResponse withVersions(List<SearchRecordVersionSummary> versionSummaries) {
+    public SearchRecordResponse withVersionDetails(
+        SearchRecordVersionSummary latest,
+        List<SearchRecordVersionSummary> versionSummaries
+    ) {
         return new SearchRecordResponse(
             id,
             userId,
@@ -29,6 +33,7 @@ public record SearchRecordResponse(
             language,
             createdAt,
             favorite,
+            latest,
             versionSummaries == null ? List.of() : List.copyOf(versionSummaries)
         );
     }

--- a/backend/src/main/java/com/glancy/backend/dto/SearchRecordVersionSummary.java
+++ b/backend/src/main/java/com/glancy/backend/dto/SearchRecordVersionSummary.java
@@ -3,6 +3,12 @@ package com.glancy.backend.dto;
 import java.time.LocalDateTime;
 
 /**
- * Lightweight summary of an individual history version for a search term.
+ * Lightweight summary of a persisted search result version for a search term.
  */
-public record SearchRecordVersionSummary(Long id, LocalDateTime createdAt, Boolean favorite) {}
+public record SearchRecordVersionSummary(
+    Long id,
+    Integer versionNumber,
+    LocalDateTime createdAt,
+    String model,
+    String preview
+) {}

--- a/backend/src/main/java/com/glancy/backend/dto/SearchResultVersionResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/SearchResultVersionResponse.java
@@ -1,0 +1,21 @@
+package com.glancy.backend.dto;
+
+import com.glancy.backend.entity.Language;
+import java.time.LocalDateTime;
+
+/**
+ * Detailed representation of a persisted search result version.
+ */
+public record SearchResultVersionResponse(
+    Long id,
+    Long recordId,
+    Long wordId,
+    Long userId,
+    String term,
+    Language language,
+    Integer versionNumber,
+    String model,
+    String preview,
+    String content,
+    LocalDateTime createdAt
+) {}

--- a/backend/src/main/java/com/glancy/backend/dto/WordResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/WordResponse.java
@@ -23,4 +23,5 @@ public class WordResponse {
     private List<String> related;
     private List<String> phrases;
     private String markdown;
+    private Long versionId;
 }

--- a/backend/src/main/java/com/glancy/backend/entity/SearchResultVersion.java
+++ b/backend/src/main/java/com/glancy/backend/entity/SearchResultVersion.java
@@ -1,0 +1,49 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Immutable snapshot of a search result persisted for history review.
+ */
+@Entity
+@Table(name = "search_result_versions")
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class SearchResultVersion extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "search_record_id", nullable = false)
+    private SearchRecord searchRecord;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "word_id")
+    private Word word;
+
+    @Column(nullable = false, length = 100)
+    private String term;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Language language;
+
+    @Column(nullable = false, length = 64)
+    private String model;
+
+    @Column(name = "version_number", nullable = false)
+    private Integer versionNumber;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "preview", nullable = false, length = 255)
+    private String preview;
+}

--- a/backend/src/main/java/com/glancy/backend/llm/parser/JacksonWordResponseParser.java
+++ b/backend/src/main/java/com/glancy/backend/llm/parser/JacksonWordResponseParser.java
@@ -73,7 +73,8 @@ public class JacksonWordResponseParser implements WordResponseParser {
             antonyms,
             related,
             phrases,
-            markdown
+            markdown,
+            null
         );
         return new ParsedWord(response, markdown);
     }
@@ -92,7 +93,8 @@ public class JacksonWordResponseParser implements WordResponseParser {
             snapshot.antonyms(),
             snapshot.related(),
             snapshot.phrases(),
-            markdown
+            markdown,
+            null
         );
         return new ParsedWord(response, markdown);
     }

--- a/backend/src/main/java/com/glancy/backend/mapper/SearchRecordMapper.java
+++ b/backend/src/main/java/com/glancy/backend/mapper/SearchRecordMapper.java
@@ -9,5 +9,6 @@ import org.mapstruct.Mapping;
 public interface SearchRecordMapper {
     @Mapping(source = "user.id", target = "userId")
     @Mapping(target = "versions", expression = "java(java.util.List.of())")
+    @Mapping(target = "latestVersion", expression = "java(null)")
     SearchRecordResponse toResponse(SearchRecord record);
 }

--- a/backend/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
+++ b/backend/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
@@ -12,10 +12,21 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface SearchRecordRepository extends JpaRepository<SearchRecord, Long> {
-    List<SearchRecord> findByUserIdOrderByCreatedAtDesc(Long userId);
-    void deleteByUserId(Long userId);
-    long countByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
-    boolean existsByUserIdAndTermAndLanguage(Long userId, String term, Language language);
-    SearchRecord findTopByUserIdAndTermAndLanguageOrderByCreatedAtDesc(Long userId, String term, Language language);
-    java.util.Optional<SearchRecord> findByIdAndUserId(Long id, Long userId);
+    List<SearchRecord> findByUserIdAndDeletedFalseOrderByCreatedAtDesc(Long userId);
+
+    long countByUserIdAndDeletedFalseAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    boolean existsByUserIdAndTermAndLanguageAndDeletedFalse(Long userId, String term, Language language);
+
+    SearchRecord findTopByUserIdAndTermAndLanguageAndDeletedFalseOrderByCreatedAtDesc(
+        Long userId,
+        String term,
+        Language language
+    );
+
+    java.util.Optional<SearchRecord> findByIdAndUserIdAndDeletedFalse(Long id, Long userId);
+
+    java.util.Optional<SearchRecord> findByIdAndDeletedFalse(Long id);
+
+    List<SearchRecord> findByUserIdAndDeletedFalse(Long userId);
 }

--- a/backend/src/main/java/com/glancy/backend/repository/SearchResultVersionRepository.java
+++ b/backend/src/main/java/com/glancy/backend/repository/SearchResultVersionRepository.java
@@ -1,0 +1,34 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.SearchResultVersion;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository storing immutable snapshots of dictionary search results.
+ */
+@Repository
+public interface SearchResultVersionRepository extends JpaRepository<SearchResultVersion, Long> {
+
+    List<SearchResultVersion> findBySearchRecordIdAndDeletedFalseOrderByVersionNumberDesc(Long searchRecordId);
+
+    Optional<SearchResultVersion> findTopBySearchRecordIdAndDeletedFalseOrderByVersionNumberDesc(Long searchRecordId);
+
+    Optional<SearchResultVersion> findByIdAndSearchRecordIdAndDeletedFalse(Long id, Long searchRecordId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update SearchResultVersion v set v.deleted = true where v.searchRecord.id = :recordId and v.deleted = false")
+    int softDeleteBySearchRecordId(Long recordId);
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        "update SearchResultVersion v set v.deleted = true " +
+        "where v.searchRecord.id in (:recordIds) and v.deleted = false"
+    )
+    int softDeleteBySearchRecordIdIn(Collection<Long> recordIds);
+}

--- a/backend/src/main/java/com/glancy/backend/service/SearchResultService.java
+++ b/backend/src/main/java/com/glancy/backend/service/SearchResultService.java
@@ -1,0 +1,165 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.SearchRecordVersionSummary;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.SearchRecord;
+import com.glancy.backend.entity.SearchResultVersion;
+import com.glancy.backend.entity.Word;
+import com.glancy.backend.exception.ResourceNotFoundException;
+import com.glancy.backend.repository.SearchRecordRepository;
+import com.glancy.backend.repository.SearchResultVersionRepository;
+import com.glancy.backend.util.SensitiveDataUtil;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Coordinates persistence of search result versions and exposes query helpers.
+ */
+@Service
+@Slf4j
+public class SearchResultService {
+
+    private static final String DEFAULT_MODEL = "unspecified";
+
+    private final SearchResultVersionRepository searchResultVersionRepository;
+    private final SearchRecordRepository searchRecordRepository;
+
+    public SearchResultService(
+        SearchResultVersionRepository searchResultVersionRepository,
+        SearchRecordRepository searchRecordRepository
+    ) {
+        this.searchResultVersionRepository = searchResultVersionRepository;
+        this.searchRecordRepository = searchRecordRepository;
+    }
+
+    @Transactional
+    public SearchResultVersion createVersion(
+        Long recordId,
+        Long userId,
+        String term,
+        Language language,
+        String model,
+        String content,
+        Word word
+    ) {
+        Objects.requireNonNull(recordId, "recordId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+
+        SearchRecord record = searchRecordRepository
+            .findByIdAndDeletedFalse(recordId)
+            .orElseThrow(() -> new ResourceNotFoundException("搜索记录不存在"));
+        if (!record.getUser().getId().equals(userId)) {
+            log.warn("User {} attempted to persist version for record {} not owned by them", userId, recordId);
+            throw new ResourceNotFoundException("搜索记录不存在");
+        }
+
+        String effectiveModel = model == null || model.isBlank() ? DEFAULT_MODEL : model;
+        String effectiveTerm = term == null || term.isBlank() ? record.getTerm() : term;
+        Language effectiveLanguage = language == null ? record.getLanguage() : language;
+
+        int nextVersionNumber = determineNextVersionNumber(recordId);
+
+        SearchResultVersion version = new SearchResultVersion();
+        version.setSearchRecord(record);
+        version.setUser(record.getUser());
+        version.setWord(word);
+        version.setTerm(effectiveTerm);
+        version.setLanguage(effectiveLanguage);
+        version.setModel(effectiveModel);
+        version.setVersionNumber(nextVersionNumber);
+        version.setContent(content);
+        version.setPreview(SensitiveDataUtil.previewText(content));
+
+        SearchResultVersion saved = searchResultVersionRepository.save(version);
+        log.info(
+            "Persisted search result version {} for record {} (term='{}', language={}, model={}, versionNumber={})",
+            saved.getId(),
+            recordId,
+            saved.getTerm(),
+            saved.getLanguage(),
+            saved.getModel(),
+            saved.getVersionNumber()
+        );
+        return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public List<SearchRecordVersionSummary> listVersionSummaries(Long userId, Long recordId) {
+        SearchRecord record = resolveAccessibleRecord(userId, recordId);
+        return searchResultVersionRepository
+            .findBySearchRecordIdAndDeletedFalseOrderByVersionNumberDesc(record.getId())
+            .stream()
+            .map(this::toSummary)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public SearchResultVersion getVersionDetail(Long userId, Long recordId, Long versionId) {
+        resolveAccessibleRecord(userId, recordId);
+        return searchResultVersionRepository
+            .findByIdAndSearchRecordIdAndDeletedFalse(versionId, recordId)
+            .orElseThrow(() -> new ResourceNotFoundException("结果版本不存在"));
+    }
+
+    @Transactional
+    public void softDeleteByRecordIds(Collection<Long> recordIds) {
+        if (recordIds == null || recordIds.isEmpty()) {
+            return;
+        }
+        int affected = searchResultVersionRepository.softDeleteBySearchRecordIdIn(recordIds);
+        log.info("Soft-deleted {} search result versions for records {}", affected, recordIds);
+    }
+
+    @Transactional
+    public void softDeleteByRecordId(Long recordId) {
+        if (recordId == null) {
+            return;
+        }
+        int affected = searchResultVersionRepository.softDeleteBySearchRecordId(recordId);
+        log.info("Soft-deleted {} search result versions for record {}", affected, recordId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<SearchRecordVersionSummary> findLatestSummary(Long recordId) {
+        return searchResultVersionRepository
+            .findTopBySearchRecordIdAndDeletedFalseOrderByVersionNumberDesc(recordId)
+            .map(this::toSummary);
+    }
+
+    private int determineNextVersionNumber(Long recordId) {
+        return searchResultVersionRepository
+            .findTopBySearchRecordIdAndDeletedFalseOrderByVersionNumberDesc(recordId)
+            .map(version -> version.getVersionNumber() + 1)
+            .orElse(1);
+    }
+
+    private SearchRecord resolveAccessibleRecord(Long userId, Long recordId) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(recordId, "recordId must not be null");
+        SearchRecord record = searchRecordRepository
+            .findByIdAndDeletedFalse(recordId)
+            .orElseThrow(() -> new ResourceNotFoundException("搜索记录不存在"));
+        if (!record.getUser().getId().equals(userId)) {
+            log.warn("User {} attempted to access record {} not owned by them", userId, recordId);
+            throw new ResourceNotFoundException("搜索记录不存在");
+        }
+        return record;
+    }
+
+    private SearchRecordVersionSummary toSummary(SearchResultVersion version) {
+        return new SearchRecordVersionSummary(
+            version.getId(),
+            version.getVersionNumber(),
+            version.getCreatedAt(),
+            version.getModel(),
+            version.getPreview()
+        );
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/WordService.java
+++ b/backend/src/main/java/com/glancy/backend/service/WordService.java
@@ -3,9 +3,11 @@ package com.glancy.backend.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glancy.backend.dto.SearchRecordRequest;
+import com.glancy.backend.dto.SearchRecordResponse;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.SearchResultVersion;
 import com.glancy.backend.entity.UserPreference;
 import com.glancy.backend.entity.Word;
 import com.glancy.backend.llm.parser.ParsedWord;
@@ -22,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 
 /**
@@ -35,6 +38,7 @@ public class WordService {
     private final WordRepository wordRepository;
     private final UserPreferenceRepository userPreferenceRepository;
     private final SearchRecordService searchRecordService;
+    private final SearchResultService searchResultService;
     private final WordResponseParser parser;
 
     public WordService(
@@ -42,17 +46,114 @@ public class WordService {
         WordRepository wordRepository,
         UserPreferenceRepository userPreferenceRepository,
         SearchRecordService searchRecordService,
+        SearchResultService searchResultService,
         WordResponseParser parser
     ) {
         this.wordSearcher = wordSearcher;
         this.wordRepository = wordRepository;
         this.userPreferenceRepository = userPreferenceRepository;
         this.searchRecordService = searchRecordService;
+        this.searchResultService = searchResultService;
         this.parser = parser;
     }
 
+    private WordResponse fetchAndPersistWord(
+        Long userId,
+        String term,
+        Language language,
+        String model,
+        SearchRecordResponse record
+    ) {
+        log.info("Word '{}' not found locally or forceNew requested, searching via LLM", term);
+        WordResponse resp = wordSearcher.search(term, language, model);
+        log.info("LLM search result: {}", resp);
+        Word savedWord = saveWord(term, resp, language);
+        String content = resp.getMarkdown();
+        if (content == null) {
+            try {
+                content = serialize(savedWord);
+            } catch (JsonProcessingException e) {
+                log.warn("Failed to serialize word '{}' for version content", savedWord.getTerm(), e);
+                content = SensitiveDataUtil.previewText(savedWord.getMarkdown());
+            }
+        }
+        SearchResultVersion version = persistVersion(record.id(), userId, model, content, savedWord);
+        if (version != null) {
+            resp.setVersionId(version.getId());
+        }
+        return resp;
+    }
+
+    private Mono<StreamPayload> finalizeStreamingSession(StreamingAccumulator session) {
+        CompletionCheck completion = session.summarize(SignalType.ON_COMPLETE);
+        if (!completion.satisfied()) {
+            log.warn(
+                "Streaming session for term '{}' completed without sentinel '{}', skipping persistence",
+                session.term(),
+                CompletionSentinel.MARKER
+            );
+            return Mono.empty();
+        }
+        try {
+            ParsedWord parsed = parser.parse(completion.sanitizedContent(), session.term(), session.language());
+            Word savedWord = saveWord(session.term(), parsed.parsed(), session.language());
+            SearchResultVersion version = persistVersion(
+                session.recordId(),
+                session.userId(),
+                session.model(),
+                parsed.markdown(),
+                savedWord
+            );
+            if (version == null) {
+                return Mono.empty();
+            }
+            return Mono.just(StreamPayload.version(String.valueOf(version.getId())));
+        } catch (Exception e) {
+            log.error("Failed to persist streamed word '{}'", session.term(), e);
+            return Mono.empty();
+        }
+    }
+
+    private SearchResultVersion persistVersion(
+        Long recordId,
+        Long userId,
+        String model,
+        String content,
+        Word word
+    ) {
+        if (recordId == null) {
+            log.warn("Skipping version persistence because search record is unavailable");
+            return null;
+        }
+        return searchResultService.createVersion(
+            recordId,
+            userId,
+            word.getTerm(),
+            word.getLanguage(),
+            model,
+            content,
+            word
+        );
+    }
+
+    public record StreamPayload(String event, String data) {
+        public static StreamPayload data(String data) {
+            return new StreamPayload(null, data);
+        }
+
+        public static StreamPayload version(String versionId) {
+            return new StreamPayload("version", versionId);
+        }
+    }
+
     @Transactional
-    public WordResponse findWordForUser(Long userId, String term, Language language, String model) {
+    public WordResponse findWordForUser(
+        Long userId,
+        String term,
+        Language language,
+        String model,
+        boolean forceNew
+    ) {
         log.info("Finding word '{}' for user {} in language {} using model {}", term, userId, language, model);
         userPreferenceRepository
             .findByUserId(userId)
@@ -62,50 +163,60 @@ public class WordService {
                 p.setDictionaryModel(DictionaryModel.DOUBAO);
                 return p;
             });
-        return wordRepository
-            .findByTermAndLanguageAndDeletedFalse(term, language)
-            .map(word -> {
-                log.info("Found word '{}' in local repository", term);
-                return toResponse(word);
-            })
-            .orElseGet(() -> {
-                log.info("Word '{}' not found locally, searching via LLM", term);
-                WordResponse resp = wordSearcher.search(term, language, model);
-                log.info("LLM search result: {}", resp);
-                saveWord(term, resp, language);
-                return resp;
-            });
+        SearchRecordRequest req = new SearchRecordRequest();
+        req.setTerm(term);
+        req.setLanguage(language);
+        SearchRecordResponse record = searchRecordService.saveRecord(userId, req);
+        if (!forceNew) {
+            return wordRepository
+                .findByTermAndLanguageAndDeletedFalse(term, language)
+                .map(word -> {
+                    log.info("Found word '{}' in local repository", term);
+                    return toResponse(word);
+                })
+                .orElseGet(() -> fetchAndPersistWord(userId, term, language, model, record));
+        }
+        return fetchAndPersistWord(userId, term, language, model, record);
     }
 
     /**
      * Stream search results for a word and persist the search record.
      */
     @Transactional
-    public Flux<String> streamWordForUser(Long userId, String term, Language language, String model) {
+    public Flux<StreamPayload> streamWordForUser(
+        Long userId,
+        String term,
+        Language language,
+        String model,
+        boolean forceNew
+    ) {
         log.info("Streaming word '{}' for user {} in language {} using model {}", term, userId, language, model);
         SearchRecordRequest req = new SearchRecordRequest();
         req.setTerm(term);
         req.setLanguage(language);
+        SearchRecordResponse record;
         try {
-            searchRecordService.saveRecord(userId, req);
+            record = searchRecordService.saveRecord(userId, req);
         } catch (Exception e) {
             log.error("Failed to save search record for user {}", userId, e);
             String msg = "Failed to save search record: " + e.getMessage();
             return Flux.error(new IllegalStateException(msg, e));
         }
 
-        var existing = wordRepository.findByTermAndLanguageAndDeletedFalse(term, language);
-        if (existing.isPresent()) {
-            log.info("Found cached word '{}' in language {}", term, language);
-            try {
-                return Flux.just(serialize(existing.get()));
-            } catch (Exception e) {
-                log.error("Failed to serialize cached word '{}'", term, e);
-                return Flux.error(new IllegalStateException("Failed to serialize cached word", e));
+        if (!forceNew) {
+            var existing = wordRepository.findByTermAndLanguageAndDeletedFalse(term, language);
+            if (existing.isPresent()) {
+                log.info("Found cached word '{}' in language {}", term, language);
+                try {
+                    return Flux.just(StreamPayload.data(serialize(existing.get())));
+                } catch (Exception e) {
+                    log.error("Failed to serialize cached word '{}'", term, e);
+                    return Flux.error(new IllegalStateException("Failed to serialize cached word", e));
+                }
             }
         }
 
-        StreamingAccumulator session = new StreamingAccumulator(userId, term, language, model);
+        StreamingAccumulator session = new StreamingAccumulator(userId, record.id(), term, language, model);
         Flux<String> stream;
         try {
             stream = wordSearcher.streamSearch(term, language, model);
@@ -115,7 +226,7 @@ public class WordService {
             return Flux.error(new IllegalStateException(msg, e));
         }
 
-        return stream
+        Flux<StreamPayload> main = stream
             .doOnNext(chunk -> {
                 log.info("Streaming chunk for term '{}': {}", term, chunk);
                 session.append(chunk);
@@ -132,31 +243,17 @@ public class WordService {
                 )
             )
             .doOnError(session::markError)
-            .doFinally(signal -> {
-                log.info("Streaming finished for term '{}' with signal {}", term, signal);
-                CompletionCheck completion = session.finish(signal);
-                if (signal == SignalType.ON_COMPLETE) {
-                    if (!completion.satisfied()) {
-                        log.warn(
-                            "Streaming session for term '{}' completed without sentinel '{}', skipping persistence",
-                            term,
-                            CompletionSentinel.MARKER
-                        );
-                        return;
-                    }
-                    try {
-                        ParsedWord parsed = parser.parse(completion.sanitizedContent(), term, language);
-                        saveWord(term, parsed.parsed(), language);
-                    } catch (Exception e) {
-                        log.error("Failed to persist streamed word '{}'", term, e);
-                    }
-                }
-            });
+            .map(StreamPayload::data);
+
+        return main
+            .concatWith(Mono.defer(() -> finalizeStreamingSession(session)))
+            .doFinally(session::logSummary);
     }
 
     private static final class StreamingAccumulator {
 
         private final Long userId;
+        private final Long recordId;
         private final String term;
         private final Language language;
         private final String model;
@@ -167,8 +264,9 @@ public class WordService {
         private Throwable failure;
         private String snapshot;
 
-        StreamingAccumulator(Long userId, String term, Language language, String model) {
+        StreamingAccumulator(Long userId, Long recordId, String term, Language language, String model) {
             this.userId = userId;
+            this.recordId = recordId;
             this.term = term;
             this.language = language;
             this.model = model;
@@ -184,7 +282,7 @@ public class WordService {
             failure = throwable;
         }
 
-        CompletionCheck finish(SignalType signal) {
+        CompletionCheck summarize(SignalType signal) {
             long duration = Duration.between(startedAt, Instant.now()).toMillis();
             String aggregated = aggregatedContent();
             String errorSummary = "<none>";
@@ -211,11 +309,37 @@ public class WordService {
             return completion;
         }
 
+        void logSummary(SignalType signal) {
+            if (signal != SignalType.ON_COMPLETE) {
+                summarize(signal);
+            }
+        }
+
         String aggregatedContent() {
             if (snapshot == null) {
                 snapshot = transcript.toString();
             }
             return snapshot;
+        }
+
+        Long recordId() {
+            return recordId;
+        }
+
+        Long userId() {
+            return userId;
+        }
+
+        String term() {
+            return term;
+        }
+
+        Language language() {
+            return language;
+        }
+
+        String model() {
+            return model;
         }
     }
 
@@ -224,13 +348,15 @@ public class WordService {
         return mapper.writeValueAsString(toResponse(word));
     }
 
-    private void saveWord(String requestedTerm, WordResponse resp, Language language) {
-        Word word = new Word();
-        word.setMarkdown(resp.getMarkdown());
+    private Word saveWord(String requestedTerm, WordResponse resp, Language language) {
         String term = resp.getTerm() != null ? resp.getTerm() : requestedTerm;
-        word.setTerm(term);
         Language lang = resp.getLanguage() != null ? resp.getLanguage() : language;
+        Word word = wordRepository
+            .findByTermAndLanguageAndDeletedFalse(term, lang)
+            .orElseGet(Word::new);
+        word.setTerm(term);
         word.setLanguage(lang);
+        word.setMarkdown(resp.getMarkdown());
         word.setDefinitions(resp.getDefinitions());
         word.setVariations(resp.getVariations());
         word.setSynonyms(resp.getSynonyms());
@@ -239,12 +365,13 @@ public class WordService {
         word.setPhrases(resp.getPhrases());
         word.setExample(resp.getExample());
         word.setPhonetic(resp.getPhonetic());
-        log.info("Persisting new word '{}' with language {}", term, lang);
+        log.info("Persisting word '{}' with language {}", term, lang);
         Word saved = wordRepository.save(word);
         resp.setId(String.valueOf(saved.getId()));
         resp.setLanguage(lang);
         resp.setTerm(term);
         resp.setMarkdown(word.getMarkdown());
+        return saved;
     }
 
     private WordResponse toResponse(Word word) {
@@ -260,7 +387,8 @@ public class WordService {
             word.getAntonyms(),
             word.getRelated(),
             word.getPhrases(),
-            word.getMarkdown()
+            word.getMarkdown(),
+            null
         );
     }
 }

--- a/backend/src/test/java/com/glancy/backend/controller/SearchResultVersionControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/SearchResultVersionControllerTest.java
@@ -1,0 +1,107 @@
+package com.glancy.backend.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.glancy.backend.dto.SearchRecordVersionSummary;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.SearchRecord;
+import com.glancy.backend.entity.SearchResultVersion;
+import com.glancy.backend.entity.User;
+import com.glancy.backend.service.SearchResultService;
+import com.glancy.backend.service.UserService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * SearchResultVersionController 接口行为测试。
+ */
+@WebMvcTest(controllers = SearchResultVersionController.class)
+@Import(
+    {
+        com.glancy.backend.config.security.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class,
+    }
+)
+class SearchResultVersionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SearchResultService searchResultService;
+
+    @MockitoBean
+    private UserService userService;
+
+    /**
+     * 验证版本列表接口返回基础摘要。 
+     */
+    @Test
+    void listVersionsReturnsSummaries() throws Exception {
+        when(userService.authenticateToken("tkn")).thenReturn(1L);
+        SearchRecordVersionSummary summary = new SearchRecordVersionSummary(
+            5L,
+            2,
+            LocalDateTime.now(),
+            "model-x",
+            "sample"
+        );
+        when(searchResultService.listVersionSummaries(eq(1L), eq(10L))).thenReturn(List.of(summary));
+
+        mockMvc
+            .perform(
+                get("/api/words/10/versions")
+                    .header("X-USER-TOKEN", "tkn")
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("model-x")))
+            .andExpect(content().string(containsString("sample")));
+    }
+
+    /**
+     * 验证版本详情接口返回完整信息。 
+     */
+    @Test
+    void getVersionReturnsDetail() throws Exception {
+        when(userService.authenticateToken("tkn")).thenReturn(1L);
+        SearchRecord record = new SearchRecord();
+        User user = new User();
+        user.setId(1L);
+        record.setId(10L);
+        record.setUser(user);
+        SearchResultVersion version = new SearchResultVersion();
+        version.setId(8L);
+        version.setSearchRecord(record);
+        version.setUser(user);
+        version.setTerm("term");
+        version.setLanguage(Language.ENGLISH);
+        version.setModel("model-y");
+        version.setVersionNumber(3);
+        version.setContent("full content");
+        version.setPreview("full");
+        version.setCreatedAt(LocalDateTime.now());
+
+        when(searchResultService.getVersionDetail(eq(1L), eq(10L), eq(8L))).thenReturn(version);
+
+        mockMvc
+            .perform(
+                get("/api/words/10/versions/8")
+                    .header("X-USER-TOKEN", "tkn")
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("model-y")))
+            .andExpect(content().string(containsString("full content")));
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
-import com.glancy.backend.service.SearchRecordService;
 import com.glancy.backend.service.UserService;
 import com.glancy.backend.service.WordService;
 import java.util.List;
@@ -37,9 +36,6 @@ class WordControllerTest {
     private WordService wordService;
 
     @MockitoBean
-    private SearchRecordService searchRecordService;
-
-    @MockitoBean
     private UserService userService;
 
     /**
@@ -59,9 +55,10 @@ class WordControllerTest {
             List.of(),
             List.of(),
             List.of(),
+            null,
             null
         );
-        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null))).thenReturn(resp);
+        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null), eq(false))).thenReturn(resp);
 
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 
@@ -96,9 +93,10 @@ class WordControllerTest {
             List.of(),
             List.of(),
             List.of(),
+            null,
             null
         );
-        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq("doubao"))).thenReturn(resp);
+        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq("doubao"), eq(false))).thenReturn(resp);
 
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 
@@ -163,9 +161,10 @@ class WordControllerTest {
             List.of(),
             List.of(),
             List.of(),
+            null,
             null
         );
-        when(wordService.findWordForUser(eq(1L), eq("hi"), eq(Language.ENGLISH), eq(null))).thenReturn(resp);
+        when(wordService.findWordForUser(eq(1L), eq("hi"), eq(Language.ENGLISH), eq(null), eq(false))).thenReturn(resp);
 
         mockMvc
             .perform(


### PR DESCRIPTION
## Summary
- add SearchResultVersion entity, repository, and service to persist versioned search results
- update word lookup flow with forceNew support, version tracking, and SSE version events
- expose version query endpoints and extend DTOs/tests to surface version metadata

## Testing
- `mvn test` *(fails: unable to reach Maven Central to resolve dependencies)*
- `mvn spotless:apply` *(fails: unable to reach Maven Central to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e92e4294833282eaae97b4de9adc