### PR TITLE
Remove Gomemo tagline from sidebar entry

### DIFF
--- a/website/src/components/Sidebar/GomemoEntry.jsx
+++ b/website/src/components/Sidebar/GomemoEntry.jsx
@@ -13,7 +13,6 @@ function GomemoEntry() {
 
   const gomemoLabel = t.gomemo || FALLBACK_GOMEMO_LABEL;
   const gomemoIconAlt = t.gomemoIconAlt || gomemoLabel;
-  const gomemoTagline = t.gomemoTagline || "";
 
   const isActive = location.pathname.startsWith(GOMEMO_PATH);
 
@@ -28,7 +27,6 @@ function GomemoEntry() {
       icon="target"
       iconAlt={gomemoIconAlt}
       label={gomemoLabel}
-      description={gomemoTagline || undefined}
       isActive={isActive}
       onClick={handleNavigate}
     />

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -57,7 +57,6 @@ export default {
   favoritesIconAlt: "Open favorites collection",
   gomemo: "Gomemo",
   gomemoIconAlt: "Navigate to the Gomemo vocabulary atelier",
-  gomemoTagline: "Daily priority words, curated for your ambitions.",
   gomemoHeroTitle: "Gomemo · Bespoke vocabulary mastery",
   gomemoHeroSubtitle:
     "Gomemo orchestrates spaced memorisation that honours your age, passions, goals and future plans in one seamless ritual.",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -56,7 +56,6 @@ export default {
   favoritesIconAlt: "打开收藏夹",
   gomemo: "为学单词",
   gomemoIconAlt: "进入 Gomemo 词汇工坊",
-  gomemoTagline: "围绕目标定制的每日高优先级清单。",
   gomemoHeroTitle: "Gomemo · 私享记忆设计",
   gomemoHeroSubtitle:
     "Gomemo 将年龄、兴趣、目标与未来规划编织成一体，让背词成为与你的节奏完美契合的日常仪式。",


### PR DESCRIPTION
## Summary
- remove the Gomemo tagline translation strings so the entry has no descriptive blurb across locales
- simplify the Gomemo sidebar entry to render without a description field, keeping the navigation clean

## Testing
- npx prettier -w .
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68d4d61606948332a4c063871583683c