### PR TITLE
feat: embed language controls into search input

### DIFF
--- a/website/jest.config.js
+++ b/website/jest.config.js
@@ -21,6 +21,7 @@ export default {
           ["@babel/preset-react", { runtime: "automatic" }],
           "@babel/preset-typescript",
         ],
+        plugins: ["@babel/plugin-transform-unicode-property-regex"],
       },
     ],
   },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17,6 +17,7 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
+    "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
     "@eslint/js": "^9.30.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/website/src/components/ui/ChatInput/ActionInput.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput.jsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef } from "react";
+import PropTypes from "prop-types";
 import ThemeIcon from "@/components/ui/Icon";
 import SearchBox from "@/components/ui/SearchBox";
+import LanguageControls from "./LanguageControls.jsx";
 import styles from "./ChatInput.module.css";
 
 const ICON_SIZE = 36;
@@ -20,6 +22,18 @@ function ActionInput({
   voiceLabel = "Voice",
   rows = 1,
   maxRows = 5,
+  sourceLanguage,
+  sourceLanguageOptions,
+  sourceLanguageLabel,
+  onSourceLanguageChange,
+  targetLanguage,
+  targetLanguageOptions,
+  targetLanguageLabel,
+  onTargetLanguageChange,
+  onSwapLanguages,
+  swapLabel,
+  normalizeSourceLanguageFn,
+  normalizeTargetLanguageFn,
 }) {
   const isEmpty = value.trim() === "";
   const localRef = useRef(null);
@@ -80,23 +94,49 @@ function ActionInput({
     [isEmpty, onVoice],
   );
 
+  const hasSourceOptions = Array.isArray(sourceLanguageOptions)
+    ? sourceLanguageOptions.length > 0
+    : false;
+  const hasTargetOptions = Array.isArray(targetLanguageOptions)
+    ? targetLanguageOptions.length > 0
+    : false;
+  const showLanguageControls = hasSourceOptions || hasTargetOptions;
+
   return (
     <form
       ref={formRef}
       className={styles["input-wrapper"]}
       onSubmit={handleSubmit}
     >
-      <SearchBox>
-        <textarea
-          ref={textareaRef}
-          rows={rows}
-          placeholder={placeholder}
-          value={value}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          className={styles.textarea}
+      {showLanguageControls ? (
+        <LanguageControls
+          sourceLanguage={sourceLanguage}
+          sourceLanguageOptions={sourceLanguageOptions}
+          sourceLanguageLabel={sourceLanguageLabel}
+          onSourceLanguageChange={onSourceLanguageChange}
+          targetLanguage={targetLanguage}
+          targetLanguageOptions={targetLanguageOptions}
+          targetLanguageLabel={targetLanguageLabel}
+          onTargetLanguageChange={onTargetLanguageChange}
+          onSwapLanguages={onSwapLanguages}
+          swapLabel={swapLabel}
+          normalizeSourceLanguage={normalizeSourceLanguageFn}
+          normalizeTargetLanguage={normalizeTargetLanguageFn}
         />
-      </SearchBox>
+      ) : null}
+      <div className={styles["search-area"]}>
+        <SearchBox>
+          <textarea
+            ref={textareaRef}
+            rows={rows}
+            placeholder={placeholder}
+            value={value}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            className={styles.textarea}
+          />
+        </SearchBox>
+      </div>
       <button
         type={isEmpty ? "button" : "submit"}
         className={styles["action-button"]}
@@ -124,3 +164,65 @@ function ActionInput({
 }
 
 export default ActionInput;
+
+ActionInput.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+  onVoice: PropTypes.func,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
+  placeholder: PropTypes.string,
+  sendLabel: PropTypes.string,
+  voiceLabel: PropTypes.string,
+  rows: PropTypes.number,
+  maxRows: PropTypes.number,
+  sourceLanguage: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+  sourceLanguageOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+      label: PropTypes.string.isRequired,
+    }),
+  ),
+  sourceLanguageLabel: PropTypes.string,
+  onSourceLanguageChange: PropTypes.func,
+  targetLanguage: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+  targetLanguageOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+      label: PropTypes.string.isRequired,
+    }),
+  ),
+  targetLanguageLabel: PropTypes.string,
+  onTargetLanguageChange: PropTypes.func,
+  onSwapLanguages: PropTypes.func,
+  swapLabel: PropTypes.string,
+  normalizeSourceLanguageFn: PropTypes.func,
+  normalizeTargetLanguageFn: PropTypes.func,
+};
+
+ActionInput.defaultProps = {
+  onChange: undefined,
+  onSubmit: undefined,
+  onVoice: undefined,
+  inputRef: undefined,
+  placeholder: undefined,
+  sendLabel: "Send",
+  voiceLabel: "Voice",
+  rows: 1,
+  maxRows: 5,
+  sourceLanguage: undefined,
+  sourceLanguageOptions: [],
+  sourceLanguageLabel: undefined,
+  onSourceLanguageChange: undefined,
+  targetLanguage: undefined,
+  targetLanguageOptions: [],
+  targetLanguageLabel: undefined,
+  onTargetLanguageChange: undefined,
+  onSwapLanguages: undefined,
+  swapLabel: undefined,
+  normalizeSourceLanguageFn: (value) => value,
+  normalizeTargetLanguageFn: (value) => value,
+};

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -8,6 +8,121 @@
   position: relative;
   width: 100%;
   margin: 0 auto;
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-3);
+}
+
+.language-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 48%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 88%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 65%, transparent),
+    0 12px 28px color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  backdrop-filter: blur(18px);
+  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.language-select-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.language-select-wrapper::after {
+  content: "";
+  position: absolute;
+  right: 16px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid color-mix(in srgb, var(--color-text) 84%, transparent);
+  border-bottom: 2px solid
+    color-mix(in srgb, var(--color-text) 84%, transparent);
+  transform: rotate(45deg);
+  pointer-events: none;
+}
+
+.language-select {
+  appearance: none;
+  min-width: 132px;
+  padding: 10px 38px 10px 18px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 52%, transparent);
+  background: linear-gradient(
+    140deg,
+    color-mix(in srgb, var(--color-surface) 94%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 82%, transparent) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 70%, transparent),
+    0 10px 22px color-mix(in srgb, var(--shadow-color) 16%, transparent);
+  color: color-mix(in srgb, var(--color-text) 92%, transparent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.language-select:hover,
+.language-select:focus-visible {
+  border-color: color-mix(in srgb, var(--primary-color) 54%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 78%, transparent),
+    0 12px 26px color-mix(in srgb, var(--shadow-color) 22%, transparent);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.language-swap-button {
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+  background: linear-gradient(
+    140deg,
+    color-mix(in srgb, var(--color-surface) 96%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 76%, transparent) 100%
+  );
+  box-shadow: 0 10px 24px
+    color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  color: color-mix(in srgb, var(--color-text) 86%, transparent);
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.language-swap-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 54%, transparent);
+  outline-offset: 2px;
+}
+
+.language-swap-button:hover,
+.language-swap-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--primary-color) 48%, transparent);
+  box-shadow: 0 12px 28px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
+}
+
+.search-area {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .textarea {

--- a/website/src/components/ui/ChatInput/LanguageControls.jsx
+++ b/website/src/components/ui/ChatInput/LanguageControls.jsx
@@ -1,0 +1,211 @@
+import PropTypes from "prop-types";
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./ChatInput.module.css";
+
+const toNormalizedOptions = (options, normalizeValue) => {
+  if (!Array.isArray(options)) {
+    return [];
+  }
+
+  return options
+    .map(({ value, label }) => {
+      if (typeof label !== "string") {
+        return null;
+      }
+
+      const normalized = normalizeValue?.(value);
+      const resolved = normalized ?? value;
+      const stringValue =
+        resolved != null ? String(resolved).toUpperCase() : undefined;
+
+      if (!stringValue) {
+        return null;
+      }
+
+      return {
+        value: stringValue,
+        label,
+      };
+    })
+    .filter(Boolean);
+};
+
+function LanguageSelect({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  normalizeValue,
+}) {
+  const normalizedOptions = toNormalizedOptions(options, normalizeValue);
+
+  if (normalizedOptions.length === 0) {
+    return null;
+  }
+
+  const normalizedValue = normalizeValue?.(value) ?? value;
+  const resolvedValue =
+    normalizedValue != null ? String(normalizedValue).toUpperCase() : undefined;
+
+  const selectValue = normalizedOptions.some(
+    (option) => option.value === resolvedValue,
+  )
+    ? resolvedValue
+    : normalizedOptions[0]?.value;
+
+  const handleChange = (event) => {
+    const selected = event?.target?.value;
+    const normalized = normalizeValue?.(selected) ?? selected;
+    onChange?.(normalized);
+  };
+
+  return (
+    <div className={styles["language-select-wrapper"]}>
+      <select
+        className={styles["language-select"]}
+        value={selectValue}
+        onChange={handleChange}
+        aria-label={ariaLabel}
+      >
+        {normalizedOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+LanguageSelect.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+      label: PropTypes.string.isRequired,
+    }),
+  ),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+  onChange: PropTypes.func,
+  ariaLabel: PropTypes.string,
+  normalizeValue: PropTypes.func,
+};
+
+LanguageSelect.defaultProps = {
+  options: [],
+  value: undefined,
+  onChange: undefined,
+  ariaLabel: undefined,
+  normalizeValue: undefined,
+};
+
+export default function LanguageControls({
+  sourceLanguage,
+  sourceLanguageOptions,
+  sourceLanguageLabel,
+  onSourceLanguageChange,
+  targetLanguage,
+  targetLanguageOptions,
+  targetLanguageLabel,
+  onTargetLanguageChange,
+  onSwapLanguages,
+  swapLabel,
+  normalizeSourceLanguage,
+  normalizeTargetLanguage,
+}) {
+  const hasSource = Array.isArray(sourceLanguageOptions)
+    ? sourceLanguageOptions.length > 0
+    : false;
+  const hasTarget = Array.isArray(targetLanguageOptions)
+    ? targetLanguageOptions.length > 0
+    : false;
+
+  if (!hasSource && !hasTarget) {
+    return null;
+  }
+
+  const canSwap =
+    hasSource && hasTarget && typeof onSwapLanguages === "function";
+  const normalizeSource =
+    typeof normalizeSourceLanguage === "function"
+      ? normalizeSourceLanguage
+      : (value) => value;
+  const normalizeTarget =
+    typeof normalizeTargetLanguage === "function"
+      ? normalizeTargetLanguage
+      : (value) => value;
+
+  return (
+    <div className={styles["language-controls"]}>
+      <LanguageSelect
+        options={sourceLanguageOptions}
+        value={sourceLanguage}
+        onChange={onSourceLanguageChange}
+        ariaLabel={sourceLanguageLabel}
+        normalizeValue={normalizeSource}
+      />
+      {canSwap ? (
+        <button
+          type="button"
+          className={styles["language-swap-button"]}
+          onClick={onSwapLanguages}
+          aria-label={swapLabel}
+          title={swapLabel}
+        >
+          <ThemeIcon
+            name="arrow-right"
+            width={18}
+            height={18}
+            aria-hidden="true"
+          />
+        </button>
+      ) : null}
+      <LanguageSelect
+        options={targetLanguageOptions}
+        value={targetLanguage}
+        onChange={onTargetLanguageChange}
+        ariaLabel={targetLanguageLabel}
+        normalizeValue={normalizeTarget}
+      />
+    </div>
+  );
+}
+
+LanguageControls.propTypes = {
+  sourceLanguage: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+  sourceLanguageOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+      label: PropTypes.string.isRequired,
+    }),
+  ),
+  sourceLanguageLabel: PropTypes.string,
+  onSourceLanguageChange: PropTypes.func,
+  targetLanguage: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+  targetLanguageOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
+      label: PropTypes.string.isRequired,
+    }),
+  ),
+  targetLanguageLabel: PropTypes.string,
+  onTargetLanguageChange: PropTypes.func,
+  onSwapLanguages: PropTypes.func,
+  swapLabel: PropTypes.string,
+  normalizeSourceLanguage: PropTypes.func,
+  normalizeTargetLanguage: PropTypes.func,
+};
+
+LanguageControls.defaultProps = {
+  sourceLanguage: undefined,
+  sourceLanguageOptions: [],
+  sourceLanguageLabel: undefined,
+  onSourceLanguageChange: undefined,
+  targetLanguage: undefined,
+  targetLanguageOptions: [],
+  targetLanguageLabel: undefined,
+  onTargetLanguageChange: undefined,
+  onSwapLanguages: undefined,
+  swapLabel: undefined,
+  normalizeSourceLanguage: undefined,
+  normalizeTargetLanguage: undefined,
+};

