### PR TITLE
fix: keep theme stable when opening preferences

### DIFF
--- a/website/src/__tests__/Preferences.test.jsx
+++ b/website/src/__tests__/Preferences.test.jsx
@@ -91,3 +91,15 @@ test("keeps user theme when server does not provide one", async () => {
   await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
   expect(mockSetTheme).not.toHaveBeenCalled();
 });
+
+/**
+ * 确认后端返回的主题值不会在用户未操作时触发全局主题切换。
+ */
+test("ignores remote theme preference without user input", async () => {
+  mockRequest.mockReset();
+  mockRequest.mockResolvedValue({ theme: "dark" });
+  render(<Preferences />);
+  await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+  expect(mockSetTheme).not.toHaveBeenCalled();
+  expect(screen.getByLabelText("Theme").value).toBe("light");
+});

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -16,14 +16,6 @@ const DEFAULT_SOURCE_LANG = "auto";
 const DEFAULT_TARGET_LANG = "ENGLISH";
 const DEFAULT_THEME = "system";
 
-const resolveThemePreference = (candidate) => {
-  if (typeof candidate !== "string") {
-    return null;
-  }
-  const trimmed = candidate.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
 function Preferences() {
   const { t } = useLanguage();
   const { theme, setTheme } = useTheme();
@@ -83,12 +75,8 @@ function Preferences() {
       setSourceLang(nextSource);
       setTargetLang(nextTarget);
       persistLanguages(nextSource, nextTarget);
-      const explicitTheme = resolveThemePreference(data.theme);
-      if (explicitTheme) {
-        setTheme(explicitTheme);
-      }
     },
-    [persistLanguages, setTheme],
+    [persistLanguages],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid applying server-provided theme when loading the preferences page so the active choice stays intact
- extend the preferences test suite to cover scenarios with and without remote theme data

## Testing
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w .
- npm test -- Preferences

------
https://chatgpt.com/codex/tasks/task_e_68d420aa6b1083328f21e4d3c31da391