### PR TITLE
feat(dictionary): normalize model selection and update tests

### DIFF
--- a/backend/src/main/java/com/glancy/backend/entity/DictionaryModel.java
+++ b/backend/src/main/java/com/glancy/backend/entity/DictionaryModel.java
@@ -4,5 +4,14 @@ package com.glancy.backend.entity;
  * Supported dictionary models for word lookup.
  */
 public enum DictionaryModel {
-    DOUBAO,
+    DOUBAO;
+
+    /**
+     * Resolve the LLM client identifier associated with this model.
+     */
+    public String getClientName() {
+        return switch (this) {
+            case DOUBAO -> "doubao";
+        };
+    }
 }

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
@@ -72,6 +72,7 @@ class WordServiceStreamPersistenceTest {
         when(wordPersonalizationService.personalize(any(WordPersonalizationContext.class), any())).thenReturn(
             new PersonalizedWordExplanation("persona", "key", "context", List.of(), List.of())
         );
+        when(userPreferenceRepository.findByUserId(anyLong())).thenReturn(Optional.empty());
         wordService = new WordService(
             wordSearcher,
             wordRepository,
@@ -116,7 +117,7 @@ class WordServiceStreamPersistenceTest {
     void savesAfterStreaming() {
         when(searchRecordService.saveRecord(eq(1L), any())).thenReturn(sampleRecordResponse("hi"));
         when(wordRepository.findByTermAndLanguageAndDeletedFalse("hi", Language.ENGLISH)).thenReturn(Optional.empty());
-        when(wordSearcher.streamSearch(eq("hi"), eq(Language.ENGLISH), any(), any())).thenReturn(
+        when(wordSearcher.streamSearch(eq("hi"), eq(Language.ENGLISH), eq("doubao"), any())).thenReturn(
             Flux.just("{\"term\":\"hi\"}", "<END>")
         );
         WordResponse resp = new WordResponse(
@@ -181,7 +182,7 @@ class WordServiceStreamPersistenceTest {
     void skipPersistenceWhenSentinelMissing() {
         when(searchRecordService.saveRecord(eq(1L), any())).thenReturn(sampleRecordResponse("hi"));
         when(wordRepository.findByTermAndLanguageAndDeletedFalse("hi", Language.ENGLISH)).thenReturn(Optional.empty());
-        when(wordSearcher.streamSearch(eq("hi"), eq(Language.ENGLISH), any(), any())).thenReturn(
+        when(wordSearcher.streamSearch(eq("hi"), eq(Language.ENGLISH), eq("doubao"), any())).thenReturn(
             Flux.just("{\"term\":\"hi\"}")
         );
 

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
@@ -17,6 +17,7 @@ import com.glancy.backend.repository.WordRepository;
 import com.glancy.backend.service.personalization.WordPersonalizationService;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -70,6 +71,7 @@ class WordServiceStreamingErrorTest {
         when(wordPersonalizationService.personalize(any(WordPersonalizationContext.class), any())).thenReturn(
             new PersonalizedWordExplanation("persona", "key", "context", List.of(), List.of())
         );
+        when(userPreferenceRepository.findByUserId(anyLong())).thenReturn(Optional.empty());
         wordService = new WordService(
             wordSearcher,
             wordRepository,

--- a/website/jest.config.js
+++ b/website/jest.config.js
@@ -7,7 +7,8 @@ export default {
     "^.+\\.css$": "identity-obj-proxy",
     "^.+\\.(svg)$": "<rootDir>/test/__mocks__/fileMock.cjs",
   },
-  extensionsToTreatAsEsm: [".jsx", ".tsx"],
+  extensionsToTreatAsEsm: [".ts", ".tsx", ".jsx"],
+  moduleFileExtensions: ["js", "jsx", "ts", "tsx", "json", "node"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "babel-jest",

--- a/website/src/hooks/__tests__/useEmailBinding.test.js
+++ b/website/src/hooks/__tests__/useEmailBinding.test.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { act, renderHook } from "@testing-library/react";
 import useEmailBinding from "@/hooks/useEmailBinding.js";
 

--- a/website/src/store/historyStore.ts
+++ b/website/src/store/historyStore.ts
@@ -4,7 +4,7 @@ import { createPersistentStore } from "./createPersistentStore.js";
 import { pickState } from "./persistUtils.js";
 import { useUserStore } from "./userStore.js";
 import type { User } from "./userStore.js";
-import { resolveWordLanguage, WORD_LANGUAGE_AUTO } from "@/utils";
+import { resolveWordLanguage, WORD_LANGUAGE_AUTO } from "@/utils/language.js";
 import { useWordStore } from "./wordStore.js";
 
 const HISTORY_LIMIT = 20;

--- a/website/test/__mocks__/apiIndexMock.cjs
+++ b/website/test/__mocks__/apiIndexMock.cjs
@@ -2,5 +2,10 @@ const api = {
   gomemo: {},
 };
 
+function createApi() {
+  return api;
+}
+
 module.exports = api;
 module.exports.default = api;
+module.exports.createApi = createApi;


### PR DESCRIPTION
## Summary
- normalize dictionary model resolution to respect user preferences and lowercase client identifiers
- add client name mapping for DictionaryModel and update streaming tests to expect the normalized client
- expand frontend test utilities and configuration so TypeScript modules and mocks load correctly during dictionary flows

## Testing
- npx prettier -w .
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npm test *(fails: JavaScript heap out of memory)*
- ./mvnw spotless:apply *(fails: network is unreachable when downloading wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a78e1eac8332a3fbc3df1126de45