### PR TITLE
refactor: streamline history version labels

### DIFF
--- a/website/src/components/Sidebar/HistoryList.jsx
+++ b/website/src/components/Sidebar/HistoryList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { useHistory, useFavorites, useUser, useLanguage } from "@/context";
 import ItemMenu from "@/components/ui/ItemMenu";
@@ -42,6 +42,21 @@ function HistoryList({ onSelect }) {
   };
 
   const hasHistory = groupedHistory.length > 0;
+  const versionDisplayLabel = t.versionLabel ?? "版本";
+  const accessibleLabelTemplate = t.versionAccessibleLabel;
+
+  const resolveAccessibleLabel = useCallback(
+    (sequence) => {
+      if (!Number.isFinite(sequence)) {
+        return versionDisplayLabel;
+      }
+      const order = Math.trunc(sequence);
+      return accessibleLabelTemplate
+        ? accessibleLabelTemplate.replace("{position}", order)
+        : `${versionDisplayLabel} ${order}`;
+    },
+    [accessibleLabelTemplate, versionDisplayLabel],
+  );
 
   return (
     <>
@@ -98,19 +113,21 @@ function HistoryList({ onSelect }) {
                         const isActive = item.latestVersionId
                           ? String(versionId) === String(item.latestVersionId)
                           : index === 0;
+                        const versionPosition = index + 1;
                         return (
                           <li key={versionId}>
                             <button
                               type="button"
                               className={styles["history-version"]}
                               data-active={isActive ? "true" : undefined}
+                              aria-label={resolveAccessibleLabel(
+                                versionPosition,
+                              )}
                               onClick={() =>
                                 handleSelectVersion(item, versionId)
                               }
                             >
-                              <span>
-                                {t.versionLabel ?? "版本"} {index + 1}
-                              </span>
+                              <span>{versionDisplayLabel}</span>
                             </button>
                           </li>
                         );

--- a/website/src/components/Sidebar/__tests__/HistoryList.test.jsx
+++ b/website/src/components/Sidebar/__tests__/HistoryList.test.jsx
@@ -62,7 +62,7 @@ describe("HistoryList", () => {
     fireEvent.click(screen.getByText("alpha"));
     expect(handleSelect).toHaveBeenCalledWith("alpha", "v1");
 
-    const versionButton = await screen.findByText("版本 2");
+    const versionButton = await screen.findByRole("button", { name: "版本 2" });
     fireEvent.click(versionButton);
     expect(handleSelect).toHaveBeenLastCalledWith("alpha", "v2");
   });

--- a/website/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
+++ b/website/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { useHistory, useLanguage } from "@/context";
 import EmptyState from "@/components/ui/EmptyState";
 import Button from "@/components/ui/Button";
@@ -8,6 +8,22 @@ import styles from "./HistoryDisplay.module.css";
 function HistoryDisplay({ onEmptyAction, onSelect }) {
   const { history } = useHistory();
   const { t } = useLanguage();
+
+  const versionDisplayLabel = t.versionLabel ?? "版本";
+  const accessibleLabelTemplate = t.versionAccessibleLabel;
+
+  const resolveAccessibleLabel = useCallback(
+    (sequence) => {
+      if (!Number.isFinite(sequence)) {
+        return versionDisplayLabel;
+      }
+      const order = Math.trunc(sequence);
+      return accessibleLabelTemplate
+        ? accessibleLabelTemplate.replace("{position}", order)
+        : `${versionDisplayLabel} ${order}`;
+    },
+    [accessibleLabelTemplate, versionDisplayLabel],
+  );
 
   const items = useMemo(() => history ?? [], [history]);
 
@@ -71,16 +87,18 @@ function HistoryDisplay({ onEmptyAction, onSelect }) {
                     const isActive = item.latestVersionId
                       ? String(versionId) === String(item.latestVersionId)
                       : index === 0;
+                    const versionPosition = index + 1;
                     return (
                       <li key={versionId}>
                         <button
                           type="button"
                           className={styles.version}
                           data-active={isActive ? "true" : undefined}
+                          aria-label={resolveAccessibleLabel(versionPosition)}
                           onClick={() => handleSelect(item.term, versionId)}
                         >
                           <span className={styles["version-label"]}>
-                            {t.versionLabel ?? "版本"} {index + 1}
+                            {versionDisplayLabel}
                           </span>
                         </button>
                       </li>

--- a/website/src/components/ui/HistoryDisplay/__tests__/HistoryDisplay.test.jsx
+++ b/website/src/components/ui/HistoryDisplay/__tests__/HistoryDisplay.test.jsx
@@ -39,7 +39,7 @@ describe("HistoryDisplay", () => {
     const handleSelect = jest.fn();
     render(<HistoryDisplay onSelect={handleSelect} />);
 
-    const versionButton = screen.getByText("版本 2");
+    const versionButton = screen.getByRole("button", { name: "版本 2" });
     fireEvent.click(versionButton);
     expect(handleSelect).toHaveBeenCalledWith("beta", "v09");
   });


### PR DESCRIPTION
## Summary
- remove the visible numbering from history version badges while keeping an accessible sequence label
- centralize the display and accessibility handling for version chips across history components
- adjust unit tests to align with the updated version labeling strategy

## Testing
- npx eslint --fix src
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src

------
https://chatgpt.com/codex/tasks/task_e_68d40e7cd6408332bf9fa58b3875239c