### PR TITLE
feat: personalize word search prompts

### DIFF
--- a/backend/src/main/java/com/glancy/backend/dto/WordPersonalizationContext.java
+++ b/backend/src/main/java/com/glancy/backend/dto/WordPersonalizationContext.java
@@ -1,0 +1,30 @@
+package com.glancy.backend.dto;
+
+import java.util.List;
+
+/**
+ * Captures the learner persona signals that drive LLM prompt adaptation and
+ * downstream personalized explanations.
+ */
+public record WordPersonalizationContext(
+    String personaDescriptor,
+    boolean personaDerivedFromProfile,
+    String audienceDescriptor,
+    String goal,
+    String preferredTone,
+    List<String> interests,
+    List<String> recentTerms
+) {
+    public WordPersonalizationContext {
+        interests = interests == null ? List.of() : List.copyOf(interests);
+        recentTerms = recentTerms == null ? List.of() : List.copyOf(recentTerms);
+    }
+
+    public boolean hasSignals() {
+        return personaDerivedFromProfile
+            || (goal != null && !goal.isBlank())
+            || (preferredTone != null && !preferredTone.isBlank())
+            || !interests.isEmpty()
+            || !recentTerms.isEmpty();
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
@@ -1,11 +1,22 @@
 package com.glancy.backend.llm.service;
 
+import com.glancy.backend.dto.WordPersonalizationContext;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import reactor.core.publisher.Flux;
 
 public interface WordSearcher {
-    WordResponse search(String term, Language language, String clientName);
+    WordResponse search(
+        String term,
+        Language language,
+        String clientName,
+        WordPersonalizationContext personalizationContext
+    );
 
-    Flux<String> streamSearch(String term, Language language, String clientName);
+    Flux<String> streamSearch(
+        String term,
+        Language language,
+        String clientName,
+        WordPersonalizationContext personalizationContext
+    );
 }

--- a/backend/src/main/java/com/glancy/backend/service/personalization/WordPersonalizationService.java
+++ b/backend/src/main/java/com/glancy/backend/service/personalization/WordPersonalizationService.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.service.personalization;
 
 import com.glancy.backend.dto.PersonalizedWordExplanation;
+import com.glancy.backend.dto.WordPersonalizationContext;
 import com.glancy.backend.dto.WordResponse;
 
 /**
@@ -8,5 +9,11 @@ import com.glancy.backend.dto.WordResponse;
  * user's profile and study traces.
  */
 public interface WordPersonalizationService {
-    PersonalizedWordExplanation personalize(Long userId, WordResponse response);
+    WordPersonalizationContext resolveContext(Long userId);
+
+    PersonalizedWordExplanation personalize(WordPersonalizationContext context, WordResponse response);
+
+    default PersonalizedWordExplanation personalize(Long userId, WordResponse response) {
+        return personalize(resolveContext(userId), response);
+    }
 }

--- a/backend/src/test/java/com/glancy/backend/service/personalization/DefaultWordPersonalizationServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/personalization/DefaultWordPersonalizationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.glancy.backend.dto.PersonalizedWordExplanation;
+import com.glancy.backend.dto.WordPersonalizationContext;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
@@ -82,7 +83,18 @@ class DefaultWordPersonalizationServiceTest {
             null
         );
 
-        PersonalizedWordExplanation result = service.personalize(1L, response);
+        WordPersonalizationContext context = service.resolveContext(1L);
+        assertNotNull(context);
+        assertTrue(context.personaDerivedFromProfile());
+        assertEquals("自驱力强的青年进阶者", context.personaDescriptor());
+        assertEquals("大学或初入职场的伙伴", context.audienceDescriptor());
+        assertTrue(context.hasSignals());
+        assertEquals("通过商务演讲展示专业度", context.goal());
+        assertEquals("柔和而坚定", context.preferredTone());
+        assertEquals(List.of("金融", "设计"), context.interests());
+        assertEquals(List.of("equity", "portfolio"), context.recentTerms());
+
+        PersonalizedWordExplanation result = service.personalize(context, response);
 
         assertNotNull(result);
         assertTrue(result.personaSummary().contains("金融"));


### PR DESCRIPTION
## Summary
- introduce `WordPersonalizationContext` so personalization data can be reused across prompt composition and explanations
- resolve personalization context once per request inside `WordService`, reuse it for cached, streamed and persisted results, and extend `WordSearcher` to accept the context
- enrich `WordSearcherImpl` prompt assembly with persona instructions, and update unit tests to cover the new context-driven behaviour

## Testing
- `mvn spotless:apply` *(fails: dependency resolution blocked by offline environment)*
- `./mvnw -Dtest=DefaultWordPersonalizationServiceTest,WordServiceStreamPersistenceTest,WordServiceStreamingErrorTest test` *(fails: Maven wrapper cannot download distribution because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d41f70e2bc83328d11d1443cff102a