### PR TITLE
Fix missing Mockito matcher import in streaming error test

### DIFF
--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -67,6 +68,12 @@ class WordServiceStreamingErrorTest {
         );
     }
 
+    /**
+     * 步骤：
+     * 1. 构造 searchRecordService 的保存返回，确保业务前置流程顺利通过。
+     * 2. 令 wordSearcher.streamSearch 抛出运行时异常模拟底层流式查询错误。
+     * 3. 调用 streamWordForUser 并断言最终异常被包装为 IllegalStateException，且包含原始信息。
+     */
     @Test
     void wrapsExceptionFromSearcher() {
         when(searchRecordService.saveRecord(eq(1L), any())).thenReturn(sampleRecordResponse());


### PR DESCRIPTION
## Summary
- add the missing `anyLong` matcher import required by Mockito in the streaming error unit test
- document the streaming error test scenario so the validation steps remain clear for future maintenance

## Testing
- `./mvnw spotless:apply` *(fails: network is unreachable when downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d418cd66288332b095c6cfa0ae9de6