### PR TITLE
Fix toolbar language props wiring

### DIFF
--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -147,6 +147,28 @@ function App() {
     setDictionarySourceLanguage,
     setDictionaryTargetLanguage,
   ]);
+  const toolbarLanguageProps = useMemo(
+    () => ({
+      sourceLanguage: dictionarySourceLanguage,
+      sourceLanguageOptions,
+      onSourceLanguageChange: setDictionarySourceLanguage,
+      sourceLanguageLabel: t.dictionarySourceLanguageLabel,
+      targetLanguage: dictionaryTargetLanguage,
+      targetLanguageOptions,
+      onTargetLanguageChange: setDictionaryTargetLanguage,
+      targetLanguageLabel: t.dictionaryTargetLanguageLabel,
+    }),
+    [
+      dictionarySourceLanguage,
+      sourceLanguageOptions,
+      setDictionarySourceLanguage,
+      t.dictionarySourceLanguageLabel,
+      dictionaryTargetLanguage,
+      targetLanguageOptions,
+      setDictionaryTargetLanguage,
+      t.dictionaryTargetLanguageLabel,
+    ],
+  );
   const abortRef = useRef(null);
   const { favorites, toggleFavorite } = useFavorites();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- memoize dictionary language props to share between the chat input and dictionary action bar
- pass language selectors into the dictionary action bar to avoid undefined references

## Testing
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w .

------
https://chatgpt.com/codex/tasks/task_e_68d57607625c83328611938a4fbe7ecf