### PR TITLE
refactor: simplify history list entries

### DIFF
--- a/website/src/components/Sidebar/HistoryList.jsx
+++ b/website/src/components/Sidebar/HistoryList.jsx
@@ -1,14 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
-import { useHistory, useUser, useLanguage } from "@/context";
-import ThemeIcon from "@/components/ui/Icon";
+import { useHistory, useUser } from "@/context";
 import Toast from "@/components/ui/Toast";
 import styles from "./Sidebar.module.css";
 
 function HistoryList({ onSelect }) {
   const { history, loadHistory, error } = useHistory();
   const { user } = useUser();
-  const { lang } = useLanguage();
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
@@ -27,28 +25,6 @@ function HistoryList({ onSelect }) {
 
   const groupedHistory = useMemo(() => history ?? [], [history]);
   const hasHistory = groupedHistory.length > 0;
-  const locale = lang === "en" ? "en-US" : "zh-CN";
-  const dateFormatter = useMemo(() => {
-    try {
-      return new Intl.DateTimeFormat(locale, {
-        month: "short",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
-    } catch {
-      return null;
-    }
-  }, [locale]);
-
-  const resolveDisplayDate = (timestamp) => {
-    if (!timestamp || !dateFormatter) return null;
-    try {
-      return dateFormatter.format(new Date(timestamp));
-    } catch {
-      return null;
-    }
-  };
 
   const handleSelect = (item) => {
     if (!onSelect) return;
@@ -64,7 +40,6 @@ function HistoryList({ onSelect }) {
         >
           <ul className={styles["history-items"]}>
             {groupedHistory.map((item) => {
-              const displayDate = resolveDisplayDate(item.createdAt);
               return (
                 <li key={item.termKey} className={styles["history-entry"]}>
                   <button
@@ -76,22 +51,7 @@ function HistoryList({ onSelect }) {
                       <span className={styles["history-term-text"]}>
                         {item.term}
                       </span>
-                      {displayDate ? (
-                        <time
-                          dateTime={item.createdAt ?? undefined}
-                          className={styles["history-meta"]}
-                        >
-                          {displayDate}
-                        </time>
-                      ) : null}
                     </div>
-                    <ThemeIcon
-                      name="arrow-right"
-                      width={18}
-                      height={18}
-                      aria-hidden="true"
-                      className={styles["history-arrow"]}
-                    />
                   </button>
                 </li>
               );

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -63,7 +63,7 @@
   width: 100%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: var(--sidebar-brand-gap, 8px);
   padding: var(--sidebar-item-padding-y, 10px)
     var(--sidebar-item-padding-x, 18px);
@@ -83,29 +83,12 @@
 .history-labels {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .history-term-text {
   font-weight: 600;
   letter-spacing: 0.01em;
-}
-
-.history-meta {
-  font-size: 12px;
-  color: color-mix(in srgb, var(--sidebar-color) 58%, transparent);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.history-arrow {
-  color: color-mix(in srgb, var(--sidebar-color) 75%, transparent);
-  transition: transform 160ms ease;
-}
-
-.history-button:hover .history-arrow,
-.history-button:focus-visible .history-arrow {
-  transform: translateX(2px);
 }
 
 .sidebar-action {


### PR DESCRIPTION
## Summary
- remove timestamp and trailing arrow from history list buttons to streamline the interaction surface
- simplify supporting logic by deleting unused date formatting and related styles, keeping the component focused on term display
- align sidebar history button styling for a balanced, left-aligned layout after removing secondary metadata

## Testing
- `npm run lint -- --fix`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w .`


------
https://chatgpt.com/codex/tasks/task_e_68d57a08f1fc83329e21b8c451311117