### PR TITLE
feat(website): add collapsible markdown sections

### DIFF
--- a/website/src/components/__tests__/MarkdownStream.test.jsx
+++ b/website/src/components/__tests__/MarkdownStream.test.jsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-jest.mock("remark-gfm", () => () => {});
 import MarkdownStream from "@/components/ui/MarkdownStream";
 
 /**

--- a/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
+++ b/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
@@ -1,17 +1,144 @@
+import { Children, cloneElement, useId, useMemo, useState } from "react";
+import PropTypes from "prop-types";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeCollapsibleSections from "./rehypeCollapsibleSections.js";
+import styles from "./MarkdownRenderer.module.css";
 
 /**
- * 通用 Markdown 渲染组件，支持 GFM 语法。
- * 可作为统一的 Markdown 渲染入口，便于未来扩展。
+ * 通用 Markdown 渲染组件，支持 GFM 语法并为标题分区提供折叠交互。
+ * 组件在渲染阶段通过 rehype 插件把指定层级以上的标题收拢为可展开的分节，
+ * 以便在长释义场景下维持简洁的视觉秩序，同时保留锚点定位能力。
  */
 function MarkdownRenderer({ children, ...props }) {
+  const components = useMemo(
+    () => ({
+      "collapsible-section": CollapsibleSection,
+      "collapsible-summary": CollapsibleSummary,
+      "collapsible-body": CollapsibleBody,
+    }),
+    [],
+  );
+
   if (!children) return null;
+
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} {...props}>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeCollapsibleSections]}
+      components={components}
+      {...props}
+    >
       {children}
     </ReactMarkdown>
   );
 }
+
+function CollapsibleSection({ children, depth = 2 }) {
+  const sectionId = useId();
+  const [isOpen, setIsOpen] = useState(depth <= 2);
+  const labelledBy = `${sectionId}-summary`;
+  const contentId = `${sectionId}-content`;
+
+  const items = Children.toArray(children);
+  return (
+    <section className={styles.section} data-depth={depth}>
+      {items.map((child) => {
+        if (child.type === CollapsibleSummary) {
+          return cloneElement(child, {
+            key: "summary",
+            depth,
+            isOpen,
+            onToggle: () => setIsOpen((value) => !value),
+            labelId: labelledBy,
+            contentId,
+          });
+        }
+        if (child.type === CollapsibleBody) {
+          return cloneElement(child, {
+            key: "body",
+            isOpen,
+            contentId,
+            labelId: labelledBy,
+          });
+        }
+        return child;
+      })}
+    </section>
+  );
+}
+
+function CollapsibleSummary({
+  children,
+  depth,
+  isOpen,
+  onToggle,
+  labelId,
+  contentId,
+}) {
+  return (
+    <button
+      type="button"
+      id={labelId}
+      className={styles.summary}
+      aria-expanded={isOpen}
+      aria-controls={contentId}
+      onClick={onToggle}
+    >
+      <span
+        className={styles["summary-title"]}
+        role="heading"
+        aria-level={depth}
+      >
+        {children}
+      </span>
+      <span className={styles.chevron} aria-hidden="true">
+        <span
+          className={styles["chevron-icon"]}
+          data-open={isOpen ? "true" : "false"}
+        />
+      </span>
+    </button>
+  );
+}
+
+function CollapsibleBody({ children, isOpen, contentId, labelId }) {
+  return (
+    <div
+      id={contentId}
+      role="region"
+      aria-labelledby={labelId}
+      className={styles.body}
+      data-open={isOpen ? "true" : "false"}
+    >
+      <div className={styles["body-inner"]}>{children}</div>
+    </div>
+  );
+}
+
+MarkdownRenderer.propTypes = {
+  children: PropTypes.node,
+};
+
+CollapsibleSection.propTypes = {
+  children: PropTypes.node.isRequired,
+  depth: PropTypes.number,
+};
+
+CollapsibleSummary.propTypes = {
+  children: PropTypes.node.isRequired,
+  contentId: PropTypes.string.isRequired,
+  depth: PropTypes.number.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  labelId: PropTypes.string.isRequired,
+  onToggle: PropTypes.func.isRequired,
+};
+
+CollapsibleBody.propTypes = {
+  children: PropTypes.node,
+  contentId: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  labelId: PropTypes.string.isRequired,
+};
 
 export default MarkdownRenderer;

