### PR TITLE
fix: preserve cached versions when payload is partial

### DIFF
--- a/website/src/store/__tests__/wordStore.test.js
+++ b/website/src/store/__tests__/wordStore.test.js
@@ -52,4 +52,33 @@ describe("wordStore", () => {
     const record = useWordStore.getState().getRecord("term:fr");
     expect(record.activeVersionId).toBe("new");
   });
+
+  /**
+   * 当后续写入仅返回部分版本时，需与已有缓存合并，确保历史版本仍可切换。
+   */
+  test("merges partial payloads with existing versions", () => {
+    const store = useWordStore.getState();
+    store.setVersions(
+      "term:es",
+      [
+        { id: "v1", markdown: "uno" },
+        { id: "v2", markdown: "dos" },
+      ],
+      { activeVersionId: "v2" },
+    );
+
+    store.setVersions("term:es", [{ id: "v2", markdown: "dos actualizado" }], {
+      activeVersionId: "v2",
+    });
+
+    const record = useWordStore.getState().getRecord("term:es");
+    expect(record.versions).toHaveLength(2);
+    expect(
+      record.versions.find((version) => version.id === "v1").markdown,
+    ).toBe("uno");
+    expect(
+      record.versions.find((version) => version.id === "v2").markdown,
+    ).toBe("dos actualizado");
+    expect(record.activeVersionId).toBe("v2");
+  });
 });


### PR DESCRIPTION
## Summary
- 引入版本集合合并逻辑，防止部分版本负载覆盖已缓存版本
- 在 setVersions 中复用合并结果并更新激活版本指针
- 新增单元测试验证部分负载仍能保留历史版本

## Testing
- npm test -- wordStore
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .

------
https://chatgpt.com/codex/tasks/task_e_68d40f60401c8332ad8bfe2de3b78300