### PR TITLE
feat: 提升侧边栏重点入口样式

### DIFF
--- a/website/src/components/Brand/index.jsx
+++ b/website/src/components/Brand/index.jsx
@@ -1,6 +1,7 @@
 import { useLanguage } from "@/context";
 import { UserMenu } from "@/components/Header";
 import SidebarActionItem from "@/components/Sidebar/SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "@/components/Sidebar/sidebarActionVariants.js";
 import { getBrandText } from "@/utils";
 
 function Brand() {
@@ -18,7 +19,7 @@ function Brand() {
         iconAlt={brandText}
         label={brandText}
         onClick={handleClick}
-        className="sidebar-brand-action"
+        variant={SIDEBAR_ACTION_VARIANTS.prominent}
       />
       <div className="mobile-user-menu">
         <UserMenu size={28} />

--- a/website/src/components/Sidebar/Favorites.jsx
+++ b/website/src/components/Sidebar/Favorites.jsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useLanguage } from "@/context";
 import SidebarActionItem from "./SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const FALLBACK_FAVORITES_LABEL = "Favorites";
 
@@ -22,6 +23,7 @@ function Favorites({ onToggle }) {
       label={favoritesLabel}
       iconAlt={favoritesIconAlt}
       onClick={handleClick}
+      variant={SIDEBAR_ACTION_VARIANTS.prominent}
     />
   );
 }

--- a/website/src/components/Sidebar/GomemoEntry.jsx
+++ b/website/src/components/Sidebar/GomemoEntry.jsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useLanguage } from "@/context";
 import SidebarActionItem from "./SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const GOMEMO_PATH = "/gomemo";
 const FALLBACK_GOMEMO_LABEL = "Gomemo";
@@ -30,6 +31,7 @@ function GomemoEntry() {
       label={gomemoLabel}
       isActive={isActive}
       onClick={handleNavigate}
+      variant={SIDEBAR_ACTION_VARIANTS.prominent}
     />
   );
 }

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -129,14 +129,48 @@
     transform 160ms ease;
 }
 
+.sidebar-action[data-variant="prominent"] {
+  --sidebar-action-prominent-color: color-mix(
+    in srgb,
+    var(--accent-color) 60%,
+    var(--sidebar-color)
+  );
+  --sidebar-action-icon-shadow: drop-shadow(0 2px 6px rgb(15 23 42 / 18%));
+  --sidebar-action-description-color: color-mix(
+    in srgb,
+    var(--accent-color) 48%,
+    var(--sidebar-color)
+  );
+
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 38%, transparent);
+  box-shadow:
+    0 10px 28px rgb(15 23 42 / 12%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  color: var(--sidebar-action-prominent-color);
+}
+
 .sidebar-action:where(:hover, :focus-visible) {
   background-color: var(--color-overlay-weak);
   transform: translateY(-1px);
 }
 
+.sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--accent-color) 24%, transparent);
+  box-shadow:
+    0 16px 36px rgb(15 23 42 / 16%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 22%, transparent);
+  transform: translateY(-2px);
+}
+
 .sidebar-action:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent-color) 60%, transparent);
   outline-offset: 3px;
+}
+
+.sidebar-action[data-variant="prominent"]:focus-visible {
+  outline-color: color-mix(in srgb, var(--accent-color) 75%, transparent);
+  outline-offset: 4px;
 }
 
 .sidebar-user-trigger .sidebar-action {
@@ -147,12 +181,37 @@
   background-color: var(--color-overlay-inverse);
 }
 
+:root[data-theme="dark"] .sidebar-action[data-variant="prominent"] {
+  background: color-mix(in srgb, var(--accent-color) 26%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
+  box-shadow:
+    0 18px 40px rgb(2 6 23 / 24%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 24%, transparent);
+}
+
+:root[data-theme="dark"]
+  .sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
+  box-shadow:
+    0 24px 52px rgb(2 6 23 / 32%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 32%, transparent);
+}
+
 .sidebar-action-active {
   background: color-mix(in srgb, var(--sidebar-bg) 94%, transparent);
   box-shadow:
     inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 28%, transparent),
     0 4px 12px rgb(15 23 42 / 6%);
   color: color-mix(in srgb, var(--accent-color) 52%, var(--sidebar-color));
