### PR TITLE
feat: replace dictionary language toggles with dropdowns

### DIFF
--- a/website/src/components/TopBar/OutputToolbar.module.css
+++ b/website/src/components/TopBar/OutputToolbar.module.css
@@ -26,17 +26,16 @@
 .language-group {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  gap: 6px;
-  padding: 4px 8px;
-  position: relative;
+  gap: 8px;
+  padding: 6px 10px;
+  min-width: 180px;
 }
 
 .language-group:not(:last-child) {
   border-right: 1px solid
     color-mix(in srgb, var(--border-color) 40%, transparent);
-  padding-right: 14px;
-  margin-right: 4px;
+  padding-right: 18px;
+  margin-right: 6px;
 }
 
 .language-label {
@@ -44,66 +43,71 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: color-mix(in srgb, var(--color-text-secondary) 80%, transparent);
-  padding-left: 4px;
+  padding-left: 2px;
 }
 
-.language-options {
-  display: inline-flex;
-  gap: 6px;
-}
-
-.language-option {
-  border: none;
-  background: transparent;
-  padding: 8px 12px;
-  border-radius: 20px;
-  min-width: 140px;
+.select-control {
+  position: relative;
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  align-items: center;
+}
+
+.select-control::after {
+  content: "";
+  position: absolute;
+  right: 16px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid color-mix(in srgb, var(--color-text) 86%, transparent);
+  border-bottom: 2px solid
+    color-mix(in srgb, var(--color-text) 86%, transparent);
+  transform: rotate(45deg);
+  pointer-events: none;
+}
+
+.select {
+  appearance: none;
+  width: 100%;
+  padding: 10px 38px 10px 16px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--color-surface) 94%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 88%, transparent) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 60%, transparent),
+    0 8px 18px color-mix(in srgb, var(--shadow-color) 14%, transparent);
+  color: color-mix(in srgb, var(--color-text) 92%, transparent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   cursor: pointer;
   transition:
-    color 0.2s ease,
-    background 0.2s ease,
+    border-color 0.2s ease,
     box-shadow 0.2s ease,
     transform 0.2s ease;
 }
 
-.option-title {
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  color: inherit;
-  text-transform: uppercase;
+.select:hover,
+.select:focus-visible {
+  border-color: color-mix(in srgb, var(--primary-color) 60%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 70%, transparent),
+    0 10px 24px color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  transform: translateY(-1px);
+  outline: none;
 }
 
 .option-description {
   font-size: 0.66rem;
-  line-height: 1.2;
-  color: color-mix(in srgb, var(--color-text-secondary) 85%, transparent);
+  line-height: 1.3;
+  color: color-mix(in srgb, var(--color-text-secondary) 82%, transparent);
   text-align: left;
-}
-
-.inactive {
-  color: var(--color-text-secondary);
-}
-
-.inactive:hover {
-  color: var(--color-text);
-  background: color-mix(in srgb, var(--color-surface-alt) 80%, transparent);
-  transform: translateY(-1px);
-}
-
-.active {
-  background: var(--primary-bg);
-  color: var(--primary-color);
-  box-shadow: 0 6px 16px
-    color-mix(in srgb, var(--shadow-color) 20%, transparent);
-}
-
-.active .option-description {
-  color: color-mix(in srgb, var(--primary-color) 80%, white 10%);
+  margin: 0;
+  padding: 0 4px;
 }
 
 .replay {
@@ -191,7 +195,7 @@
   .language-group {
     border-right: none;
     padding: 0;
-    gap: 4px;
+    gap: 6px;
   }
 
   .language-group:not(:last-child) {
@@ -201,19 +205,8 @@
       color-mix(in srgb, var(--border-color) 35%, transparent);
   }
 
-  .language-options {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .language-option {
-    min-width: unset;
-    padding: 6px 12px;
-    gap: 2px;
-  }
-
-  .option-title {
-    font-size: 0.68rem;
+  .select-control::after {
+    right: 14px;
   }
 
   .option-description {


### PR DESCRIPTION
## Summary
- refactor the output toolbar language selector to use select dropdowns instead of toggle buttons
- refresh the toolbar styling for dropdown affordances, preserving the premium visual language and contextual description support

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .

------
https://chatgpt.com/codex/tasks/task_e_68d4be6e95188332a2cae8e6f505af3a