### PR TITLE
Refine settings modal layout

### DIFF
--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -7,9 +7,9 @@ function SettingsModal({ open, onClose }) {
     <BaseModal
       open={open}
       onClose={onClose}
-      className={`modal-content ${styles["auth-modal"]}`}
+      className={`${styles.dialog} modal-content`}
     >
-      <Preferences />
+      <Preferences variant="dialog" />
     </BaseModal>
   );
 }

--- a/website/src/components/modals/SettingsModal.module.css
+++ b/website/src/components/modals/SettingsModal.module.css
@@ -1,45 +1,34 @@
 @import url("./ModalContent.module.css");
 
-.auth-modal {
-  max-width: 400px;
-  width: 90%;
-  max-height: 90vh;
+.dialog {
+  width: min(92vw, 720px);
+  max-height: min(92vh, 760px);
+  padding: clamp(var(--space-5), 6vw, var(--space-7));
+  border-radius: var(--radius-xxl);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--app-bg) 92%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 78%, transparent) 100%
+  );
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+  box-shadow: 0 48px 128px
+    color-mix(in srgb, var(--shadow-color) 32%, transparent);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+}
+
+.dialog > :global(section) {
+  flex: 1;
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  padding-right: clamp(var(--space-1), 1vw, var(--space-2));
+  scroll-behavior: smooth;
 }
 
-.auth-modal .app {
-  width: 100%;
-}
-
-.auth-modal form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  width: 100%;
-}
-
-.auth-modal form > div {
-  display: flex;
-  flex-direction: column;
-}
-
-.auth-modal label {
-  margin-bottom: 0.25rem;
-  font-weight: 500;
-}
-
-.auth-modal input {
-  width: 100%;
-  padding: 0.5rem;
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  background: var(--app-bg);
-  color: var(--app-color);
-}
-
-.auth-modal button[type="submit"] {
-  width: 100%;
+@media (width <= 599px) {
+  .dialog {
+    padding: clamp(var(--space-4), 8vw, var(--space-6));
+    border-radius: var(--radius-xl);
+  }
 }

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -10,6 +10,15 @@ export default {
   prefTitle: "Preferences",
   prefDescription:
     "Tailor Glancy's languages, voices, and ambience to suit every session.",
+  prefDefaultsTitle: "Default languages",
+  prefDefaultsDescription:
+    "Choose the source and target languages Glancy prepares whenever you arrive.",
+  prefInterfaceTitle: "Interface experience",
+  prefInterfaceDescription:
+    "Adjust how the interface speaks and presents itself across sessions.",
+  prefVoicesTitle: "Pronunciation",
+  prefVoicesDescription:
+    "Select the studio voices that narrate English and Chinese entries.",
   prefSystemLanguage: "System Language",
   prefSystemLanguageAuto: "Match Device Language",
   prefLanguage: "Source Language",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -9,6 +9,13 @@ export default {
   updateSuccess: "更新成功",
   prefTitle: "偏好设置",
   prefDescription: "协调语言、音色与外观，让每次查词都恰到好处。",
+  prefDefaultsTitle: "默认使用语言",
+  prefDefaultsDescription:
+    "进入查词时沿用的源语言与目标语言配置，确保体验连贯。",
+  prefInterfaceTitle: "界面体验",
+  prefInterfaceDescription: "调整界面语言与主题，让系统表达更贴合你的习惯。",
+  prefVoicesTitle: "发音演绎",
+  prefVoicesDescription: "挑选英文与中文的播报音色，保持查词时的听感质感。",
   prefSystemLanguage: "界面语言",
   prefSystemLanguageAuto: "自动跟随系统",
   prefLanguage: "源语言",

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -1,32 +1,37 @@
 .container {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  width: min(100%, 560px);
+  display: grid;
+  gap: clamp(var(--space-4), 3vw, var(--space-6));
+  padding: clamp(var(--space-4), 4vw, var(--space-6));
+}
+
+.container-page {
+  width: min(100%, 720px);
   margin: 0 auto;
-  padding: clamp(var(--space-3), 4vw, var(--space-5));
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-xxl);
   background: linear-gradient(
     160deg,
-    color-mix(in srgb, var(--app-bg) 92%, transparent) 0%,
-    color-mix(in srgb, var(--color-surface-alt) 80%, transparent) 100%
+    color-mix(in srgb, var(--app-bg) 94%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 82%, transparent) 100%
   );
   border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
-  box-shadow: 0 32px 64px
+  box-shadow: 0 36px 84px
     color-mix(in srgb, var(--shadow-color) 26%, transparent);
-  overflow: hidden;
+}
+
+.container-dialog {
+  width: min(100%, 640px);
+  padding: 0;
 }
 
 @supports (backdrop-filter: blur(12px)) {
-  .container {
+  .container-page {
     backdrop-filter: blur(18px);
-    background: color-mix(in srgb, var(--app-bg) 78%, transparent);
+    background: color-mix(in srgb, var(--app-bg) 82%, transparent);
   }
 }
 
 .header {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--space-2);
 }
 
@@ -34,36 +39,64 @@
   margin: 0;
   font-size: var(--text-2xl);
   font-weight: var(--font-bold);
-  letter-spacing: 0.025em;
-  color: var(--color-text);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--color-text);
 }
 
 .subtitle {
   margin: 0;
   font-size: var(--text-sm);
   line-height: 1.6;
-  color: color-mix(in srgb, var(--color-text) 68%, transparent);
+  color: color-mix(in srgb, var(--color-text) 66%, transparent);
 }
 
 .form {
   display: grid;
-  gap: var(--space-4);
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
 }
 
