### PR TITLE
Reset chat output during regenerate streams

### DIFF
--- a/website/src/pages/App/__tests__/streaming.test.jsx
+++ b/website/src/pages/App/__tests__/streaming.test.jsx
@@ -246,9 +246,9 @@ test("renders markdown preview from streaming json", async () => {
 });
 
 /**
- * 验证重新输出按钮以 forceNew 参数重新发起流并保留旧版本展示。
+ * 验证重新输出按钮以 forceNew 参数重新发起流并在新流开始前清空旧展示。
  */
-test("reoutput triggers forceNew stream and retains previous entry", async () => {
+test("reoutput triggers forceNew stream and resets view before streaming", async () => {
   const generator = jest
     .fn()
     .mockImplementationOnce(async function* () {
@@ -274,8 +274,11 @@ test("reoutput triggers forceNew stream and retains previous entry", async () =>
   fireEvent.click(screen.getByTestId("topbar-reoutput"));
 
   await waitFor(() => expect(generator).toHaveBeenCalledTimes(2));
-  await new Promise((resolve) => setTimeout(resolve, 10));
-  expect(screen.getByRole("heading", { name: "First" })).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("heading", { name: "First" }),
+    ).not.toBeInTheDocument();
+  });
 
   await screen.findByRole("heading", { name: "Second Chapter" });
   expect(generator.mock.calls[1][0].forceNew).toBe(true);

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -159,14 +159,16 @@ function App() {
         model: DEFAULT_MODEL,
       });
       const isNewTerm = currentTermKey !== cacheKey;
+      const shouldResetView = isNewTerm || forceNew;
       setCurrentTermKey(cacheKey);
-      if (isNewTerm) {
+      setCurrentTerm(normalized);
+      setStreamText("");
+      if (shouldResetView) {
         setEntry(null);
+        setFinalText("");
         setVersions([]);
         setActiveVersionId(null);
-        setFinalText("");
       }
-      setStreamText("");
 
       if (!forceNew && versionId) {
         const cachedRecord = wordStoreApi.getState().getRecord?.(cacheKey);


### PR DESCRIPTION
## Summary
- reset the dictionary view state before starting a new lookup so regenerate clears the UI before streaming fresh content
- expand the reoutput streaming test to assert the view is cleared prior to the next response

## Testing
- npm run lint
- npm run lint:css
- npm run test -- --runTestsByPath src/pages/App/__tests__/streaming.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d382c1234083328c4f34e887804fe5