### PR TITLE
fix: adjust zh label for gomemo

### DIFF
--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -54,7 +54,7 @@ export default {
   personalizationPromptsTitle: "思考提示",
   favorites: "收藏夹",
   favoritesIconAlt: "打开收藏夹",
-  gomemo: "学单词",
+  gomemo: "为学单词",
   gomemoIconAlt: "进入 Gomemo 词汇工坊",
   gomemoTagline: "围绕目标定制的每日高优先级清单。",
   gomemoHeroTitle: "Gomemo · 私享记忆设计",


### PR DESCRIPTION
## Summary
- update the zh locale string for Gomemo from “学单词” to “为学单词” to match the desired wording

## Testing
- npx eslint --fix src/i18n/common/zh.js
- npx stylelint --fix "src/**/*.{css,scss,less}" || true
- npx prettier -w src/i18n/common/zh.js

------
https://chatgpt.com/codex/tasks/task_e_68d4cfe1eee48332b2bac5457eaded2b