-.fields {
+.section {
+  margin: 0;
+  padding: clamp(var(--space-2), 3vw, var(--space-3)) 0 0;
+  border: none;
   display: grid;
   gap: var(--space-3);
-  padding: var(--space-3);
-  border-radius: calc(var(--radius-xl) - var(--space-1));
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--input-bg) 94%, transparent) 0%,
-    color-mix(in srgb, var(--color-surface-muted) 65%, transparent) 100%
-  );
-  border: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
-  box-shadow: inset 0 1px 0
-    color-mix(in srgb, var(--neutral-0) 40%, transparent);
+  min-inline-size: 0;
+}
+
+.section:first-of-type {
+  padding-top: 0;
+}
+
+.section + .section {
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 35%, transparent);
+}
+
+.section-title {
+  margin: 0;
+  padding: 0;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+
+.section-description {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-text) 56%, transparent);
+}
+
+.section-fields {
+  display: grid;
+  gap: clamp(var(--space-3), 2.5vw, var(--space-4));
+}
+
+.section-fields-split {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .field {
@@ -71,21 +104,20 @@
   --form-row-direction-desktop: column;
   --form-row-align: stretch;
   --form-row-align-desktop: stretch;
-  --form-label-color: color-mix(in srgb, var(--color-text) 72%, transparent);
+  --form-label-color: color-mix(in srgb, var(--color-text) 70%, transparent);
   --form-label-size: var(--text-xs);
   --form-label-letter-spacing: 0.12em;
   --form-label-text-transform: uppercase;
   --form-label-weight: var(--font-medium);
   --form-label-width: auto;
 
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--space-2);
-  padding: var(--space-3);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--app-bg) 88%, transparent);
+  padding: clamp(var(--space-3), 2.5vw, var(--space-4));
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--app-bg) 90%, transparent);
   border: 1px solid color-mix(in srgb, var(--border-color) 45%, transparent);
-  box-shadow: 0 18px 36px
+  box-shadow: 0 20px 48px
     color-mix(in srgb, var(--shadow-color) 18%, transparent);
   transition:
     border-color 160ms ease,
@@ -95,34 +127,30 @@
 
 .field:hover {
   transform: translateY(-2px);
-  border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
-  box-shadow: 0 24px 44px
-    color-mix(in srgb, var(--shadow-color) 26%, transparent);
+  border-color: color-mix(in srgb, var(--border-color) 65%, transparent);
+  box-shadow: 0 24px 56px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
 }
 
 .field:focus-within {
-  border-color: color-mix(in srgb, var(--highlight-color) 70%, transparent);
-  box-shadow: 0 28px 52px
-    color-mix(in srgb, var(--shadow-color) 30%, transparent);
-}
-
-.field-wide {
-  grid-column: 1 / -1;
+  border-color: color-mix(in srgb, var(--highlight-color) 68%, transparent);
+  box-shadow: 0 26px 60px
+    color-mix(in srgb, var(--shadow-color) 28%, transparent);
 }
 
 .actions {
   display: flex;
   justify-content: flex-end;
-  padding-top: var(--space-2);
-  border-top: 1px solid color-mix(in srgb, var(--border-color) 35%, transparent);
+  padding-top: clamp(var(--space-3), 3vw, var(--space-4));
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 30%, transparent);
 }
 
 .submit-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 160px;
