### PR TITLE
feat: support dictionary flavor on web

### DIFF
--- a/website/src/api/__tests__/searchRecords.test.js
+++ b/website/src/api/__tests__/searchRecords.test.js
@@ -1,5 +1,6 @@
 import { createSearchRecordsApi } from "@/api/searchRecords.js";
 import { API_PATHS } from "@/config/api.js";
+import { WORD_FLAVOR_BILINGUAL } from "@/utils/language.js";
 import { jest } from "@jest/globals";
 
 test("fetchSearchRecords calls with token", async () => {
@@ -8,6 +9,18 @@ test("fetchSearchRecords calls with token", async () => {
   await api.fetchSearchRecords({ token: "t" });
   expect(request).toHaveBeenCalledWith(`${API_PATHS.searchRecords}/user`, {
     token: "t",
+  });
+});
+
+test("saveSearchRecord posts flavor payload", async () => {
+  const request = jest.fn().mockResolvedValue({});
+  const api = createSearchRecordsApi(request);
+  await api.saveSearchRecord({ token: "t", term: "foo", language: "ENGLISH" });
+  const [, options] = request.mock.calls[0];
+  expect(JSON.parse(options.body)).toEqual({
+    term: "foo",
+    language: "ENGLISH",
+    flavor: WORD_FLAVOR_BILINGUAL,
   });
 });
 

--- a/website/src/api/__tests__/words.cache.e2e.test.js
+++ b/website/src/api/__tests__/words.cache.e2e.test.js
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 
 const streamWordMock = jest.fn(async function* () {
-  yield "**hello**";
+  yield { type: "chunk", data: "**hello**" };
 });
 
 jest.unstable_mockModule("@/hooks/useApi.js", () => ({
@@ -11,6 +11,7 @@ jest.unstable_mockModule("@/hooks/useApi.js", () => ({
 const { createWordsApi } = await import("@/api/words.js");
 const { useStreamWord } = await import("@/hooks");
 const { useWordStore } = await import("@/store");
+const { WORD_FLAVOR_BILINGUAL } = await import("@/utils/language.js");
 
 const request = jest.fn();
 const api = createWordsApi(request);
@@ -30,6 +31,7 @@ test("streams then reads markdown from cache", async () => {
     user,
     term: "hello",
     language: "ENGLISH",
+    flavor: WORD_FLAVOR_BILINGUAL,
   })) {
     // consume stream
   }
@@ -38,6 +40,7 @@ test("streams then reads markdown from cache", async () => {
     userId: "u",
     term: "hello",
     language: "ENGLISH",
+    flavor: WORD_FLAVOR_BILINGUAL,
   });
 
   expect(result.markdown).toBe("**hello**");

--- a/website/src/api/__tests__/words.stream.test.js
+++ b/website/src/api/__tests__/words.stream.test.js
@@ -42,6 +42,7 @@ jest.unstable_mockModule("@/hooks", () => ({
 const { streamWord } = await import("../words.js");
 const { API_PATHS } = await import("../../config/api.js");
 const { DEFAULT_MODEL } = await import("../../config/model.js");
+const { WORD_FLAVOR_BILINGUAL } = await import("@/utils/language.js");
 
 /**
  * 验证流式接口能够解析 SSE 并输出日志。
@@ -67,13 +68,14 @@ test("streamWord yields chunks with logging", async () => {
     userId: "u",
     term: "hello",
     language: "ENGLISH",
+    flavor: WORD_FLAVOR_BILINGUAL,
     token: "t",
   })) {
     chunks.push(event);
   }
 
   expect(global.fetch).toHaveBeenCalledWith(
-    `${API_PATHS.words}/stream?userId=u&term=hello&language=ENGLISH&model=${DEFAULT_MODEL}`,
+    `${API_PATHS.words}/stream?userId=u&term=hello&language=ENGLISH&flavor=${WORD_FLAVOR_BILINGUAL}&model=${DEFAULT_MODEL}`,
     expect.objectContaining({
       headers: expect.objectContaining({
         "X-USER-TOKEN": "t",
@@ -126,6 +128,7 @@ test("streamWord stops on DONE marker", async () => {
     userId: "u",
     term: "hello",
     language: "ENGLISH",
+    flavor: WORD_FLAVOR_BILINGUAL,
   })) {
     chunks.push(chunk);
   }
@@ -160,6 +163,7 @@ test("streamWord throws on error event", async () => {
         userId: "u",
         term: "hello",
         language: "ENGLISH",
+        flavor: WORD_FLAVOR_BILINGUAL,
       })) {
         // consume stream
       }

--- a/website/src/api/__tests__/words.test.js
+++ b/website/src/api/__tests__/words.test.js
@@ -1,6 +1,8 @@
 import { createWordsApi } from "../words.js";
 import { API_PATHS } from "../../config/api.js";
 import { DEFAULT_MODEL } from "../../config/index.js";
+import { WORD_FLAVOR_BILINGUAL } from "@/utils/language.js";
+import { useWordStore } from "@/store/wordStore.js";
 import { jest } from "@jest/globals";
 
 /**
@@ -13,11 +15,12 @@ test("fetchWord builds query string", async () => {
     userId: "u",
     term: "hello",
     language: "ENGLISH",
+    flavor: WORD_FLAVOR_BILINGUAL,
     token: "t",
   });
   const [url, opts] = request.mock.calls[0];
   expect(url).toBe(
-    `${API_PATHS.words}?userId=u&term=hello&language=ENGLISH&model=${DEFAULT_MODEL}`,
+    `${API_PATHS.words}?userId=u&term=hello&language=ENGLISH&flavor=${WORD_FLAVOR_BILINGUAL}&model=${DEFAULT_MODEL}`,
   );
   expect(opts.token).toBe("t");
 });
@@ -28,7 +31,12 @@ test("fetchWord builds query string", async () => {
 test("fetchWord caches repeated queries", async () => {
   const request = jest.fn().mockResolvedValue({ word: "hello" });
   const api = createWordsApi(request);
-  const args = { userId: "u", term: "hello", language: "ENGLISH" };
+  const args = {
+    userId: "u",
+    term: "hello",
+    language: "ENGLISH",
+    flavor: WORD_FLAVOR_BILINGUAL,
+  };
   await api.fetchWord(args);
   await api.fetchWord(args);
   expect(request).toHaveBeenCalledTimes(1);
@@ -46,4 +54,7 @@ test("fetchWordAudio caches repeated queries", async () => {
   const second = await api.fetchWordAudio(args);
   expect(request).toHaveBeenCalledTimes(1);
   expect(second).toBe(first);
+});
+beforeEach(() => {
+  useWordStore.getState().clear();
 });

--- a/website/src/api/searchRecords.js
+++ b/website/src/api/searchRecords.js
@@ -1,17 +1,23 @@
 import { API_PATHS } from "@/config/api.js";
 import { apiRequest, createJsonRequest } from "./client.js";
 import { useApi } from "@/hooks/useApi.js";
+import { WORD_FLAVOR_BILINGUAL } from "@/utils/language.js";
 
 export function createSearchRecordsApi(request = apiRequest) {
   const jsonRequest = createJsonRequest(request);
   const fetchSearchRecords = ({ token }) =>
     request(`${API_PATHS.searchRecords}/user`, { token });
 
-  const saveSearchRecord = ({ token, term, language }) =>
+  const saveSearchRecord = ({
+    token,
+    term,
+    language,
+    flavor = WORD_FLAVOR_BILINGUAL,
+  }) =>
     jsonRequest(`${API_PATHS.searchRecords}/user`, {
       method: "POST",
       token,
-      body: { term, language },
+      body: { term, language, flavor },
     });
 
   const clearSearchRecords = ({ token }) =>

--- a/website/src/components/Sidebar/HistoryList.jsx
+++ b/website/src/components/Sidebar/HistoryList.jsx
@@ -52,7 +52,8 @@ function HistoryList({ onSelect }) {
 
   const handleSelect = (item) => {
     if (!onSelect) return;
-    onSelect(item.term);
+    const versionId = item?.latestVersionId ?? undefined;
+    onSelect(item, versionId);
   };
 
   return (

--- a/website/src/components/Sidebar/__tests__/HistoryList.test.jsx
+++ b/website/src/components/Sidebar/__tests__/HistoryList.test.jsx
@@ -7,7 +7,8 @@ const historyMock = [
   {
     term: "alpha",
     language: "ENGLISH",
-    termKey: "ENGLISH:alpha",
+    flavor: "BILINGUAL",
+    termKey: "ENGLISH:BILINGUAL:alpha",
     createdAt: "2024-05-01T10:00:00Z",
     favorite: false,
     versions: [
@@ -39,9 +40,9 @@ describe("HistoryList", () => {
   });
 
   /**
-   * 验证点击历史项时会返回词条名称。
+   * 验证点击历史项时会返回完整历史对象并附带版本信息。
    */
-  test("calls onSelect with term only", async () => {
+  test("calls onSelect with history payload", async () => {
     const handleSelect = jest.fn();
     render(<HistoryList onSelect={handleSelect} />);
 
@@ -50,6 +51,6 @@ describe("HistoryList", () => {
     });
 
     fireEvent.click(screen.getByText("alpha"));
-    expect(handleSelect).toHaveBeenCalledWith("alpha");
+    expect(handleSelect).toHaveBeenCalledWith(historyMock[0], "v1");
   });
 });

--- a/website/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
+++ b/website/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
@@ -52,9 +52,10 @@ function HistoryDisplay({ onEmptyAction, onSelect }) {
     );
   }
 
-  const handleSelect = (term) => {
+  const handleSelect = (historyItem) => {
     if (!onSelect) return;
-    onSelect(term);
+    const versionId = historyItem?.latestVersionId ?? undefined;
+    onSelect(historyItem, versionId);
   };
 
   return (
@@ -67,7 +68,7 @@ function HistoryDisplay({ onEmptyAction, onSelect }) {
               <button
                 type="button"
                 className={styles.term}
-                onClick={() => handleSelect(item.term)}
+                onClick={() => handleSelect(item)}
               >
                 <span className={styles["term-text"]}>{item.term}</span>
                 <span className={styles.trailing}>

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -25,6 +25,9 @@ export default {
   dictionaryLanguageEnglish: "English term",
   dictionaryLanguageEnglishDescription:
     "Interpret as an English word or phrase with Chinese-first guidance.",
+  dictionaryLanguageEnglishMonolingual: "English term · English definitions",
+  dictionaryLanguageEnglishMonolingualDescription:
+    "Receive nuanced English-to-English explanations without Chinese scaffolding.",
   dictionaryLanguageChinese: "Chinese term",
   dictionaryLanguageChineseDescription:
     "Interpret as a Chinese character or word with English-first storytelling.",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -23,6 +23,9 @@ export default {
   dictionaryLanguageEnglish: "英文词条",
   dictionaryLanguageEnglishDescription:
     "固定以英文单词或短语的视角解析，输出中文主导的详解。",
+  dictionaryLanguageEnglishMonolingual: "英文词条 · 英文释义",
+  dictionaryLanguageEnglishMonolingualDescription:
+    "只提供英文释义与例句，适合深度英英思维训练。",
   dictionaryLanguageChinese: "中文词条",
   dictionaryLanguageChineseDescription:
     "固定视为中文汉字或词语，生成以英文释义为核心的深度解读。",

--- a/website/src/pages/App/__tests__/streaming.test.jsx
+++ b/website/src/pages/App/__tests__/streaming.test.jsx
@@ -26,7 +26,18 @@ jest.unstable_mockModule("@/components/Layout", () => ({
       {sidebarProps && (
         <button
           data-testid="history-select"
-          onClick={() => sidebarProps.onSelectHistory("foo", undefined)}
+          onClick={() =>
+            sidebarProps.onSelectHistory(
+              {
+                term: "foo",
+                language: "ENGLISH",
+                flavor: "BILINGUAL",
+                termKey: "ENGLISH:BILINGUAL:foo",
+                latestVersionId: undefined,
+              },
+              undefined,
+            )
+          }
         />
       )}
       <div>{children}</div>
@@ -124,6 +135,8 @@ jest.unstable_mockModule("@/context", () => ({
       dictionaryLanguageAutoDescription: "根据输入自动识别",
       dictionaryLanguageEnglish: "英文词条",
       dictionaryLanguageEnglishDescription: "固定按英文解析",
+      dictionaryLanguageEnglishMonolingual: "英英释义",
+      dictionaryLanguageEnglishMonolingualDescription: "提供英文释义",
       dictionaryLanguageChinese: "中文词条",
       dictionaryLanguageChineseDescription: "固定按中文解析",
     },
@@ -147,6 +160,7 @@ const { useStreamWord } = await import("@/hooks");
 const { useWordStore } = await import("@/store/wordStore.js");
 const { useSettingsStore } = await import("@/store");
 const { wordCacheKey } = await import("@/api/words.js");
+const { WORD_FLAVOR_BILINGUAL } = await import("@/utils/language.js");
 
 beforeEach(() => {
   useStreamWord.mockReset();
@@ -319,7 +333,11 @@ test("navigates between cached versions", async () => {
             activeVersionId: "v1",
           }),
         };
-        const cacheKey = wordCacheKey({ term: "foo", language: "ENGLISH" });
+        const cacheKey = wordCacheKey({
+          term: "foo",
+          language: "ENGLISH",
+          flavor: WORD_FLAVOR_BILINGUAL,
+        });
         useWordStore.getState().setVersions(cacheKey, [
           { id: "v1", term: "foo", markdown: "# First" },
           { id: "v2", term: "foo", markdown: "# Second" },

--- a/website/src/store/settings/index.ts
+++ b/website/src/store/settings/index.ts
@@ -5,7 +5,11 @@ import {
   getSupportedLanguageCodes,
   isSupportedLanguage,
 } from "@/i18n/languages.js";
-import { WORD_LANGUAGE_AUTO, normalizeWordLanguage } from "@/utils/language.js";
+import {
+  WORD_LANGUAGE_AUTO,
+  WORD_LANGUAGE_ENGLISH_MONO,
+  normalizeWordLanguage,
+} from "@/utils/language.js";
 
 const LEGACY_LANGUAGE_STORAGE_KEY = "lang";
 const SETTINGS_STORAGE_KEY = "settings";
@@ -13,7 +17,11 @@ const DEFAULT_LANGUAGE_FALLBACK = "zh";
 
 type SystemLanguage = typeof SYSTEM_LANGUAGE_AUTO | string;
 
-type DictionaryLanguage = typeof WORD_LANGUAGE_AUTO | "CHINESE" | "ENGLISH";
+type DictionaryLanguage =
+  | typeof WORD_LANGUAGE_AUTO
+  | "CHINESE"
+  | "ENGLISH"
+  | typeof WORD_LANGUAGE_ENGLISH_MONO;
 
 type SettingsState = {
   systemLanguage: SystemLanguage;

--- a/website/src/utils/index.js
+++ b/website/src/utils/index.js
@@ -5,10 +5,14 @@ export { withStopPropagation } from "./stopPropagation.js";
 export {
   detectWordLanguage,
   WORD_LANGUAGE_AUTO,
+  WORD_LANGUAGE_ENGLISH_MONO,
   resolveWordLanguage,
   getSupportedWordLanguages,
   normalizeWordLanguage,
   isWordLanguage,
+  resolveWordFlavor,
+  WORD_FLAVOR_BILINGUAL,
+  WORD_FLAVOR_MONOLINGUAL_ENGLISH,
 } from "./language.js";
 export { getBrandText, BRAND_TEXT } from "./brand.js";
 export { validateEmail, validatePhone, validateAccount } from "./validators.js";

--- a/website/src/utils/language.js
+++ b/website/src/utils/language.js
@@ -1,8 +1,12 @@
 export const WORD_LANGUAGE_AUTO = "AUTO";
+export const WORD_LANGUAGE_ENGLISH_MONO = "ENGLISH_MONOLINGUAL";
+export const WORD_FLAVOR_BILINGUAL = "BILINGUAL";
+export const WORD_FLAVOR_MONOLINGUAL_ENGLISH = "MONOLINGUAL_ENGLISH";
 const SUPPORTED_WORD_LANGUAGES = Object.freeze([
   WORD_LANGUAGE_AUTO,
   "CHINESE",
   "ENGLISH",
+  WORD_LANGUAGE_ENGLISH_MONO,
 ]);
 
 const HAN_SCRIPT_PATTERN = /\p{Script=Han}/u;
@@ -61,9 +65,19 @@ export function resolveWordLanguage(
 ) {
   const normalized = normalizeWordLanguage(preference);
   if (normalized !== WORD_LANGUAGE_AUTO) {
+    if (normalized === WORD_LANGUAGE_ENGLISH_MONO) {
+      return "ENGLISH";
+    }
     return normalized;
   }
   return detectWordLanguage(text);
+}
+
+export function resolveWordFlavor(preference = WORD_LANGUAGE_AUTO) {
+  const normalized = normalizeWordLanguage(preference);
+  return normalized === WORD_LANGUAGE_ENGLISH_MONO
+    ? WORD_FLAVOR_MONOLINGUAL_ENGLISH
+    : WORD_FLAVOR_BILINGUAL;
 }
 
 export function getSupportedWordLanguages() {


### PR DESCRIPTION
## Summary
- extend word API client to encode dictionary flavor in cache keys, REST queries, and SSE handling so bilingual and monolingual lookups stay isolated
- propagate flavor through the streaming hook and App page, updating executeLookup, history selection, and cache hydration logic
- persist dictionary flavor in history records/UI and adjust related API clients and tests to cover the expanded payloads

## Testing
- npm run test -- --runInBand src/api/__tests__/words.test.js
- npm run test -- --runInBand src/api/__tests__/words.stream.test.js
- npm run test -- --runInBand src/api/__tests__/words.cache.e2e.test.js
- npm run test -- --runInBand src/api/__tests__/searchRecords.test.js
- npm run test -- --runInBand src/store/__tests__/historyStore.test.js
- npm run test -- --runInBand src/components/Sidebar/__tests__/HistoryList.test.jsx
- npm run test -- --runInBand src/pages/App/__tests__/streaming.test.jsx


------
https://chatgpt.com/codex/tasks/task_e_68d4abadeacc8332ac75492d3f8710f3