--- a/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
@@ -41,3 +41,47 @@ test("clears value via parent state on Enter submit", () => {
   fireEvent.keyDown(textarea, { key: "Enter" });
   expect(textarea.value).toBe("");
 });
+
+/**
+ * 验证语言控制面板在提供选项时能够触发下拉与交换事件。
+ */
+test("handles language selection and swapping", () => {
+  const handleSourceChange = jest.fn();
+  const handleTargetChange = jest.fn();
+  const handleSwap = jest.fn();
+
+  render(
+    <ActionInput
+      value=""
+      onChange={() => {}}
+      onSubmit={() => {}}
+      sourceLanguage="CHINESE"
+      sourceLanguageOptions={[
+        { value: "CHINESE", label: "中文词条" },
+        { value: "ENGLISH", label: "英文词条" },
+      ]}
+      sourceLanguageLabel="源语言"
+      onSourceLanguageChange={handleSourceChange}
+      targetLanguage="ENGLISH"
+      targetLanguageOptions={[
+        { value: "ENGLISH", label: "英文释义" },
+        { value: "CHINESE", label: "中文释义" },
+      ]}
+      targetLanguageLabel="目标语言"
+      onTargetLanguageChange={handleTargetChange}
+      onSwapLanguages={handleSwap}
+      swapLabel="交换语向"
+    />,
+  );
+
+  const selects = screen.getAllByRole("combobox");
+  fireEvent.change(selects[0], { target: { value: "ENGLISH" } });
+  expect(handleSourceChange).toHaveBeenCalledWith("ENGLISH");
+
+  fireEvent.change(selects[1], { target: { value: "CHINESE" } });
+  expect(handleTargetChange).toHaveBeenCalledWith("CHINESE");
+
+  const swapButton = screen.getByRole("button", { name: "交换语向" });
+  fireEvent.click(swapButton);
+  expect(handleSwap).toHaveBeenCalledTimes(1);
+});

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -37,6 +37,7 @@ export default {
   dictionarySourceLanguageChinese: "Chinese term",
   dictionarySourceLanguageChineseDescription:
     "Treat the input as Chinese and surface Chinese-first experiences.",
+  dictionarySwapLanguages: "Swap languages",
   dictionaryTargetLanguageLabel: "Target language",
   dictionaryTargetLanguageEnglish: "English definitions",
   dictionaryTargetLanguageEnglishDescription:

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -34,6 +34,7 @@ export default {
   dictionarySourceLanguageChinese: "中文词条",
   dictionarySourceLanguageChineseDescription:
     "按中文词语理解，优先呈现中文语境中的重点。",
+  dictionarySwapLanguages: "交换语向",
   dictionaryTargetLanguageLabel: "目标语言",
   dictionaryTargetLanguageEnglish: "英文释义",
   dictionaryTargetLanguageEnglishDescription:

--- a/website/src/pages/App/__tests__/streaming.test.jsx
+++ b/website/src/pages/App/__tests__/streaming.test.jsx
@@ -137,6 +137,7 @@ jest.unstable_mockModule("@/context", () => ({
       dictionarySourceLanguageEnglishDescription: "固定按英文解析",
       dictionarySourceLanguageChinese: "中文词条",
       dictionarySourceLanguageChineseDescription: "固定按中文解析",
+      dictionarySwapLanguages: "交换语向",
       dictionaryTargetLanguageLabel: "目标语言",
       dictionaryTargetLanguageChinese: "中文释义",
       dictionaryTargetLanguageChineseDescription: "输出中文解释",

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -20,6 +20,8 @@ import {
   resolveDictionaryConfig,
   resolveDictionaryFlavor,
   WORD_LANGUAGE_AUTO,
+  normalizeWordSourceLanguage,
+  normalizeWordTargetLanguage,
   resolveShareTarget,
   attemptShareLink,
 } from "@/utils";
@@ -120,28 +122,30 @@ function App() {
       }),
     [dictionarySourceLanguage, dictionaryTargetLanguage],
   );
-  const toolbarLanguageProps = useMemo(
-    () => ({
-      sourceLanguage: dictionarySourceLanguage,
-      onSourceLanguageChange: setDictionarySourceLanguage,
-      sourceLanguageOptions,
-      sourceLanguageLabel: t.dictionarySourceLanguageLabel,
-      targetLanguage: dictionaryTargetLanguage,
-      onTargetLanguageChange: setDictionaryTargetLanguage,
-      targetLanguageOptions,
-      targetLanguageLabel: t.dictionaryTargetLanguageLabel,
-    }),
-    [
+  const handleSwapLanguages = useCallback(() => {
+    const normalizedSource = normalizeWordSourceLanguage(
       dictionarySourceLanguage,
-      setDictionarySourceLanguage,
-      sourceLanguageOptions,
-      t.dictionarySourceLanguageLabel,
+    );
+    const normalizedTarget = normalizeWordTargetLanguage(
       dictionaryTargetLanguage,
-      setDictionaryTargetLanguage,
-      targetLanguageOptions,
-      t.dictionaryTargetLanguageLabel,
-    ],
-  );
+    );
+
+    const nextSource = normalizedTarget;
+    const nextTarget =
+      normalizedSource === WORD_LANGUAGE_AUTO
+        ? normalizedTarget === "CHINESE"
+          ? "ENGLISH"
+          : "CHINESE"
+        : normalizeWordTargetLanguage(normalizedSource);
+
+    setDictionarySourceLanguage(nextSource);
+    setDictionaryTargetLanguage(nextTarget);
+  }, [
+    dictionarySourceLanguage,
+    dictionaryTargetLanguage,
+    setDictionarySourceLanguage,
+    setDictionaryTargetLanguage,
+  ]);
   const abortRef = useRef(null);
   const { favorites, toggleFavorite } = useFavorites();
   const navigate = useNavigate();
@@ -702,7 +706,6 @@ function App() {
             !showFavorites && !showHistory ? handleDeleteHistory : undefined,
           onShare: !showFavorites && !showHistory ? handleShare : undefined,
           onReport: !showFavorites && !showHistory ? handleReport : undefined,
-          toolbarProps: toolbarLanguageProps,
         }}
         bottomContent={
           <div>
@@ -714,6 +717,18 @@ function App() {
               onVoice={handleVoice}
               placeholder={t.inputPlaceholder}
               maxRows={5}
+              sourceLanguage={dictionarySourceLanguage}
+              sourceLanguageOptions={sourceLanguageOptions}
+              sourceLanguageLabel={t.dictionarySourceLanguageLabel}
+              onSourceLanguageChange={setDictionarySourceLanguage}
+              targetLanguage={dictionaryTargetLanguage}
+              targetLanguageOptions={targetLanguageOptions}
+              targetLanguageLabel={t.dictionaryTargetLanguageLabel}
+              onTargetLanguageChange={setDictionaryTargetLanguage}
+              onSwapLanguages={handleSwapLanguages}
+              swapLabel={t.dictionarySwapLanguages}
+              normalizeSourceLanguageFn={normalizeWordSourceLanguage}
+              normalizeTargetLanguageFn={normalizeWordTargetLanguage}
             />
             <ICP />
           </div>


### PR DESCRIPTION
## Summary
- embed a reusable LanguageControls module inside the chat search form with luxury styling updates
- route dictionary language state through the chat input, including swap behaviour and new localisation strings
- update Jest configuration and tests to cover the new controls while supporting unicode regex parsing

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .
- npm test -- ActionInput (fails: Jest environment teardown ReferenceError)

------
https://chatgpt.com/codex/tasks/task_e_68d56cdd3e3c83328a0c41bf56db93ce