+}
+
+.sidebar-action-active[data-variant="prominent"] {
+  background: color-mix(in srgb, var(--accent-color) 30%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
+  box-shadow:
+    0 18px 48px rgb(15 23 42 / 20%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 42%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 82%, var(--sidebar-color));
 }
 
 .sidebar-action-icon {
@@ -163,7 +222,10 @@
   width: 24px;
   height: 24px;
   color: inherit;
-  filter: drop-shadow(0 1px 1px rgb(15 23 42 / 12%));
+  filter: var(
+    --sidebar-action-icon-shadow,
+    drop-shadow(0 1px 1px rgb(15 23 42 / 12%))
+  );
 }
 
 .sidebar-action-body {
@@ -201,7 +263,10 @@
 .sidebar-action-description {
   font-size: 12px;
   line-height: 1.4;
-  color: color-mix(in srgb, var(--sidebar-color) 60%, transparent);
+  color: var(
+    --sidebar-action-description-color,
+    color-mix(in srgb, var(--sidebar-color) 60%, transparent)
+  );
   letter-spacing: 0.02em;
 }
 

--- a/website/src/components/Sidebar/SidebarActionItem.jsx
+++ b/website/src/components/Sidebar/SidebarActionItem.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import ThemeIcon from "@/components/ui/Icon";
 import styles from "./Sidebar.module.css";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const joinClassName = (...tokens) => tokens.filter(Boolean).join(" ");
 
@@ -32,10 +33,17 @@ function SidebarActionItem({
   badge,
   trailing,
   isActive = false,
+  variant = SIDEBAR_ACTION_VARIANTS.default,
   className,
   onClick,
   ...rest
 }) {
+  const resolvedVariant = Object.values(SIDEBAR_ACTION_VARIANTS).includes(
+    variant,
+  )
+    ? variant
+    : SIDEBAR_ACTION_VARIANTS.default;
+
   const composedClassName = joinClassName(
     styles["sidebar-action"],
     isActive ? styles["sidebar-action-active"] : "",
@@ -70,6 +78,7 @@ function SidebarActionItem({
         type={type}
         className={composedClassName}
         onClick={onClick}
+        data-variant={resolvedVariant}
         {...rest}
       >
         {content}
@@ -78,7 +87,12 @@ function SidebarActionItem({
   }
 
   return (
-    <Component className={composedClassName} onClick={onClick} {...rest}>
+    <Component
+      className={composedClassName}
+      onClick={onClick}
+      data-variant={resolvedVariant}
+      {...rest}
+    >
       {content}
     </Component>
   );
@@ -94,6 +108,7 @@ SidebarActionItem.propTypes = {
   badge: PropTypes.node,
   trailing: PropTypes.node,
   isActive: PropTypes.bool,
+  variant: PropTypes.oneOf(Object.values(SIDEBAR_ACTION_VARIANTS)),
   className: PropTypes.string,
   onClick: PropTypes.func,
 };
@@ -107,6 +122,7 @@ SidebarActionItem.defaultProps = {
   badge: undefined,
   trailing: undefined,
   isActive: false,
+  variant: SIDEBAR_ACTION_VARIANTS.default,
   className: undefined,
   onClick: undefined,
 };

--- a/website/src/components/Sidebar/sidebarActionVariants.js
+++ b/website/src/components/Sidebar/sidebarActionVariants.js
@@ -1,0 +1,4 @@
+export const SIDEBAR_ACTION_VARIANTS = Object.freeze({
+  default: "default",
+  prominent: "prominent",
+});

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -36,7 +36,7 @@
   padding-block: var(--space-2, 8px);
 }
 
-.sidebar-brand-action {
+.sidebar-brand [data-variant="prominent"] {
   flex: 1;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- 为 SidebarActionItem 增加 variant 支持并抽离常量，避免重复定义视觉权重
- 让 Gomemo、收藏夹与品牌入口统一采用 prominent 样式并注入高端视觉细节
- 更新侧边栏 CSS 令品牌区按数据属性控制布局，覆盖亮暗主题表现

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src

------
https://chatgpt.com/codex/tasks/task_e_68d57a8a69208332aef83487939e8200