### PR TITLE
fix: hydrate gomemo user identity

### DIFF
--- a/website/src/pages/Gomemo/Gomemo.jsx
+++ b/website/src/pages/Gomemo/Gomemo.jsx
@@ -52,7 +52,8 @@ function buildChoiceOptions(correct, distractors) {
 function Gomemo() {
   const { t } = useLanguage();
   const api = useApi();
-  const { currentUser } = useUserStore();
+  const selectCurrentUser = useCallback((state) => state.user, []);
+  const currentUser = useUserStore(selectCurrentUser);
   const {
     plan,
     review,


### PR DESCRIPTION
## Summary
- ensure the Gomemo page selects the authenticated user via a stable store selector to recover the token

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68d440f33674833298430c1685213963