### PR TITLE
feat: enable bilingual dictionary guidance

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
@@ -189,12 +189,19 @@ public class WordSearcherImpl implements WordSearcher {
     ) {
         StringBuilder builder = new StringBuilder("查询词汇：").append(cleanInput);
         if (language == Language.CHINESE) {
+            ChineseEntryProfile profile = resolveChineseEntryProfile(cleanInput);
             builder
-                .append("\n条目类型：")
-                .append(classifyChineseEntry(cleanInput))
+                .append("\n条目结构定位：")
+                .append(profile.typeLabel())
+                .append("\n写作指引：")
+                .append(profile.guidance())
                 .append(
-                    "\n若为汉字，请以说文解字笔法拆解字形、字源、篆隶演变与常见组合；若为词语，则聚焦现代语境下的义项、搭配与例句。"
+                    "\n结构要求：请以英文释义为主，配套中文例句与 English Rendering，对齐模板并以 <END> 收尾。"
                 );
+        } else {
+            builder
+                .append("\n条目类型：英文词汇")
+                .append("\n结构要求：保持模板的分层释义、例句与语法说明，并以 <END> 结尾。");
         }
         if (personalizationContext != null && personalizationContext.hasSignals()) {
             if (!personalizationContext.recentTerms().isEmpty()) {
@@ -203,28 +210,51 @@ public class WordSearcherImpl implements WordSearcher {
             if (StringUtils.hasText(personalizationContext.goal())) {
                 builder.append("\n学习目标：").append(personalizationContext.goal());
             }
-            builder.append("\n请结合画像输出结构化释义、语义差异与可执行练习建议。");
+            builder.append("\n请结合画像输出结构化释义、语义差异与可执行练习建议（英文表达）。");
         } else {
-            builder.append("\n请输出结构化释义、用法说明与示例。");
+            builder.append("\n请确保释义、用法说明与示例完整。");
         }
         return builder.toString();
     }
 
-    private String classifyChineseEntry(String cleanInput) {
+    private ChineseEntryProfile resolveChineseEntryProfile(String cleanInput) {
         if (!StringUtils.hasText(cleanInput)) {
-            return "词语（默认结构）";
+            return new ChineseEntryProfile(
+                "Multi-character Word",
+                "未识别输入，按常规汉语词语处理，突出现代义项与搭配。"
+            );
         }
         String condensed = cleanInput.replaceAll("\\s+", "");
         int codePoints = condensed.codePointCount(0, condensed.length());
+        boolean containsHan = condensed
+            .codePoints()
+            .anyMatch(cp -> Character.UnicodeScript.of(cp) == Character.UnicodeScript.HAN);
+        if (!containsHan) {
+            return new ChineseEntryProfile(
+                "Multi-character Word",
+                "包含非汉字字符，请解释其在中文语境中的意义来源，并提供英文释义。"
+            );
+        }
         boolean allHan = condensed
             .codePoints()
             .allMatch(cp -> Character.UnicodeScript.of(cp) == Character.UnicodeScript.HAN);
         if (!allHan) {
-            return "混合或外来词（保持常规词典结构）";
+            return new ChineseEntryProfile(
+                "Multi-character Word",
+                "含汉字与其他符号混写，需补充借词背景，同时仍按词语结构组织英文释义。"
+            );
         }
         if (codePoints == 1) {
-            return "汉字（拆解字源与古今演变）";
+            return new ChineseEntryProfile(
+                "Single Character",
+                "请拆解字源、构形与历史演变，再补充当代主流义项与用例。"
+            );
         }
-        return "词语（聚焦现代义项与语境）";
+        return new ChineseEntryProfile(
+            "Multi-character Word",
+            "标准汉语词语，请分层呈现核心义项、语域差异与常见搭配，并提供文化背景。"
+        );
     }
+
+    private record ChineseEntryProfile(String typeLabel, String guidance) {}
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -57,7 +57,7 @@ llm:
   prompt-path: prompts/english_to_chinese.txt
   prompt-paths:
     ENGLISH: prompts/english_to_chinese.txt
-    CHINESE: prompts/chinese_to_chinese.txt
+    CHINESE: prompts/chinese_to_english_markdown.txt
 
 gomemo:
   default-daily-target: 12

--- a/backend/src/main/resources/prompts/chinese_to_english_markdown.txt
+++ b/backend/src/main/resources/prompts/chinese_to_english_markdown.txt
@@ -1,0 +1,84 @@
+你是一部面向全球学习者的「中译英奢雅词典」。请参照 Glancy 英中词典的结构与细腻程度，为中文词条生成纯 Markdown（禁止表格与代码块）。若无法确认信息，请整段省略，不得输出占位内容。最后一行必须是哨兵 <END>。
+
+## 参数（可由调用端覆盖）
+- min_examples_per_sense: {min_examples_per_sense=2}    # 每个义项最少例句数（建议 2-3 条）
+- max_examples_per_sense: {max_examples_per_sense=3}    # 每个义项最多例句数
+- max_senses: {max_senses=8}                            # 最多保留的义项数
+- max_collocations: {max_collocations=6}
+- max_idioms: {max_idioms=6}
+- max_derivatives: {max_derivatives=6}
+
+## 全局规则
+1) 至少输出：`# Entry: {term}`、`## Pronunciation`、`## English Definitions` 中的 s1，且 s1 需包含不少于 min_examples_per_sense 条例句。
+2) 所有英文释义、例句译文必须采用地道英语；中文例句应保持简洁自然。
+3) 所有例句结构：
+   - **Example 1（中文）**: {中文例句}
+     **English Rendering**: {英文翻译}
+   例句需原创、不重复，且覆盖不同语境。
+4) 若条目为单字，请兼顾「字源」「构形」「古今义流变」；若为词语，强调现代语境，可在“Historical Resonance”补充古义。
+5) 义项编号格式：`### s# Definition ({pos_abbr}. {pos_full})：{英文释义}`，如 `### s1 Definition (n. noun)：serene grace and natural beauty`。
+6) 章节内如出现搭配、习语等，可在条目尾部用 `[ref: s#]` 指明对应义项。
+7) 词汇学标签（register/region）需从受控集合中选取：
+   - Register（语域）：{Formal, Neutral, Informal, Colloquial, Literary, Dialectal, Academic}
+   - Region（地域）：{Mainland, Taiwan, HongKong, Overseas, General}
+8) 若信息不可靠，整段移除，不得输出“未知”或类似措辞。
+9) 语气保持优雅、克制，避免口语化感叹。
+
+## 输出结构（按顺序，缺则跳过）
+# Entry: {term}
+
+## Entry Classification
+- Type: {"Single Character" | "Multi-character Word"}
+- Recommended Audience: {HSK level、Usage tier 等，如无则省略}
+
+## Pronunciation
+- Pinyin: {带声调的拼音，词语需空格分节}
+- Alternate Readings: {若有多音或方言读音，列出；无则省略}
+
+## Stroke & Origin Notes（仅单字保留）
+- Glyph Evolution: {甲骨/金文/小篆/隶书等简述}
+- Structure Insight: {指明部件、构字法、本义}
+
+## English Definitions
+### s1 Definition ({pos_abbr}. {pos_full})：{英文释义}
+- **Example 1（中文）**: {中文例句}
+  **English Rendering**: {英文翻译}
+- **Example 2（中文）**: {中文例句}
+  **English Rendering**: {英文翻译}
+- **Example 3（中文，可选）**: {中文例句}
+  **English Rendering**: {英文翻译}
+
+### s2 Definition ({pos_abbr}. {pos_full})：{英文释义}
+- **Example 1（中文）**: {中文例句}
+  **English Rendering**: {英文翻译}
+- …（不超过 max_examples_per_sense 条）
+
+## Collocations & Set Expressions
+- {搭配或固定搭配}: {英文释义} [ref: s#]
+  - **Example（中文）**: {中文例句}
+    **English Rendering**: {英文翻译}
+- …（不超过 max_collocations 条）
+
+## Idioms & Cultural Echoes
+- {习语或文化典故}: {英文解释} [ref: s#]
+  - **Example（中文）**: {中文例句}
+    **English Rendering**: {英文翻译}
+- …（不超过 max_idioms 条）
+
+## Register & Usage Notes
+- Register: {受控词表中的语域}
+- Region: {受控词表中的地域}
+- Usage Insight: {常见搭配、语感提醒、易错点，必要时含极简示例}
+
+## Historical Resonance（可选）
+- {历代文献或历史语义演变的英文概述}
+
+## Derivatives & Extended Forms
+- {派生词或相关构词}: {英文解释} [ref: s#]
+- …（不超过 max_derivatives 条）
+
+## Practice Prompts
+- {针对该词条的操练建议，如英文造句、情景扮演、书写练习等}
+- {可选的第二条练习建议}
+
+<END>

--- a/website/src/components/TopBar/OutputToolbar.jsx
+++ b/website/src/components/TopBar/OutputToolbar.jsx
@@ -57,6 +57,9 @@ function OutputToolbar({
           {languageOptions.map(({ value, label, description }) => {
             const optionValue = normalizeWordLanguage(value);
             const isActive = optionValue === normalizedLanguageMode;
+            const descriptionId = description
+              ? `dictionary-language-${optionValue.toLowerCase()}`
+              : undefined;
             return (
               <button
                 key={optionValue}
@@ -65,10 +68,19 @@ function OutputToolbar({
                   isActive ? styles.active : styles.inactive
                 }`}
                 aria-pressed={isActive}
+                aria-describedby={descriptionId}
                 onClick={() => onLanguageModeChange?.(optionValue)}
                 title={description || undefined}
               >
-                <span>{label}</span>
+                <span className={styles["option-title"]}>{label}</span>
+                {description ? (
+                  <span
+                    className={styles["option-description"]}
+                    id={descriptionId}
+                  >
+                    {description}
+                  </span>
+                ) : null}
               </button>
             );
           })}

--- a/website/src/components/TopBar/OutputToolbar.module.css
+++ b/website/src/components/TopBar/OutputToolbar.module.css
@@ -26,12 +26,13 @@
 .language-option {
   border: none;
   background: transparent;
-  padding: 4px 12px;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--color-text-secondary);
+  padding: 8px 12px;
+  border-radius: 20px;
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
   cursor: pointer;
   transition:
     color 0.2s ease,
@@ -40,9 +41,19 @@
     transform 0.2s ease;
 }
 
-.language-option span {
-  display: block;
-  white-space: nowrap;
+.option-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: inherit;
+  text-transform: uppercase;
+}
+
+.option-description {
+  font-size: 0.66rem;
+  line-height: 1.2;
+  color: color-mix(in srgb, var(--color-text-secondary) 85%, transparent);
+  text-align: left;
 }
 
 .inactive {
@@ -60,6 +71,10 @@
   color: var(--primary-color);
   box-shadow: 0 6px 16px
     color-mix(in srgb, var(--shadow-color) 20%, transparent);
+}
+
+.active .option-description {
+  color: color-mix(in srgb, var(--primary-color) 80%, white 10%);
 }
 
 .replay {
@@ -144,8 +159,17 @@
   }
 
   .language-option {
-    padding: 4px 10px;
+    min-width: 120px;
+    padding: 6px 10px;
+    gap: 2px;
+  }
+
+  .option-title {
     font-size: 0.68rem;
+  }
+
+  .option-description {
+    font-size: 0.62rem;
   }
 
   .replay span {

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -21,13 +21,13 @@ export default {
   dictionaryLanguageLabel: "Lookup language",
   dictionaryLanguageAuto: "Auto",
   dictionaryLanguageAutoDescription:
-    "Detect the term's language automatically.",
+    "Let Glancy detect whether the entry is English or Chinese.",
   dictionaryLanguageEnglish: "English term",
   dictionaryLanguageEnglishDescription:
-    "Always interpret the query as an English word or phrase.",
+    "Interpret as an English word or phrase with Chinese-first guidance.",
   dictionaryLanguageChinese: "Chinese term",
   dictionaryLanguageChineseDescription:
-    "Treat the query as a Chinese character or word for native explanations.",
+    "Interpret as a Chinese character or word with English-first storytelling.",
   prefTheme: "Theme",
   searchTitle: "Word Search",
   searchButton: "Search",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -19,12 +19,13 @@ export default {
   autoDetect: "自动检测",
   dictionaryLanguageLabel: "检索语言",
   dictionaryLanguageAuto: "自动",
-  dictionaryLanguageAutoDescription: "根据输入内容自动识别语言。",
+  dictionaryLanguageAutoDescription: "根据输入自动判断是英文还是中文。",
   dictionaryLanguageEnglish: "英文词条",
-  dictionaryLanguageEnglishDescription: "固定以英文单词或短语的视角解析。",
+  dictionaryLanguageEnglishDescription:
+    "固定以英文单词或短语的视角解析，输出中文主导的详解。",
   dictionaryLanguageChinese: "中文词条",
   dictionaryLanguageChineseDescription:
-    "固定视为中文汉字或词语，提供本义与衍生解释。",
+    "固定视为中文汉字或词语，生成以英文释义为核心的深度解读。",
   prefTheme: "主题",
   searchTitle: "词汇查询",
   searchButton: "搜索",

--- a/website/src/utils/__tests__/language.test.js
+++ b/website/src/utils/__tests__/language.test.js
@@ -1,0 +1,33 @@
+import {
+  detectWordLanguage,
+  resolveWordLanguage,
+  normalizeWordLanguage,
+  WORD_LANGUAGE_AUTO,
+} from "@/utils/language.js";
+
+describe("language utilities", () => {
+  test("detectWordLanguage 区分纯英文与中文输入", () => {
+    expect(detectWordLanguage("elegance")).toBe("ENGLISH");
+    expect(detectWordLanguage("优雅")).toBe("CHINESE");
+  });
+
+  test("detectWordLanguage 识别混合文本中的中文字符", () => {
+    expect(detectWordLanguage("A＋级定制体验")).toBe("CHINESE");
+  });
+
+  test("detectWordLanguage 捕获扩展汉字符号", () => {
+    expect(detectWordLanguage("〇")).toBe("CHINESE");
+  });
+
+  test("normalizeWordLanguage 统一化各种输入", () => {
+    expect(normalizeWordLanguage("english")).toBe("ENGLISH");
+    expect(normalizeWordLanguage("CHINESE")).toBe("CHINESE");
+    expect(normalizeWordLanguage("unknown")).toBe(WORD_LANGUAGE_AUTO);
+  });
+
+  test("resolveWordLanguage 在自动模式下使用检测结果", () => {
+    expect(resolveWordLanguage("晨曦", WORD_LANGUAGE_AUTO)).toBe("CHINESE");
+    expect(resolveWordLanguage("dawn", WORD_LANGUAGE_AUTO)).toBe("ENGLISH");
+    expect(resolveWordLanguage("纹章", "CHINESE")).toBe("CHINESE");
+  });
+});

--- a/website/src/utils/language.js
+++ b/website/src/utils/language.js
@@ -5,7 +5,8 @@ const SUPPORTED_WORD_LANGUAGES = Object.freeze([
   "ENGLISH",
 ]);
 
-const CHINESE_CHAR_PATTERN = /[\u4e00-\u9fff]/u;
+const HAN_SCRIPT_PATTERN = /\p{Script=Han}/u;
+const EXTENDED_CHINESE_MARKS_PATTERN = /[\u3007\u3021-\u3029]/u;
 
 /**
  * Detect the language of a text based on presence of Chinese characters.
@@ -13,7 +14,16 @@ const CHINESE_CHAR_PATTERN = /[\u4e00-\u9fff]/u;
  * @returns {'CHINESE' | 'ENGLISH'}
  */
 export function detectWordLanguage(text = "") {
-  return CHINESE_CHAR_PATTERN.test(text) ? "CHINESE" : "ENGLISH";
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return "ENGLISH";
+  }
+  if (
+    HAN_SCRIPT_PATTERN.test(text) ||
+    EXTENDED_CHINESE_MARKS_PATTERN.test(text)
+  ) {
+    return "CHINESE";
+  }
+  return "ENGLISH";
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a dedicated Chinese-to-English prompt and bind it in the LLM configuration
- refine WordSearcher guidance so Chinese lookups produce English-first narratives while preserving personalization context
- refresh the lookup language selector and language utilities with richer heuristics, translations, and unit tests

## Testing
- npm test -- --runTestsByPath src/utils/__tests__/language.test.js
- npx eslint --fix "src/**/*.{js,jsx,ts,tsx}"
- npx stylelint --fix "src/**/*.{css,scss}"
- npx prettier -w "src/**/*.{js,jsx,ts,tsx,css}"
- mvn spotless:apply *(fails: repository download blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_68d44469d5f08332926348793d5aef42