-  padding: 0.85rem 1.8rem;
+  min-width: 168px;
+  padding: 0.9rem 1.8rem;
   border: none;
   border-radius: var(--radius-lg);
   background: linear-gradient(
@@ -136,8 +164,8 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  box-shadow: 0 20px 48px
-    color-mix(in srgb, var(--shadow-color) 28%, transparent);
+  box-shadow: 0 28px 64px
+    color-mix(in srgb, var(--shadow-color) 32%, transparent);
   transition:
     transform 160ms ease,
     box-shadow 160ms ease;
@@ -147,28 +175,22 @@
   outline: none;
   transform: translateY(-1px);
   box-shadow:
-    0 24px 54px color-mix(in srgb, var(--shadow-color) 34%, transparent),
+    0 32px 72px color-mix(in srgb, var(--shadow-color) 36%, transparent),
     0 0 0 3px color-mix(in srgb, var(--highlight-color) 35%, transparent);
 }
 
 .submit-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 28px 56px
-    color-mix(in srgb, var(--shadow-color) 36%, transparent);
+  box-shadow: 0 36px 80px
+    color-mix(in srgb, var(--shadow-color) 40%, transparent);
 }
 
 .submit-button:active {
   transform: translateY(0);
 }
 
-@media (width >= 600px) {
-  .fields {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media (width >= 480px) {
   .form {
-    gap: var(--space-5);
+    gap: clamp(var(--space-5), 3vw, var(--space-6));
   }
 }

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useId } from "react";
+import PropTypes from "prop-types";
 import styles from "./Preferences.module.css";
 import { useLanguage } from "@/context";
 import { useTheme } from "@/context";
@@ -18,7 +19,12 @@ const DEFAULT_SOURCE_LANG = "auto";
 const DEFAULT_TARGET_LANG = "ENGLISH";
 const DEFAULT_THEME = "system";
 
-function Preferences() {
+const VARIANTS = {
+  PAGE: "page",
+  DIALOG: "dialog",
+};
+
+function Preferences({ variant = VARIANTS.PAGE }) {
   const { t, lang } = useLanguage();
   const { theme, setTheme } = useTheme();
   const { user } = useUser();
@@ -85,13 +91,6 @@ function Preferences() {
     [t],
   );
 
-  const handleSystemLanguageChange = useCallback(
-    (value) => {
-      setSystemLanguage(value);
-    },
-    [setSystemLanguage],
-  );
-
   const searchLanguageOptions = useMemo(
     () => [
       { value: "CHINESE", label: "CHINESE" },
@@ -145,6 +144,13 @@ function Preferences() {
       });
   }, [api, applyPreferences, openPopup, t.fail, user]);
 
+  const handleSystemLanguageChange = useCallback(
+    (value) => {
+      setSystemLanguage(value);
+    },
+    [setSystemLanguage],
+  );
+
   const handleSave = useCallback(
     async (event) => {
       event.preventDefault();
@@ -180,9 +186,20 @@ function Preferences() {
     ],
   );
 
+  const containerClassName = [
+    styles.container,
+    variant === VARIANTS.PAGE
+      ? styles["container-page"]
+      : styles["container-dialog"],
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const splitFieldsClassName = `${styles["section-fields"]} ${styles["section-fields-split"]}`;
+
   return (
     <section
-      className={styles.container}
+      className={containerClassName}
       aria-labelledby={headingId}
       aria-describedby={descriptionId}
     >
@@ -195,58 +212,97 @@ function Preferences() {
         </p>
       </header>
       <form className={styles.form} onSubmit={handleSave}>
-        <div className={styles.fields}>
-          <FormRow
-            label={t.prefSystemLanguage}
-            id="system-language"
-            className={`${styles.field} ${styles["field-wide"]}`}
-          >
-            <SelectField
-              value={systemLanguage}
-              onChange={handleSystemLanguageChange}
-              options={systemLanguageOptions}
-            />
-          </FormRow>
-          <FormRow
-            label={t.prefLanguage}
-            id="source-lang"
-            className={styles.field}
-          >
-            <SelectField
-              value={sourceLang}
-              onChange={setSourceLang}
-              options={languageOptions}
-            />
-          </FormRow>
-          <FormRow
-            label={t.prefSearchLanguage}
-            id="target-lang"
-            className={styles.field}
-          >
-            <SelectField
-              value={targetLang}
-              onChange={setTargetLang}
-              options={searchLanguageOptions}
-            />
-          </FormRow>
-          <FormRow label={t.prefVoiceEn} id="voice-en" className={styles.field}>
-            <VoiceSelector lang="en" />
-          </FormRow>
-          <FormRow label={t.prefVoiceZh} id="voice-zh" className={styles.field}>
-            <VoiceSelector lang="zh" />
-          </FormRow>
-          <FormRow
-            label={t.prefTheme}
-            id="theme-select"
-            className={`${styles.field} ${styles["field-wide"]}`}
-          >
-            <SelectField
-              value={theme}
-              onChange={setTheme}
-              options={themeOptions}
-            />
-          </FormRow>
-        </div>
+        <fieldset className={styles.section}>
+          <legend className={styles["section-title"]}>
+            {t.prefDefaultsTitle}
+          </legend>
+          <p className={styles["section-description"]}>
+            {t.prefDefaultsDescription}
+          </p>
+          <div className={splitFieldsClassName}>
+            <FormRow
+              label={t.prefLanguage}
+              id="source-lang"
+              className={styles.field}
+            >
+              <SelectField
+                value={sourceLang}
+                onChange={setSourceLang}
+                options={languageOptions}
+              />
+            </FormRow>
+            <FormRow
+              label={t.prefSearchLanguage}
+              id="target-lang"
+              className={styles.field}
+            >
+              <SelectField
+                value={targetLang}
+                onChange={setTargetLang}
+                options={searchLanguageOptions}
+              />
+            </FormRow>
+          </div>
+        </fieldset>
+
+        <fieldset className={styles.section}>
+          <legend className={styles["section-title"]}>
+            {t.prefInterfaceTitle}
+          </legend>
+          <p className={styles["section-description"]}>
+            {t.prefInterfaceDescription}
+          </p>
+          <div className={splitFieldsClassName}>
+            <FormRow
+              label={t.prefSystemLanguage}
+              id="system-language"
+              className={styles.field}
+            >
+              <SelectField
+                value={systemLanguage}
+                onChange={handleSystemLanguageChange}
+                options={systemLanguageOptions}
+              />
+            </FormRow>
+            <FormRow
+              label={t.prefTheme}
+              id="theme-select"
+              className={styles.field}
+            >
+              <SelectField
+                value={theme}
+                onChange={setTheme}
+                options={themeOptions}
+              />
+            </FormRow>
+          </div>
+        </fieldset>
+
+        <fieldset className={styles.section}>
+          <legend className={styles["section-title"]}>
+            {t.prefVoicesTitle}
+          </legend>
+          <p className={styles["section-description"]}>
+            {t.prefVoicesDescription}
+          </p>
+          <div className={splitFieldsClassName}>
+            <FormRow
+              label={t.prefVoiceEn}
+              id="voice-en"
+              className={styles.field}
+            >
+              <VoiceSelector lang="en" />
+            </FormRow>
+            <FormRow
+              label={t.prefVoiceZh}
+              id="voice-zh"
+              className={styles.field}
+            >
+              <VoiceSelector lang="zh" />
+            </FormRow>
+          </div>
+        </fieldset>
+
         <div className={styles.actions}>
           <button type="submit" className={styles["submit-button"]}>
             {t.saveButton}
@@ -261,5 +317,13 @@ function Preferences() {
     </section>
   );
 }
+
+Preferences.propTypes = {
+  variant: PropTypes.oneOf(Object.values(VARIANTS)),
+};
+
+Preferences.defaultProps = {
+  variant: VARIANTS.PAGE,
+};
 
 export default Preferences;


### PR DESCRIPTION
## Summary
- add a dialog variant to the preferences view with reorganised sections for default languages, interface and voices
- refresh the settings modal styling so the content sits within a single spacious panel without overflow
- provide translation strings for the new section headings in both English and Chinese

## Testing
- npx eslint --fix src/pages/preferences/index.jsx src/components/modals/SettingsModal.jsx
- npx stylelint --fix src/pages/preferences/Preferences.module.css src/components/modals/SettingsModal.module.css
- npx prettier -w src/pages/preferences/index.jsx src/pages/preferences/Preferences.module.css src/components/modals/SettingsModal.jsx src/components/modals/SettingsModal.module.css src/i18n/common/en.js src/i18n/common/zh.js

------
https://chatgpt.com/codex/tasks/task_e_68d565b7f9808332909e5db876e812c1