### PR TITLE
feat: 移除输出工具栏语言选择器

### DIFF
--- a/website/src/components/Brand/index.jsx
+++ b/website/src/components/Brand/index.jsx
@@ -1,6 +1,7 @@
 import { useLanguage } from "@/context";
 import { UserMenu } from "@/components/Header";
 import SidebarActionItem from "@/components/Sidebar/SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "@/components/Sidebar/sidebarActionVariants.js";
 import { getBrandText } from "@/utils";
 
 function Brand() {
@@ -18,7 +19,7 @@ function Brand() {
         iconAlt={brandText}
         label={brandText}
         onClick={handleClick}
-        className="sidebar-brand-action"
+        variant={SIDEBAR_ACTION_VARIANTS.prominent}
       />
       <div className="mobile-user-menu">
         <UserMenu size={28} />

--- a/website/src/components/OutputToolbar/OutputToolbar.module.css
+++ b/website/src/components/OutputToolbar/OutputToolbar.module.css
@@ -24,17 +24,11 @@
   border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
 }
 
-.cluster-languages,
 .cluster-controls,
 .cluster-actions {
   display: flex;
   align-items: center;
   min-width: 0;
-}
-
-.cluster-languages {
-  flex: 1 1 32%;
-  justify-content: flex-start;
 }
 
 .cluster-controls {
@@ -48,101 +42,6 @@
   flex: 0 0 auto;
   justify-content: flex-end;
   margin-left: auto;
-}
-
-.language-select {
-  display: inline-flex;
-  align-items: stretch;
-  gap: 12px;
-  padding: 6px 10px;
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 42%, transparent);
-  background: color-mix(in srgb, var(--color-surface-alt) 96%, transparent);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 52%, transparent),
-    0 6px 18px color-mix(in srgb, var(--shadow-color) 14%, transparent);
-  min-width: 0;
-  max-width: 440px;
-  flex: 1 1 auto;
-}
-
-.language-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 6px 12px;
-  min-width: 160px;
-  flex: 1 1 0;
-}
-
-.language-group:not(:last-child) {
-  border-right: 1px solid
-    color-mix(in srgb, var(--border-color) 36%, transparent);
-  padding-right: 18px;
-  margin-right: 8px;
-}
-
-.language-label {
-  font-size: 0.68rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-text-secondary) 78%, transparent);
-  padding-left: 4px;
-}
-
-.select-control {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.select-control::after {
-  content: "";
-  position: absolute;
-  right: 16px;
-  width: 8px;
-  height: 8px;
-  border-right: 2px solid color-mix(in srgb, var(--color-text) 86%, transparent);
-  border-bottom: 2px solid
-    color-mix(in srgb, var(--color-text) 86%, transparent);
-  transform: rotate(45deg);
-  pointer-events: none;
-}
-
-.select {
-  appearance: none;
-  width: 100%;
-  padding: 10px 40px 10px 16px;
-  border-radius: 18px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 52%, transparent);
-  background: linear-gradient(
-    145deg,
-    color-mix(in srgb, var(--color-surface) 94%, transparent) 0%,
-    color-mix(in srgb, var(--color-surface-alt) 88%, transparent) 100%
-  );
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 60%, transparent),
-    0 8px 18px color-mix(in srgb, var(--shadow-color) 14%, transparent);
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    transform 0.2s ease;
-}
-
-.select:hover,
-.select:focus-visible {
-  border-color: color-mix(in srgb, var(--primary-color) 60%, transparent);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 70%, transparent),
-    0 10px 24px color-mix(in srgb, var(--shadow-color) 18%, transparent);
-  transform: translateY(-1px);
-  outline: none;
 }
 
 .replay {

--- a/website/src/components/OutputToolbar/__tests__/OutputToolbar.test.jsx
+++ b/website/src/components/OutputToolbar/__tests__/OutputToolbar.test.jsx
@@ -114,26 +114,6 @@ describe("OutputToolbar", () => {
   });
 
   /**
-   * 当提供语言选项描述时应通过 title 呈现提示信息。
-   */
-  test("attaches hover hint for language options", () => {
-    render(
-      <OutputToolbar
-        term="hello"
-        sourceLanguage="AUTO"
-        sourceLanguageOptions={[
-          { value: "AUTO", label: "自动识别", description: "自动检测输入语言" },
-        ]}
-      />,
-    );
-
-    expect(screen.getByRole("combobox", { name: "源语言" })).toHaveAttribute(
-      "title",
-      "自动检测输入语言",
-    );
-  });
-
-  /**
    * 确认启用动作按钮时在工具栏中渲染并响应交互。
    */
   test("renders action buttons when permitted", () => {

--- a/website/src/components/OutputToolbar/index.jsx
+++ b/website/src/components/OutputToolbar/index.jsx
@@ -3,12 +3,6 @@ import { memo, useMemo } from "react";
 import { TtsButton } from "@/components";
 import ThemeIcon from "@/components/ui/Icon";
 import { useLanguage, useUser } from "@/context";
-import {
-  normalizeWordSourceLanguage,
-  normalizeWordTargetLanguage,
-  WORD_LANGUAGE_AUTO,
-  WORD_DEFAULT_TARGET_LANGUAGE,
-} from "@/utils";
 import styles from "./OutputToolbar.module.css";
 
 const ACTION_BLUEPRINTS = [
@@ -55,103 +49,6 @@ const ACTION_BLUEPRINTS = [
   },
 ];
 
-function LanguageGroup({
-  label,
-  options,
-  value,
-  onChange,
-  normalizeValue,
-  type,
-}) {
-  const normalizedOptions = Array.isArray(options)
-    ? options.map(({ value: optionValue, label: optionLabel, description }) => {
-        const normalizedOption = normalizeValue?.(optionValue) ?? optionValue;
-        const normalizedString =
-          normalizedOption != null ? String(normalizedOption) : "";
-        return {
-          value: normalizedString,
-          label: optionLabel,
-          description,
-        };
-      })
-    : [];
-
-  if (normalizedOptions.length === 0) {
-    return null;
-  }
-
-  const resolvedValue = normalizeValue?.(value) ?? value;
-  const normalizedValue =
-    resolvedValue != null ? String(resolvedValue) : undefined;
-  const selectValue = normalizedOptions.some(
-    ({ value: optionValue }) => optionValue === normalizedValue,
-  )
-    ? normalizedValue
-    : (normalizedOptions[0]?.value ?? "");
-  const activeOption = normalizedOptions.find(
-    ({ value: optionValue }) => optionValue === selectValue,
-  );
-  const baseId = `dictionary-${type}-language`;
-  const activeDescription = activeOption?.description;
-
-  const handleChange = (event) => {
-    const selectedValue = event?.target?.value;
-    const normalizedSelection =
-      normalizeValue?.(selectedValue) ?? selectedValue;
-    onChange?.(normalizedSelection);
-  };
-
-  return (
-    <div className={styles["language-group"]}>
-      {label ? (
-        <label className={styles["language-label"]} htmlFor={baseId}>
-          {label}
-        </label>
-      ) : null}
-      <div className={styles["select-control"]}>
-        <select
-          id={baseId}
-          className={styles.select}
-          value={selectValue}
-          onChange={handleChange}
-          title={activeDescription || undefined}
-        >
-          {normalizedOptions.map(
-            ({ value: optionValue, label: optionLabel }) => (
-              <option key={optionValue || optionLabel} value={optionValue}>
-                {optionLabel}
-              </option>
-            ),
-          )}
-        </select>
-      </div>
-    </div>
-  );
-}
-
-LanguageGroup.propTypes = {
-  label: PropTypes.string,
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
-      label: PropTypes.string.isRequired,
-      description: PropTypes.string,
-    }),
-  ),
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
-  onChange: PropTypes.func,
-  normalizeValue: PropTypes.func,
-  type: PropTypes.string.isRequired,
-};
-
-LanguageGroup.defaultProps = {
-  label: undefined,
-  options: [],
-  value: undefined,
-  onChange: undefined,
-  normalizeValue: undefined,
-};
-
 function OutputToolbar({
   term,
   lang,
@@ -161,14 +58,6 @@ function OutputToolbar({
   activeVersionId,
   onNavigate,
   ttsComponent = TtsButton,
-  sourceLanguage = WORD_LANGUAGE_AUTO,
-  sourceLanguageOptions = [],
-  onSourceLanguageChange,
-  sourceLanguageLabel,
-  targetLanguage,
-  targetLanguageOptions = [],
-  onTargetLanguageChange,
-  targetLanguageLabel,
   favorited = false,
   onToggleFavorite,
   canFavorite = false,
@@ -202,13 +91,6 @@ function OutputToolbar({
     : t.versionIndicatorEmpty || "0/0";
   const speakableTerm = typeof term === "string" ? term.trim() : term;
   const showTts = Boolean(speakableTerm);
-  const normalizedSourceLanguage = normalizeWordSourceLanguage(sourceLanguage);
-  const normalizedTargetLanguage = normalizeWordTargetLanguage(targetLanguage);
-  const showSourceSelector =
-    Array.isArray(sourceLanguageOptions) && sourceLanguageOptions.length > 0;
-  const showTargetSelector =
-    Array.isArray(targetLanguageOptions) && targetLanguageOptions.length > 0;
-  const hasLanguageSelector = showSourceSelector || showTargetSelector;
   const actionContext = useMemo(
     () => ({
       t,
@@ -267,32 +149,6 @@ function OutputToolbar({
 
   return (
     <div className={styles.toolbar} data-testid="output-toolbar">
-      {hasLanguageSelector ? (
-        <div className={styles["cluster-languages"]}>
-          <div className={styles["language-select"]}>
-            {showSourceSelector ? (
-              <LanguageGroup
-                type="source"
-                label={sourceLanguageLabel || t.dictionarySourceLanguageLabel}
-                options={sourceLanguageOptions}
-                value={normalizedSourceLanguage}
-                onChange={onSourceLanguageChange}
-                normalizeValue={normalizeWordSourceLanguage}
-              />
-            ) : null}
-            {showTargetSelector ? (
-              <LanguageGroup
-                type="target"
-                label={targetLanguageLabel || t.dictionaryTargetLanguageLabel}
-                options={targetLanguageOptions}
-                value={normalizedTargetLanguage}
-                onChange={onTargetLanguageChange}
-                normalizeValue={normalizeWordTargetLanguage}
-              />
-            ) : null}
-          </div>
-        </div>
-      ) : null}
       <div className={styles["cluster-controls"]}>
         {showTts ? (
           <TtsComponent
@@ -400,26 +256,6 @@ OutputToolbar.propTypes = {
   activeVersionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onNavigate: PropTypes.func,
   ttsComponent: PropTypes.elementType,
-  sourceLanguage: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
-  sourceLanguageOptions: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
-      label: PropTypes.string.isRequired,
-      description: PropTypes.string,
-    }),
-  ),
-  onSourceLanguageChange: PropTypes.func,
-  sourceLanguageLabel: PropTypes.string,
-  targetLanguage: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
-  targetLanguageOptions: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
-      label: PropTypes.string.isRequired,
-      description: PropTypes.string,
-    }),
-  ),
-  onTargetLanguageChange: PropTypes.func,
-  targetLanguageLabel: PropTypes.string,
   favorited: PropTypes.bool,
   onToggleFavorite: PropTypes.func,
   canFavorite: PropTypes.bool,
@@ -440,14 +276,6 @@ OutputToolbar.defaultProps = {
   activeVersionId: undefined,
   onNavigate: undefined,
   ttsComponent: TtsButton,
-  sourceLanguage: WORD_LANGUAGE_AUTO,
-  sourceLanguageOptions: [],
-  onSourceLanguageChange: undefined,
-  sourceLanguageLabel: undefined,
-  targetLanguage: WORD_DEFAULT_TARGET_LANGUAGE,
-  targetLanguageOptions: [],
-  onTargetLanguageChange: undefined,
-  targetLanguageLabel: undefined,
   favorited: false,
   onToggleFavorite: undefined,
   canFavorite: false,

--- a/website/src/components/Sidebar/Favorites.jsx
+++ b/website/src/components/Sidebar/Favorites.jsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useLanguage } from "@/context";
 import SidebarActionItem from "./SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const FALLBACK_FAVORITES_LABEL = "Favorites";
 
@@ -22,6 +23,7 @@ function Favorites({ onToggle }) {
       label={favoritesLabel}
       iconAlt={favoritesIconAlt}
       onClick={handleClick}
+      variant={SIDEBAR_ACTION_VARIANTS.prominent}
     />
   );
 }

--- a/website/src/components/Sidebar/GomemoEntry.jsx
+++ b/website/src/components/Sidebar/GomemoEntry.jsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useLanguage } from "@/context";
 import SidebarActionItem from "./SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const GOMEMO_PATH = "/gomemo";
 const FALLBACK_GOMEMO_LABEL = "Gomemo";
@@ -30,6 +31,7 @@ function GomemoEntry() {
       label={gomemoLabel}
       isActive={isActive}
       onClick={handleNavigate}
+      variant={SIDEBAR_ACTION_VARIANTS.prominent}
     />
   );
 }

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -112,14 +112,48 @@
     transform 160ms ease;
 }
 
+.sidebar-action[data-variant="prominent"] {
+  --sidebar-action-prominent-color: color-mix(
+    in srgb,
+    var(--accent-color) 60%,
+    var(--sidebar-color)
+  );
+  --sidebar-action-icon-shadow: drop-shadow(0 2px 6px rgb(15 23 42 / 18%));
+  --sidebar-action-description-color: color-mix(
+    in srgb,
+    var(--accent-color) 48%,
+    var(--sidebar-color)
+  );
+
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 38%, transparent);
+  box-shadow:
+    0 10px 28px rgb(15 23 42 / 12%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  color: var(--sidebar-action-prominent-color);
+}
+
 .sidebar-action:where(:hover, :focus-visible) {
   background-color: var(--color-overlay-weak);
   transform: translateY(-1px);
 }
 
+.sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--accent-color) 24%, transparent);
+  box-shadow:
+    0 16px 36px rgb(15 23 42 / 16%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 22%, transparent);
+  transform: translateY(-2px);
+}
+
 .sidebar-action:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent-color) 60%, transparent);
   outline-offset: 3px;