--- a/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
+++ b/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
@@ -1,0 +1,106 @@
+.section {
+  margin-block: 16px;
+  border-radius: var(--radius-lg, 14px);
+  border: 1px solid
+    color-mix(in srgb, var(--color-surface-alt) 46%, transparent);
+  background: color-mix(in srgb, var(--color-surface-muted) 74%, transparent);
+  box-shadow: 0 12px 32px
+    color-mix(in srgb, var(--surface-dark) 10%, transparent);
+  overflow: hidden;
+}
+
+.section[data-depth="3"] {
+  background: color-mix(in srgb, var(--color-surface-muted) 66%, transparent);
+}
+
+.section[data-depth="4"] {
+  background: color-mix(in srgb, var(--color-surface-muted) 58%, transparent);
+}
+
+.summary {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 24px;
+  border: none;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-surface-alt) 65%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-muted) 85%, transparent) 100%
+  );
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
+}
+
+.summary:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--surface-dark) 24%, transparent);
+  outline-offset: 4px;
+}
+
+.summary-title {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.chevron {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--surface-light) 85%, transparent);
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--color-surface-alt) 50%, transparent);
+}
+
+.chevron-icon {
+  width: 12px;
+  height: 12px;
+  border-right: 2px solid
+    color-mix(in srgb, var(--surface-dark) 48%, transparent);
+  border-bottom: 2px solid
+    color-mix(in srgb, var(--surface-dark) 48%, transparent);
+  transform: rotate(-45deg);
+  transition: transform 0.32s ease;
+}
+
+.chevron-icon[data-open="true"] {
+  transform: rotate(135deg);
+}
+
+.body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition:
+    grid-template-rows 0.32s ease,
+    padding 0.32s ease;
+  padding: 0 28px;
+  background: color-mix(in srgb, var(--color-surface-alt) 78%, transparent);
+}
+
+.body[data-open="true"] {
+  grid-template-rows: 1fr;
+  padding: 24px 28px 28px;
+  background: color-mix(in srgb, var(--color-surface-muted) 82%, transparent);
+}
+
+.body-inner {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.body-inner > :global(*) {
+  margin: 0;
+}

--- a/website/src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx
+++ b/website/src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react";
-jest.mock("remark-gfm", () => () => {});
+import { fireEvent, render, screen } from "@testing-library/react";
 import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
 
 /**
@@ -14,4 +13,32 @@ test("renders GFM syntax", () => {
 test("returns null for empty content", () => {
   const { container } = render(<MarkdownRenderer>{""}</MarkdownRenderer>);
   expect(container).toBeEmptyDOMElement();
+});
+
+/**
+ * 验证二级标题会收拢正文并默认展开，且交互按钮可切换状态。
+ */
+test("wraps second level headings into expandable sections", () => {
+  const markdown = "## Overview\n\nParagraph";
+  render(<MarkdownRenderer>{markdown}</MarkdownRenderer>);
+
+  const toggle = screen.getByRole("button", { name: "Overview" });
+  expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+  fireEvent.click(toggle);
+  expect(toggle).toHaveAttribute("aria-expanded", "false");
+});
+
+/**
+ * 验证三级标题默认折叠，并保持层级嵌套的正确性。
+ */
+test("nests collapsible sections for deeper headings", () => {
+  const markdown = "## Parent\n\n### Child\n\nDetail";
+  render(<MarkdownRenderer>{markdown}</MarkdownRenderer>);
+
+  const parentToggle = screen.getByRole("button", { name: "Parent" });
+  const childToggle = screen.getByRole("button", { name: "Child" });
+
+  expect(parentToggle).toHaveAttribute("aria-expanded", "true");
+  expect(childToggle).toHaveAttribute("aria-expanded", "false");
 });

--- a/website/src/components/ui/MarkdownRenderer/rehypeCollapsibleSections.js
+++ b/website/src/components/ui/MarkdownRenderer/rehypeCollapsibleSections.js
@@ -1,0 +1,87 @@
+const MINIMUM_DEPTH = 2;
+
+function createSectionNode(headingNode, depth) {
+  const sectionId = headingNode.properties?.id;
+  const summaryProperties = { depth };
+  if (headingNode.properties?.className) {
+    summaryProperties.className = headingNode.properties.className;
+  }
+
+  return {
+    type: "element",
+    tagName: "collapsible-section",
+    properties: {
+      depth,
+      ...(sectionId ? { id: sectionId } : {}),
+    },
+    children: [
+      {
+        type: "element",
+        tagName: "collapsible-summary",
+        properties: summaryProperties,
+        children: headingNode.children,
+      },
+      {
+        type: "element",
+        tagName: "collapsible-body",
+        properties: { depth },
+        children: [],
+      },
+    ],
+  };
+}
+
+function rehypeCollapsibleSections(options = {}) {
+  const minDepth = options.minDepth ?? MINIMUM_DEPTH;
+
+  return function transform(tree) {
+    if (!tree || !Array.isArray(tree.children)) return;
+
+    const result = [];
+    const stack = [
+      {
+        depth: 0,
+        body: result,
+      },
+    ];
+
+    const closeToDepth = (targetDepth) => {
+      while (stack.length > 1 && stack[stack.length - 1].depth >= targetDepth) {
+        stack.pop();
+      }
+    };
+
+    const appendToCurrent = (node) => {
+      stack[stack.length - 1].body.push(node);
+    };
+
+    for (const node of tree.children) {
+      if (node.type !== "element") {
+        appendToCurrent(node);
+        continue;
+      }
+
+      const match = /^h([1-6])$/.exec(node.tagName ?? "");
+      if (!match) {
+        appendToCurrent(node);
+        continue;
+      }
+
+      const depth = Number(match[1]);
+      closeToDepth(depth);
+
+      if (depth < minDepth) {
+        appendToCurrent(node);
+        continue;
+      }
+
+      const sectionNode = createSectionNode(node, depth);
+      appendToCurrent(sectionNode);
+      stack.push({ depth, body: sectionNode.children[1].children });
+    }
+
+    tree.children = result;
+  };
+}
+
+export default rehypeCollapsibleSections;


### PR DESCRIPTION
## Summary
- add a rehype pipeline to wrap markdown headings into collapsible sections
- build a styled accordion experience for markdown blocks with luxurious theming
- extend markdown renderer tests to cover collapsible behaviour and clean up redundant mocks

## Testing
- npm run lint
- npm run lint:css
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .
- npm run test -- MarkdownRenderer

------
https://chatgpt.com/codex/tasks/task_e_68d43592cc408332a133b62425a6b83d