### PR TITLE
feat: 优化搜索空状态的呈现

### DIFF
--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -75,6 +75,10 @@
   text-align: center;
 }
 
+.display-empty {
+  justify-content: center;
+}
+
 .stream-text {
   width: 100%;
   padding: var(--space-3, 16px);
@@ -122,6 +126,11 @@
     padding: var(--space-3, 16px);
     width: 100%;
     text-align: left;
+  }
+
+  .display-empty {
+    align-items: center;
+    text-align: center;
   }
 }
 

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -13,7 +13,6 @@ import HistoryDisplay from "@/components/ui/HistoryDisplay";
 import ICP from "@/components/ui/ICP";
 import FavoritesView from "./FavoritesView.jsx";
 import { useAppShortcuts } from "@/hooks";
-import Button from "@/components/ui/Button";
 import EmptyState from "@/components/ui/EmptyState";
 import DictionaryEntryActionBar from "@/components/DictionaryEntryActionBar";
 import {
@@ -705,6 +704,23 @@ function App() {
   const resolvedTerm = activeTerm;
   const hasResolvedEntry = isEntryViewActive && Boolean(entry);
   const isTermActionable = isEntryViewActive && Boolean(resolvedTerm);
+  const isEmptyStateActive = useMemo(
+    () =>
+      !showFavorites &&
+      !showHistory &&
+      !entry &&
+      !finalText &&
+      !streamText &&
+      !loading,
+    [showFavorites, showHistory, entry, finalText, streamText, loading],
+  );
+  const displayClassName = useMemo(
+    () =>
+      ["display", isEmptyStateActive ? "display-empty" : ""]
+        .filter(Boolean)
+        .join(" "),
+    [isEmptyStateActive],
+  );
   const dictionaryActionBar = (
     <DictionaryEntryActionBar
       visible={hasResolvedEntry}
@@ -762,7 +778,7 @@ function App() {
           </div>
         }
       >
-        <div className="display">
+        <div className={displayClassName}>
           {showFavorites ? (
             <FavoritesView
               favorites={favorites}
@@ -797,11 +813,6 @@ function App() {
               iconName="target"
               title={t.searchEmptyTitle}
               description={t.searchEmptyDescription}
-              actions={
-                <Button type="button" onClick={focusInput}>
-                  {t.searchEmptyAction}
-                </Button>
-              }
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- 通过派生类名逻辑在空状态时让主显示区域垂直居中，保持整体布局稳定
- 精简搜索空状态交互，去除多余操作按钮以突出视觉核心
- 为移动端和桌面端提供一致的居中样式，确保视觉层级统一

## Testing
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w src/pages/App/index.jsx src/pages/App/App.css

------
https://chatgpt.com/codex/tasks/task_e_68d57b6df4948332b376d6e288d5bfe1