### PR TITLE
Add Gomemo vocabulary memorization experience

### DIFF
--- a/website/src/components/Sidebar/CollectionButton.jsx
+++ b/website/src/components/Sidebar/CollectionButton.jsx
@@ -1,0 +1,42 @@
+import PropTypes from "prop-types";
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./Sidebar.module.css";
+
+const joinClassName = (...parts) => parts.filter(Boolean).join(" ");
+
+function CollectionButton({ icon, label, iconAlt, isActive = false, onClick }) {
+  const buttonClassName = joinClassName(
+    styles["collection-button"],
+    isActive ? styles["collection-button-active"] : "",
+  );
+
+  return (
+    <button type="button" className={buttonClassName} onClick={onClick}>
+      <ThemeIcon
+        name={icon}
+        alt={iconAlt || label}
+        width={16}
+        height={16}
+        aria-hidden={iconAlt ? undefined : "true"}
+        className={styles["collection-button-icon"]}
+      />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+CollectionButton.propTypes = {
+  icon: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  iconAlt: PropTypes.string,
+  isActive: PropTypes.bool,
+  onClick: PropTypes.func,
+};
+
+CollectionButton.defaultProps = {
+  iconAlt: undefined,
+  isActive: false,
+  onClick: undefined,
+};
+
+export default CollectionButton;

--- a/website/src/components/Sidebar/Favorites.jsx
+++ b/website/src/components/Sidebar/Favorites.jsx
@@ -1,17 +1,18 @@
-import ThemeIcon from "@/components/ui/Icon";
+import { useCallback } from "react";
+import CollectionButton from "./CollectionButton.jsx";
 import { useLanguage } from "@/context";
 import styles from "./Sidebar.module.css";
 
 const FALLBACK_FAVORITES_LABEL = "Favorites";
 
-const getFavoritesIconAlt = (label, altFromLocale) => altFromLocale || label;
-
 function Favorites({ onToggle }) {
   const { t } = useLanguage();
 
-  const handleClick = () => {
-    if (onToggle) onToggle((v) => !v);
-  };
+  const handleClick = useCallback(() => {
+    if (typeof onToggle === "function") {
+      onToggle((value) => !value);
+    }
+  }, [onToggle]);
 
   const favoritesSectionClassName = [
     styles["sidebar-section"],
@@ -20,22 +21,16 @@ function Favorites({ onToggle }) {
   ].join(" ");
 
   const favoritesLabel = t.favorites || FALLBACK_FAVORITES_LABEL;
-  const favoritesIconAlt = getFavoritesIconAlt(
-    favoritesLabel,
-    t.favoritesIconAlt,
-  );
+  const favoritesIconAlt = t.favoritesIconAlt || favoritesLabel;
 
   return (
     <div className={favoritesSectionClassName}>
-      <h3 className={styles["collection-button"]} onClick={handleClick}>
-        <ThemeIcon
-          name="star-solid"
-          alt={favoritesIconAlt}
-          width={16}
-          height={16}
-        />
-        {favoritesLabel}
-      </h3>
+      <CollectionButton
+        icon="star-solid"
+        label={favoritesLabel}
+        iconAlt={favoritesIconAlt}
+        onClick={handleClick}
+      />
     </div>
   );
 }

--- a/website/src/components/Sidebar/GomemoEntry.jsx
+++ b/website/src/components/Sidebar/GomemoEntry.jsx
@@ -1,0 +1,51 @@
+import { useCallback, useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import CollectionButton from "./CollectionButton.jsx";
+import { useLanguage } from "@/context";
+import styles from "./Sidebar.module.css";
+
+const GOMEMO_PATH = "/gomemo";
+const FALLBACK_GOMEMO_LABEL = "Gomemo";
+
+function GomemoEntry() {
+  const { t } = useLanguage();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const gomemoLabel = t.gomemo || FALLBACK_GOMEMO_LABEL;
+  const gomemoIconAlt = t.gomemoIconAlt || gomemoLabel;
+  const gomemoTagline = t.gomemoTagline || "";
+
+  const sectionClassName = useMemo(
+    () =>
+      [styles["sidebar-section"], styles["sidebar-hoverable"]]
+        .filter(Boolean)
+        .join(" "),
+    [],
+  );
+
+  const isActive = location.pathname.startsWith(GOMEMO_PATH);
+
+  const handleNavigate = useCallback(() => {
+    if (location.pathname !== GOMEMO_PATH) {
+      navigate(GOMEMO_PATH);
+    }
+  }, [location.pathname, navigate]);
+
+  return (
+    <div className={sectionClassName}>
+      <CollectionButton
+        icon="target"
+        label={gomemoLabel}
+        iconAlt={gomemoIconAlt}
+        isActive={isActive}
+        onClick={handleNavigate}
+      />
+      {gomemoTagline && (
+        <p className={styles["collection-note"]}>{gomemoTagline}</p>
+      )}
+    </div>
+  );
+}
+
+export default GomemoEntry;

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -182,15 +182,61 @@
   border-radius: var(--radius-sm, 4px);
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: var(--sidebar-brand-gap, 8px);
+  width: 100%;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.collection-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 60%, transparent);
+  outline-offset: 3px;
 }
 
 .collection-button:hover {
   background-color: var(--color-overlay-weak);
+  transform: translateX(1px);
 }
 
 :root[data-theme="dark"] .collection-button:hover {
   background-color: var(--color-overlay-inverse);
+}
+
+.collection-button-icon {
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 1px rgb(0 0 0 / 8%));
+}
+
+.collection-button-active {
+  background: color-mix(in srgb, var(--sidebar-bg) 94%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--accent-color) 28%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 52%, var(--sidebar-color));
+}
+
+.collection-button-active .collection-button-icon {
+  filter: drop-shadow(
+    0 0 4px color-mix(in srgb, var(--accent-color) 40%, transparent)
+  );
+}
+
+.collection-note {
+  margin: 0;
+  padding-inline: var(--sidebar-item-padding-x, 16px);
+  padding-bottom: var(--space-1, 4px);
+  font-size: 12px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--sidebar-color) 64%, transparent);
+  letter-spacing: 0.02em;
 }
 
 .sidebar-hoverable {

--- a/website/src/components/Sidebar/SidebarFunctions.jsx
+++ b/website/src/components/Sidebar/SidebarFunctions.jsx
@@ -1,3 +1,4 @@
+import GomemoEntry from "./GomemoEntry.jsx";
 import Favorites from "./Favorites.jsx";
 import HistoryList from "./HistoryList.jsx";
 import { useUser } from "@/context";
@@ -7,6 +8,7 @@ function SidebarFunctions({ onToggleFavorites, onSelectHistory }) {
   const { user } = useUser();
   return (
     <div className={styles["sidebar-functions"]}>
+      <GomemoEntry />
       {user && <Favorites onToggle={onToggleFavorites} />}
       <HistoryList onSelect={onSelectHistory} />
     </div>

--- a/website/src/components/Sidebar/index.js
+++ b/website/src/components/Sidebar/index.js
@@ -1,5 +1,5 @@
 export { default } from "./Sidebar.jsx";
-export { default as Favorites } from "./Favorites.jsx";
-export { default as HistoryList } from "./HistoryList.jsx";
 export { default as SidebarFunctions } from "./SidebarFunctions.jsx";
 export { default as SidebarUser } from "./SidebarUser.jsx";
+export { default as Favorites } from "./Favorites.jsx";
+export { default as GomemoEntry } from "./GomemoEntry.jsx";

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -35,6 +35,71 @@ export default {
   personalizationHooksTitle: "Reinforcement Tips",
   personalizationPromptsTitle: "Reflection Prompts",
   favorites: "Favorites",
+  favoritesIconAlt: "Open favorites collection",
+  gomemo: "Gomemo",
+  gomemoIconAlt: "Navigate to the Gomemo vocabulary atelier",
+  gomemoTagline: "Daily priority words, curated for your ambitions.",
+  gomemoHeroTitle: "Gomemo · Bespoke vocabulary mastery",
+  gomemoHeroSubtitle:
+    "Gomemo orchestrates spaced memorisation that honours your age, passions, goals and future plans in one seamless ritual.",
+  gomemoHeroBadgePersonal: "Age-attuned pathways",
+  gomemoHeroBadgeRhythm: "Adaptive daily rhythm",
+  gomemoHeroBadgeFuture: "Future-ready planning",
+  gomemoPriorityTitle: "Know exactly what deserves your focus",
+  gomemoPrioritySubtitle:
+    "A weighted intelligence scores each candidate by age profile, personal interests, outcome goals, recent searches, daily quota and long-term plans.",
+  gomemoPriorityAgeTitle: "Age-sensitive cadence",
+  gomemoPriorityAgeDescription:
+    "Difficulty and storytelling shift with your cognitive rhythm, from junior explorers to seasoned professionals.",
+  gomemoPriorityInterestTitle: "Interest signature",
+  gomemoPriorityInterestDescription:
+    "Examples weave in your passions—be it design, finance or anime—so every word feels native to your world.",
+  gomemoPriorityGoalTitle: "Goal alignment",
+  gomemoPriorityGoalDescription:
+    "Exam prep, immigration interview or business pitch—priorities flex to accelerate the milestone ahead.",
+  gomemoPriorityHistoryTitle: "Search memory",
+  gomemoPriorityHistoryDescription:
+    "Latest lookups, forgotten attempts and tricky synonyms reform a queue that never lets weak spots fade.",
+  gomemoPriorityDailyTitle: "Daily quota intelligence",
+  gomemoPriorityDailyDescription:
+    "Your preferred word volume informs pacing so sessions feel achievable yet compounding.",
+  gomemoPriorityPlanTitle: "Future plan fusion",
+  gomemoPriorityPlanDescription:
+    "Upcoming trips, career shifts or exams feed forward to surface vocabulary you will soon rely on.",
+  gomemoModesTitle: "Elevated practice, every modality",
+  gomemoModesSubtitle:
+    "Blend leading memory techniques into a couture study loop that keeps curiosity awake.",
+  gomemoModesCardTitle: "Immersive flash cards",
+  gomemoModesCardDescription:
+    "Luxury-grade cards with imagery and mnemonics crafted for instant association and long recall.",
+  gomemoModesQuizTitle: "Curated multiple choice",
+  gomemoModesQuizDescription:
+    "Adaptive distractors target nuance, sharpening recognition even under exam pressure.",
+  gomemoModesSpellingTitle: "Precision spelling",
+  gomemoModesSpellingDescription:
+    "Type, correct and auto-highlight phonetic traps so orthography becomes effortless.",
+  gomemoModesVisualTitle: "Visual pairing",
+  gomemoModesVisualDescription:
+    "Select imagery that resonates with your interest fields to anchor sensory memory.",
+  gomemoModesAudioTitle: "Immersive listening",
+  gomemoModesAudioDescription:
+    "Studio-grade pronunciations and shadowing drills refine accent and tonal mastery.",
+  gomemoInsightsTitle: "Track, reflect, elevate",
+  gomemoInsightsSubtitle:
+    "Every rehearsal is logged to celebrate micro-wins and surface curated advice from Doubao.",
+  gomemoInsightsTrackingTitle: "Sculpted progress analytics",
+  gomemoInsightsTrackingDescription:
+    "Heatmaps and retention curves reveal when to reinforce, reschedule or elevate difficulty.",
+  gomemoInsightsReviewTitle: "Doubao debrief",
+  gomemoInsightsReviewDescription:
+    "A Doubao-powered narrative summarises your session, applauds breakthroughs and pinpoints delicate terms.",
+  gomemoInsightsNextTitle: "Forward guidance",
+  gomemoInsightsNextDescription:
+    "Receive bespoke study routes, weekend intensives and upcoming word themes aligned with your future plans.",
+  gomemoCtaTitle: "Craft your signature vocabulary atelier",
+  gomemoCtaSubtitle:
+    "Synchronise ambition with an intelligent guide that keeps every session poised and purposeful.",
+  gomemoCtaAction: "Begin personalised rehearsal",
   searchHistory: "History",
   noFavorites: "No favorites yet",
   noHistory: "No history",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -34,6 +34,66 @@ export default {
   personalizationHooksTitle: "巩固建议",
   personalizationPromptsTitle: "思考提示",
   favorites: "收藏夹",
+  favoritesIconAlt: "打开收藏夹",
+  gomemo: "学单词",
+  gomemoIconAlt: "进入 Gomemo 词汇工坊",
+  gomemoTagline: "围绕目标定制的每日高优先级清单。",
+  gomemoHeroTitle: "Gomemo · 私享记忆设计",
+  gomemoHeroSubtitle:
+    "Gomemo 将年龄、兴趣、目标与未来规划编织成一体，让背词成为与你的节奏完美契合的日常仪式。",
+  gomemoHeroBadgePersonal: "年龄自适应",
+  gomemoHeroBadgeRhythm: "每日节奏智能",
+  gomemoHeroBadgeFuture: "提前对齐未来",
+  gomemoPriorityTitle: "精准知道当下该背什么",
+  gomemoPrioritySubtitle:
+    "加权引擎综合年龄画像、兴趣偏好、阶段目标、搜索记录、日背数量与未来计划，计算出最高优先级的词表。",
+  gomemoPriorityAgeTitle: "年龄节律匹配",
+  gomemoPriorityAgeDescription:
+    "难度梯度与叙事语境随年龄段微调，从校园到职场都能轻松吸收。",
+  gomemoPriorityInterestTitle: "兴趣脉络嵌入",
+  gomemoPriorityInterestDescription:
+    "例句与语境主动呼应你的兴趣领域，让新词迅速融入熟悉的世界。",
+  gomemoPriorityGoalTitle: "目标导向加速",
+  gomemoPriorityGoalDescription:
+    "无论是考试、面试还是商务场景，系统都会突出最能推动成果的词汇。",
+  gomemoPriorityHistoryTitle: "搜索记忆回溯",
+  gomemoPriorityHistoryDescription:
+    "近期查询、遗忘词与易错点重新排队，弱项不会再悄然滑落。",
+  gomemoPriorityDailyTitle: "每日剂量校准",
+  gomemoPriorityDailyDescription:
+    "依据你的词量承诺调节节奏，既不过载也能保持稳步进阶。",
+  gomemoPriorityPlanTitle: "未来计划联动",
+  gomemoPriorityPlanDescription:
+    "旅行、升学或职业转折等规划都会提前反映，词汇准备领先一步。",
+  gomemoModesTitle: "精选记忆法，一应俱全",
+  gomemoModesSubtitle:
+    "汇聚市面验证过的高效记忆方式，打造高奢却高效的学习闭环。",
+  gomemoModesCardTitle: "沉浸式卡片",
+  gomemoModesCardDescription: "高质感图文与助记提示并行，秒建联想、持久记忆。",
+  gomemoModesQuizTitle: "智适应选择题",
+  gomemoModesQuizDescription:
+    "干扰项按掌握度调节，训练细微辨识力与考试反应速度。",
+  gomemoModesSpellingTitle: "精准拼写",
+  gomemoModesSpellingDescription: "输入纠错与音素提示同步呈现，消除拼写盲区。",
+  gomemoModesVisualTitle: "图像匹配",
+  gomemoModesVisualDescription: "依照兴趣选择图像锚点，激活多感官记忆通路。",
+  gomemoModesAudioTitle: "沉浸听力",
+  gomemoModesAudioDescription: "录音室级发音与跟读训练，雕琢口音与语调。",
+  gomemoInsightsTitle: "记录、复盘、再提升",
+  gomemoInsightsSubtitle:
+    "全程记录背诵轨迹，并由豆包输出高质复盘与下一阶段建议。",
+  gomemoInsightsTrackingTitle: "立体化进度洞察",
+  gomemoInsightsTrackingDescription:
+    "热力图与记忆曲线及时提示该强化、该休息还是该进阶。",
+  gomemoInsightsReviewTitle: "豆包复盘报告",
+  gomemoInsightsReviewDescription:
+    "豆包以叙事方式总结当日亮点与薄弱词，打造高记忆度回顾。",
+  gomemoInsightsNextTitle: "未来学习指引",
+  gomemoInsightsNextDescription:
+    "给出周末冲刺、主题词单与长线规划建议，紧贴你的未来安排。",
+  gomemoCtaTitle: "开启你的专属词汇工作室",
+  gomemoCtaSubtitle: "让每一次背诵都与抱负同频，优雅而高效。",
+  gomemoCtaAction: "立即启用智能背词",
   searchHistory: "搜索记录",
   noDefinition: "暂无释义",
   noFavorites: "暂无收藏",

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -9,6 +9,7 @@ import CookieConsent from "./components/CookieConsent";
 import FallbackRedirect from "./components/FallbackRedirect.jsx";
 
 const App = lazy(() => import("./pages/App"));
+const Gomemo = lazy(() => import("./pages/Gomemo"));
 const Login = lazy(() => import("./pages/auth/Login"));
 const Register = lazy(() => import("./pages/auth/Register"));
 import {
@@ -47,6 +48,7 @@ createRoot(document.getElementById("root")).render(
               <ErrorBoundary>
                 <Suspense fallback={<Loader />}>
                   <Routes>
+                    <Route path="/gomemo" element={<Gomemo />} />
                     <Route path="/login" element={<Login />} />
                     <Route path="/register" element={<Register />} />
                     <Route path="/" element={<App />} />

--- a/website/src/pages/Gomemo/Gomemo.jsx
+++ b/website/src/pages/Gomemo/Gomemo.jsx
@@ -1,0 +1,220 @@
+import { useMemo } from "react";
+import Layout from "@/components/Layout";
+import Button from "@/components/ui/Button";
+import ThemeIcon from "@/components/ui/Icon";
+import { useLanguage } from "@/context";
+import styles from "./Gomemo.module.css";
+
+const EmptyToolbar = () => null;
+
+function Gomemo() {
+  const { t } = useLanguage();
+
+  const heroBadges = useMemo(
+    () =>
+      [
+        t.gomemoHeroBadgePersonal,
+        t.gomemoHeroBadgeRhythm,
+        t.gomemoHeroBadgeFuture,
+      ].filter(Boolean),
+    [t],
+  );
+
+  const priorityFacets = useMemo(
+    () =>
+      [
+        {
+          title: t.gomemoPriorityAgeTitle,
+          description: t.gomemoPriorityAgeDescription,
+          icon: "cake",
+        },
+        {
+          title: t.gomemoPriorityInterestTitle,
+          description: t.gomemoPriorityInterestDescription,
+          icon: "adjustments-horizontal",
+        },
+        {
+          title: t.gomemoPriorityGoalTitle,
+          description: t.gomemoPriorityGoalDescription,
+          icon: "target",
+        },
+        {
+          title: t.gomemoPriorityHistoryTitle,
+          description: t.gomemoPriorityHistoryDescription,
+          icon: "refresh",
+        },
+        {
+          title: t.gomemoPriorityDailyTitle,
+          description: t.gomemoPriorityDailyDescription,
+          icon: "shield-check",
+        },
+        {
+          title: t.gomemoPriorityPlanTitle,
+          description: t.gomemoPriorityPlanDescription,
+          icon: "arrow-right-on-rectangle",
+        },
+      ].filter((facet) => facet.title && facet.description),
+    [t],
+  );
+
+  const practiceModes = useMemo(
+    () =>
+      [
+        {
+          title: t.gomemoModesCardTitle,
+          description: t.gomemoModesCardDescription,
+          icon: "glancy",
+        },
+        {
+          title: t.gomemoModesQuizTitle,
+          description: t.gomemoModesQuizDescription,
+          icon: "question-mark-circle",
+        },
+        {
+          title: t.gomemoModesSpellingTitle,
+          description: t.gomemoModesSpellingDescription,
+          icon: "command-line",
+        },
+        {
+          title: t.gomemoModesVisualTitle,
+          description: t.gomemoModesVisualDescription,
+          icon: "eye",
+        },
+        {
+          title: t.gomemoModesAudioTitle,
+          description: t.gomemoModesAudioDescription,
+          icon: "voice-button",
+        },
+      ].filter((mode) => mode.title && mode.description),
+    [t],
+  );
+
+  const insightHighlights = useMemo(
+    () =>
+      [
+        {
+          title: t.gomemoInsightsTrackingTitle,
+          description: t.gomemoInsightsTrackingDescription,
+          icon: "cog-6-tooth",
+        },
+        {
+          title: t.gomemoInsightsReviewTitle,
+          description: t.gomemoInsightsReviewDescription,
+          icon: "star-solid",
+        },
+        {
+          title: t.gomemoInsightsNextTitle,
+          description: t.gomemoInsightsNextDescription,
+          icon: "arrow-right",
+        },
+      ].filter((item) => item.title && item.description),
+    [t],
+  );
+
+  return (
+    <Layout topBarProps={{ toolbarComponent: EmptyToolbar }}>
+      <div className={styles["gomemo-page"]}>
+        <section className={styles.hero}>
+          <div className={styles["hero-inner"]}>
+            <span className={styles["hero-kicker"]}>{t.gomemo}</span>
+            <h1>{t.gomemoHeroTitle}</h1>
+            <p>{t.gomemoHeroSubtitle}</p>
+            {heroBadges.length > 0 && (
+              <div className={styles["hero-badges"]}>
+                {heroBadges.map((badge) => (
+                  <span key={badge} className={styles["hero-badge"]}>
+                    {badge}
+                  </span>
+                ))}
+              </div>
+            )}
+            <Button className={styles["hero-cta"]}>{t.gomemoCtaAction}</Button>
+          </div>
+        </section>
+
+        <section className={`${styles.priority} ${styles.section}`}>
+          <header className={styles["section-header"]}>
+            <h2 className={styles["section-title"]}>{t.gomemoPriorityTitle}</h2>
+            <p className={styles["section-subtitle"]}>
+              {t.gomemoPrioritySubtitle}
+            </p>
+          </header>
+          <div className={styles["priority-grid"]}>
+            {priorityFacets.map((facet) => (
+              <article key={facet.title} className={styles["priority-card"]}>
+                <ThemeIcon
+                  name={facet.icon}
+                  alt=""
+                  aria-hidden="true"
+                  width={28}
+                  height={28}
+                  className={styles["card-icon"]}
+                />
+                <h3>{facet.title}</h3>
+                <p>{facet.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={`${styles.modes} ${styles.section}`}>
+          <header className={styles["section-header"]}>
+            <h2 className={styles["section-title"]}>{t.gomemoModesTitle}</h2>
+            <p className={styles["section-subtitle"]}>
+              {t.gomemoModesSubtitle}
+            </p>
+          </header>
+          <div className={styles["modes-grid"]}>
+            {practiceModes.map((mode) => (
+              <article key={mode.title} className={styles["mode-card"]}>
+                <ThemeIcon
+                  name={mode.icon}
+                  alt=""
+                  aria-hidden="true"
+                  width={26}
+                  height={26}
+                  className={styles["card-icon"]}
+                />
+                <h3>{mode.title}</h3>
+                <p>{mode.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={`${styles.insights} ${styles.section}`}>
+          <header className={styles["section-header"]}>
+            <h2 className={styles["section-title"]}>{t.gomemoInsightsTitle}</h2>
+            <p className={styles["section-subtitle"]}>
+              {t.gomemoInsightsSubtitle}
+            </p>
+          </header>
+          <div className={styles["insight-grid"]}>
+            {insightHighlights.map((item) => (
+              <article key={item.title} className={styles["insight-card"]}>
+                <ThemeIcon
+                  name={item.icon}
+                  alt=""
+                  aria-hidden="true"
+                  width={26}
+                  height={26}
+                  className={styles["card-icon"]}
+                />
+                <h3>{item.title}</h3>
+                <p>{item.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles["cta-panel"]}>
+          <h2 className={styles["cta-title"]}>{t.gomemoCtaTitle}</h2>
+          <p className={styles["cta-subtitle"]}>{t.gomemoCtaSubtitle}</p>
+          <Button className={styles["hero-cta"]}>{t.gomemoCtaAction}</Button>
+        </section>
+      </div>
+    </Layout>
+  );
+}
+
+export default Gomemo;

--- a/website/src/pages/Gomemo/Gomemo.module.css
+++ b/website/src/pages/Gomemo/Gomemo.module.css
@@ -1,0 +1,321 @@
+.gomemo-page {
+  padding: calc(var(--space-5, 32px) + var(--space-2, 8px)) var(--space-5, 32px)
+    calc(var(--space-5, 32px) + env(safe-area-inset-bottom, 0px));
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space-5, 32px) + var(--space-2, 8px));
+  color: var(--color-text);
+}
+
+.hero {
+  position: relative;
+  border-radius: var(--radius-xl, 20px);
+  padding: calc(var(--space-5, 32px) + var(--space-2, 8px));
+  background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--accent-color) 28%, transparent) 0%,
+      color-mix(in srgb, var(--sidebar-bg) 94%, transparent) 100%
+    )
+    border-box;
+  border: 1px solid color-mix(in srgb, var(--border-color) 42%, transparent);
+  box-shadow: 0 28px 80px -40px var(--shadow-color);
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: -30% 40% auto -40%;
+  height: 160%;
+  background: radial-gradient(
+    circle at center,
+    color-mix(in srgb, var(--accent-color) 36%, transparent) 0%,
+    transparent 65%
+  );
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.hero-inner {
+  position: relative;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 16px);
+}
+
+.hero-kicker {
+  font-size: 14px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw + 1.2rem, 3rem);
+  letter-spacing: -0.015em;
+}
+
+.hero p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: color-mix(in srgb, var(--color-text) 72%, transparent);
+}
+
+.hero-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2, 8px);
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sidebar-bg) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 36%, transparent);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.hero-cta {
+  align-self: flex-start;
+  margin-top: var(--space-1, 4px);
+  padding: 0.85em 1.8em;
+  border-radius: 999px !important;
+  background: var(--primary-bg);
+  color: var(--primary-color);
+  border: 1px solid transparent;
+  box-shadow: 0 24px 48px -28px var(--shadow-color);
+  transition:
+    transform 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.hero-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 32px 64px -32px var(--shadow-color);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 16px);
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  max-width: 760px;
+}
+
+.section-title {
+  margin: 0;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.4rem);
+  letter-spacing: -0.01em;
+}
+
+.section-subtitle {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+
+.priority {
+  border-radius: var(--radius-xl, 20px);
+  padding: calc(var(--space-4, 24px) + var(--space-1, 4px));
+  background: color-mix(in srgb, var(--sidebar-bg) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
+  box-shadow: 0 20px 60px -40px var(--shadow-color);
+}
+
+.priority-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-3, 16px);
+}
+
+.priority-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  padding: var(--space-3, 16px);
+  border-radius: var(--radius-lg, 12px);
+  background: color-mix(in srgb, var(--chat-window-bg) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 28%, transparent);
+  box-shadow: 0 16px 36px -32px var(--shadow-color);
+}
+
+.card-icon {
+  width: 28px;
+  height: 28px;
+}
+
+.priority-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  letter-spacing: -0.005em;
+}
+
+.priority-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-text) 68%, transparent);
+}
+
+.modes {
+  border-radius: var(--radius-xl, 20px);
+  padding: calc(var(--space-4, 24px) + var(--space-1, 4px));
+  background: linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--accent-color) 18%, transparent) 0%,
+      color-mix(in srgb, var(--chat-window-bg) 96%, transparent) 100%
+    )
+    border-box;
+  border: 1px solid color-mix(in srgb, var(--border-color) 38%, transparent);
+  box-shadow: 0 24px 70px -48px var(--shadow-color);
+}
+
+.modes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-3, 16px);
+}
+
+.mode-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  padding: calc(var(--space-3, 16px) + 4px);
+  border-radius: var(--radius-lg, 12px);
+  backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--sidebar-bg) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 30%, transparent);
+}
+
+.mode-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mode-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+
+.insights {
+  border-radius: var(--radius-xl, 20px);
+  padding: calc(var(--space-4, 24px) + var(--space-1, 4px));
+  background: color-mix(in srgb, var(--sidebar-bg) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+  box-shadow: 0 20px 64px -46px var(--shadow-color);
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-3, 16px);
+}
+
+.insight-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  padding: var(--space-3, 16px);
+  border-radius: var(--radius-lg, 12px);
+  background: color-mix(in srgb, var(--chat-window-bg) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 28%, transparent);
+}
+
+.insight-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.insight-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+
+.cta-panel {
+  border-radius: var(--radius-xl, 20px);
+  padding: calc(var(--space-4, 24px) + var(--space-1, 4px));
+  background: linear-gradient(
+      120deg,
+      color-mix(in srgb, var(--accent-color) 24%, transparent) 0%,
+      color-mix(in srgb, var(--chat-window-bg) 96%, transparent) 100%
+    )
+    border-box;
+  border: 1px solid color-mix(in srgb, var(--border-color) 36%, transparent);
+  box-shadow: 0 26px 72px -50px var(--shadow-color);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 16px);
+  align-items: flex-start;
+}
+
+.cta-title {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.4vw + 1rem, 2.6rem);
+  letter-spacing: -0.01em;
+}
+
+.cta-subtitle {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-text) 72%, transparent);
+}
+
+.cta-panel .hero-cta {
+  margin-top: var(--space-2, 8px);
+}
+
+@media (width <= 960px) {
+  .gomemo-page {
+    padding: calc(var(--space-4, 24px) + var(--space-1, 4px));
+    gap: var(--space-4, 24px);
+  }
+
+  .hero,
+  .priority,
+  .modes,
+  .insights,
+  .cta-panel {
+    padding: calc(var(--space-4, 24px) + var(--space-1, 4px));
+  }
+}
+
+@media (width <= 600px) {
+  .gomemo-page {
+    padding: var(--space-3, 16px);
+  }
+
+  .hero,
+  .priority,
+  .modes,
+  .insights,
+  .cta-panel {
+    padding: calc(var(--space-3, 16px) + var(--space-1, 4px));
+  }
+
+  .hero-badges {
+    gap: var(--space-1, 4px);
+  }
+
+  .hero-badge {
+    font-size: 11px;
+    padding: 6px 12px;
+  }
+}

--- a/website/src/pages/Gomemo/index.jsx
+++ b/website/src/pages/Gomemo/index.jsx
@@ -1,0 +1,1 @@
+export { default } from "./Gomemo.jsx";


### PR DESCRIPTION
## Summary
- add a reusable sidebar collection button and expose the new Gomemo entry above favorites
- translate and wire Gomemo copy for both English and Chinese locales, including favorites icon alt text
- implement the dedicated Gomemo page with luxury-inspired styling and sections for prioritisation, practice modes, and Doubao-powered insights

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68d4248741788332ad8efcbd717d6a8f