+}
+
+.sidebar-action[data-variant="prominent"]:focus-visible {
+  outline-color: color-mix(in srgb, var(--accent-color) 75%, transparent);
+  outline-offset: 4px;
 }
 
 .sidebar-user-trigger .sidebar-action {
@@ -130,12 +164,37 @@
   background-color: var(--color-overlay-inverse);
 }
 
+:root[data-theme="dark"] .sidebar-action[data-variant="prominent"] {
+  background: color-mix(in srgb, var(--accent-color) 26%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
+  box-shadow:
+    0 18px 40px rgb(2 6 23 / 24%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 24%, transparent);
+}
+
+:root[data-theme="dark"]
+  .sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
+  box-shadow:
+    0 24px 52px rgb(2 6 23 / 32%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 32%, transparent);
+}
+
 .sidebar-action-active {
   background: color-mix(in srgb, var(--sidebar-bg) 94%, transparent);
   box-shadow:
     inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 28%, transparent),
     0 4px 12px rgb(15 23 42 / 6%);
   color: color-mix(in srgb, var(--accent-color) 52%, var(--sidebar-color));
+}
+
+.sidebar-action-active[data-variant="prominent"] {
+  background: color-mix(in srgb, var(--accent-color) 30%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
+  box-shadow:
+    0 18px 48px rgb(15 23 42 / 20%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 42%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 82%, var(--sidebar-color));
 }
 
 .sidebar-action-icon {
@@ -146,7 +205,10 @@
   width: 24px;
   height: 24px;
   color: inherit;
-  filter: drop-shadow(0 1px 1px rgb(15 23 42 / 12%));
+  filter: var(
+    --sidebar-action-icon-shadow,
+    drop-shadow(0 1px 1px rgb(15 23 42 / 12%))
+  );
 }
 
 .sidebar-action-body {
@@ -184,7 +246,10 @@
 .sidebar-action-description {
   font-size: 12px;
   line-height: 1.4;
-  color: color-mix(in srgb, var(--sidebar-color) 60%, transparent);
+  color: var(
+    --sidebar-action-description-color,
+    color-mix(in srgb, var(--sidebar-color) 60%, transparent)
+  );
   letter-spacing: 0.02em;
 }
 

--- a/website/src/components/Sidebar/SidebarActionItem.jsx
+++ b/website/src/components/Sidebar/SidebarActionItem.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import ThemeIcon from "@/components/ui/Icon";
 import styles from "./Sidebar.module.css";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const joinClassName = (...tokens) => tokens.filter(Boolean).join(" ");
 
@@ -32,10 +33,17 @@ function SidebarActionItem({
   badge,
   trailing,
   isActive = false,
+  variant = SIDEBAR_ACTION_VARIANTS.default,
   className,
   onClick,
   ...rest
 }) {
+  const resolvedVariant = Object.values(SIDEBAR_ACTION_VARIANTS).includes(
+    variant,
+  )
+    ? variant
+    : SIDEBAR_ACTION_VARIANTS.default;
+
   const composedClassName = joinClassName(
     styles["sidebar-action"],
     isActive ? styles["sidebar-action-active"] : "",
@@ -70,6 +78,7 @@ function SidebarActionItem({
         type={type}
         className={composedClassName}
         onClick={onClick}
+        data-variant={resolvedVariant}
         {...rest}
       >
         {content}
@@ -78,7 +87,12 @@ function SidebarActionItem({
   }
 
   return (
-    <Component className={composedClassName} onClick={onClick} {...rest}>
+    <Component
+      className={composedClassName}
+      onClick={onClick}
+      data-variant={resolvedVariant}
+      {...rest}
+    >
       {content}
     </Component>
   );
@@ -94,6 +108,7 @@ SidebarActionItem.propTypes = {
   badge: PropTypes.node,
   trailing: PropTypes.node,
   isActive: PropTypes.bool,
+  variant: PropTypes.oneOf(Object.values(SIDEBAR_ACTION_VARIANTS)),
   className: PropTypes.string,
   onClick: PropTypes.func,
 };
@@ -107,6 +122,7 @@ SidebarActionItem.defaultProps = {
   badge: undefined,
   trailing: undefined,
   isActive: false,
+  variant: SIDEBAR_ACTION_VARIANTS.default,
   className: undefined,
   onClick: undefined,
 };

--- a/website/src/components/Sidebar/sidebarActionVariants.js
+++ b/website/src/components/Sidebar/sidebarActionVariants.js
@@ -1,0 +1,4 @@
+export const SIDEBAR_ACTION_VARIANTS = Object.freeze({
+  default: "default",
+  prominent: "prominent",
+});

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -36,7 +36,7 @@
   padding-block: var(--space-2, 8px);
 }
 
-.sidebar-brand-action {
+.sidebar-brand [data-variant="prominent"] {
   flex: 1;
   width: 100%;
 }

--- a/website/src/pages/App/index.jsx
+++ b/website/src/pages/App/index.jsx
@@ -146,28 +146,6 @@ function App() {
     setDictionarySourceLanguage,
     setDictionaryTargetLanguage,
   ]);
-  const toolbarLanguageProps = useMemo(
-    () => ({
-      sourceLanguage: dictionarySourceLanguage,
-      sourceLanguageOptions,
-      onSourceLanguageChange: setDictionarySourceLanguage,
-      sourceLanguageLabel: t.dictionarySourceLanguageLabel,
-      targetLanguage: dictionaryTargetLanguage,
-      targetLanguageOptions,
-      onTargetLanguageChange: setDictionaryTargetLanguage,
-      targetLanguageLabel: t.dictionaryTargetLanguageLabel,
-    }),
-    [
-      dictionarySourceLanguage,
-      sourceLanguageOptions,
-      setDictionarySourceLanguage,
-      t.dictionarySourceLanguageLabel,
-      dictionaryTargetLanguage,
-      targetLanguageOptions,
-      setDictionaryTargetLanguage,
-      t.dictionaryTargetLanguageLabel,
-    ],
-  );
   const abortRef = useRef(null);
   const { favorites, toggleFavorite } = useFavorites();
   const navigate = useNavigate();
@@ -740,7 +718,6 @@ function App() {
       onShare={isEntryViewActive ? handleShare : undefined}
       canReport={isTermActionable}
       onReport={isEntryViewActive ? handleReport : undefined}
-      {...toolbarLanguageProps}
     />
   );
 


### PR DESCRIPTION
## Summary
- 移除 OutputToolbar 语言切换 UI 及相关逻辑，保持工具栏布局专注于语音与版本控制
- 清理样式文件并更新 App 页面道具传递，避免冗余语言配置
- 调整配套单元测试以匹配最新的界面结构

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src
- npm test -- OutputToolbar

------
https://chatgpt.com/codex/tasks/task_e_68d5810365608332806a216588177555