### PR TITLE
Handle change email verification purpose

### DIFF
--- a/backend/src/main/java/com/glancy/backend/service/email/VerificationEmailComposer.java
+++ b/backend/src/main/java/com/glancy/backend/service/email/VerificationEmailComposer.java
@@ -183,6 +183,7 @@ public class VerificationEmailComposer {
         return switch (purpose) {
             case REGISTER -> "注册";
             case LOGIN -> "登录";
+            case CHANGE_EMAIL -> "邮箱变更";
         };
     }
 


### PR DESCRIPTION
## Summary
- add the missing CHANGE_EMAIL purpose label in VerificationEmailComposer to cover all enum values

## Testing
- mvn spotless:apply *(fails: Network is unreachable while downloading org.springframework.boot:spring-boot-dependencies:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68d42be477e0833294f16110708255bc