### PR TITLE
Refine chat input language controls layout

### DIFF
--- a/website/src/components/Brand/index.jsx
+++ b/website/src/components/Brand/index.jsx
@@ -1,6 +1,7 @@
 import { useLanguage } from "@/context";
 import { UserMenu } from "@/components/Header";
 import SidebarActionItem from "@/components/Sidebar/SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "@/components/Sidebar/sidebarActionVariants.js";
 import { getBrandText } from "@/utils";
 
 function Brand() {
@@ -18,7 +19,7 @@ function Brand() {
         iconAlt={brandText}
         label={brandText}
         onClick={handleClick}
-        className="sidebar-brand-action"
+        variant={SIDEBAR_ACTION_VARIANTS.prominent}
       />
       <div className="mobile-user-menu">
         <UserMenu size={28} />

--- a/website/src/components/Sidebar/Favorites.jsx
+++ b/website/src/components/Sidebar/Favorites.jsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useLanguage } from "@/context";
 import SidebarActionItem from "./SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const FALLBACK_FAVORITES_LABEL = "Favorites";
 
@@ -22,6 +23,7 @@ function Favorites({ onToggle }) {
       label={favoritesLabel}
       iconAlt={favoritesIconAlt}
       onClick={handleClick}
+      variant={SIDEBAR_ACTION_VARIANTS.prominent}
     />
   );
 }

--- a/website/src/components/Sidebar/GomemoEntry.jsx
+++ b/website/src/components/Sidebar/GomemoEntry.jsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useLanguage } from "@/context";
 import SidebarActionItem from "./SidebarActionItem.jsx";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const GOMEMO_PATH = "/gomemo";
 const FALLBACK_GOMEMO_LABEL = "Gomemo";
@@ -30,6 +31,7 @@ function GomemoEntry() {
       label={gomemoLabel}
       isActive={isActive}
       onClick={handleNavigate}
+      variant={SIDEBAR_ACTION_VARIANTS.prominent}
     />
   );
 }

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -112,14 +112,48 @@
     transform 160ms ease;
 }
 
+.sidebar-action[data-variant="prominent"] {
+  --sidebar-action-prominent-color: color-mix(
+    in srgb,
+    var(--accent-color) 60%,
+    var(--sidebar-color)
+  );
+  --sidebar-action-icon-shadow: drop-shadow(0 2px 6px rgb(15 23 42 / 18%));
+  --sidebar-action-description-color: color-mix(
+    in srgb,
+    var(--accent-color) 48%,
+    var(--sidebar-color)
+  );
+
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 38%, transparent);
+  box-shadow:
+    0 10px 28px rgb(15 23 42 / 12%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  color: var(--sidebar-action-prominent-color);
+}
+
 .sidebar-action:where(:hover, :focus-visible) {
   background-color: var(--color-overlay-weak);
   transform: translateY(-1px);
 }
 
+.sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--accent-color) 24%, transparent);
+  box-shadow:
+    0 16px 36px rgb(15 23 42 / 16%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 22%, transparent);
+  transform: translateY(-2px);
+}
+
 .sidebar-action:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent-color) 60%, transparent);
   outline-offset: 3px;
+}
+
+.sidebar-action[data-variant="prominent"]:focus-visible {
+  outline-color: color-mix(in srgb, var(--accent-color) 75%, transparent);
+  outline-offset: 4px;
 }
 
 .sidebar-user-trigger .sidebar-action {
@@ -130,12 +164,37 @@
   background-color: var(--color-overlay-inverse);
 }
 
+:root[data-theme="dark"] .sidebar-action[data-variant="prominent"] {
+  background: color-mix(in srgb, var(--accent-color) 26%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
+  box-shadow:
+    0 18px 40px rgb(2 6 23 / 24%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 24%, transparent);
+}
+
+:root[data-theme="dark"]
+  .sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
+  box-shadow:
+    0 24px 52px rgb(2 6 23 / 32%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 32%, transparent);
+}
+
 .sidebar-action-active {
   background: color-mix(in srgb, var(--sidebar-bg) 94%, transparent);
   box-shadow:
     inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 28%, transparent),
     0 4px 12px rgb(15 23 42 / 6%);
   color: color-mix(in srgb, var(--accent-color) 52%, var(--sidebar-color));
+}
+
+.sidebar-action-active[data-variant="prominent"] {
+  background: color-mix(in srgb, var(--accent-color) 30%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
+  box-shadow:
+    0 18px 48px rgb(15 23 42 / 20%),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 42%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 82%, var(--sidebar-color));
 }
 
 .sidebar-action-icon {
@@ -146,7 +205,10 @@
   width: 24px;
   height: 24px;
   color: inherit;
-  filter: drop-shadow(0 1px 1px rgb(15 23 42 / 12%));
+  filter: var(
+    --sidebar-action-icon-shadow,
+    drop-shadow(0 1px 1px rgb(15 23 42 / 12%))
+  );
 }
 
 .sidebar-action-body {
@@ -184,7 +246,10 @@
 .sidebar-action-description {
   font-size: 12px;
   line-height: 1.4;
-  color: color-mix(in srgb, var(--sidebar-color) 60%, transparent);
+  color: var(
+    --sidebar-action-description-color,
+    color-mix(in srgb, var(--sidebar-color) 60%, transparent)
+  );
   letter-spacing: 0.02em;
 }
 

--- a/website/src/components/Sidebar/SidebarActionItem.jsx
+++ b/website/src/components/Sidebar/SidebarActionItem.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import ThemeIcon from "@/components/ui/Icon";
 import styles from "./Sidebar.module.css";
+import { SIDEBAR_ACTION_VARIANTS } from "./sidebarActionVariants.js";
 
 const joinClassName = (...tokens) => tokens.filter(Boolean).join(" ");
 
@@ -32,10 +33,17 @@ function SidebarActionItem({
   badge,
   trailing,
   isActive = false,
+  variant = SIDEBAR_ACTION_VARIANTS.default,
   className,
   onClick,
   ...rest
 }) {
+  const resolvedVariant = Object.values(SIDEBAR_ACTION_VARIANTS).includes(
+    variant,
+  )
+    ? variant
+    : SIDEBAR_ACTION_VARIANTS.default;
+
   const composedClassName = joinClassName(
     styles["sidebar-action"],
     isActive ? styles["sidebar-action-active"] : "",
@@ -70,6 +78,7 @@ function SidebarActionItem({
         type={type}
         className={composedClassName}
         onClick={onClick}
+        data-variant={resolvedVariant}
         {...rest}
       >
         {content}
@@ -78,7 +87,12 @@ function SidebarActionItem({
   }
 
   return (
-    <Component className={composedClassName} onClick={onClick} {...rest}>
+    <Component
+      className={composedClassName}
+      onClick={onClick}
+      data-variant={resolvedVariant}
+      {...rest}
+    >
       {content}
     </Component>
   );
@@ -94,6 +108,7 @@ SidebarActionItem.propTypes = {
   badge: PropTypes.node,
   trailing: PropTypes.node,
   isActive: PropTypes.bool,
+  variant: PropTypes.oneOf(Object.values(SIDEBAR_ACTION_VARIANTS)),
   className: PropTypes.string,
   onClick: PropTypes.func,
 };
@@ -107,6 +122,7 @@ SidebarActionItem.defaultProps = {
   badge: undefined,
   trailing: undefined,
   isActive: false,
+  variant: SIDEBAR_ACTION_VARIANTS.default,
   className: undefined,
   onClick: undefined,
 };

--- a/website/src/components/Sidebar/sidebarActionVariants.js
+++ b/website/src/components/Sidebar/sidebarActionVariants.js
@@ -1,0 +1,4 @@
+export const SIDEBAR_ACTION_VARIANTS = Object.freeze({
+  default: "default",
+  prominent: "prominent",
+});

--- a/website/src/components/__tests__/SearchBox.test.jsx
+++ b/website/src/components/__tests__/SearchBox.test.jsx
@@ -35,7 +35,18 @@ test("uses themed background with body fallback", () => {
     </SearchBox>,
   );
   const box = container.firstChild;
-  expect(getComputedStyle(box).backgroundColor).toBe(
-    "var(--chat-window-bg, var(--body-bg))",
+  expect(getComputedStyle(box).backgroundColor).toContain("color-mix");
+});
+
+/**
+ * 验证自定义 className 会被拼接进最终类名。
+ */
+test("merges custom className", () => {
+  const { container } = render(
+    <SearchBox className="extra-class">
+      <textarea data-testid="input" />
+    </SearchBox>,
   );
+  const box = container.firstChild;
+  expect(box.className).toContain("extra-class");
 });

--- a/website/src/components/ui/ChatInput/ActionInput.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput.jsx
@@ -108,24 +108,26 @@ function ActionInput({
       className={styles["input-wrapper"]}
       onSubmit={handleSubmit}
     >
-      {showLanguageControls ? (
-        <LanguageControls
-          sourceLanguage={sourceLanguage}
-          sourceLanguageOptions={sourceLanguageOptions}
-          sourceLanguageLabel={sourceLanguageLabel}
-          onSourceLanguageChange={onSourceLanguageChange}
-          targetLanguage={targetLanguage}
-          targetLanguageOptions={targetLanguageOptions}
-          targetLanguageLabel={targetLanguageLabel}
-          onTargetLanguageChange={onTargetLanguageChange}
-          onSwapLanguages={onSwapLanguages}
-          swapLabel={swapLabel}
-          normalizeSourceLanguage={normalizeSourceLanguageFn}
-          normalizeTargetLanguage={normalizeTargetLanguageFn}
-        />
-      ) : null}
-      <div className={styles["search-area"]}>
-        <SearchBox>
+      <SearchBox className={styles["input-surface"]}>
+        {showLanguageControls ? (
+          <div className={styles["leading-accessory"]}>
+            <LanguageControls
+              sourceLanguage={sourceLanguage}
+              sourceLanguageOptions={sourceLanguageOptions}
+              sourceLanguageLabel={sourceLanguageLabel}
+              onSourceLanguageChange={onSourceLanguageChange}
+              targetLanguage={targetLanguage}
+              targetLanguageOptions={targetLanguageOptions}
+              targetLanguageLabel={targetLanguageLabel}
+              onTargetLanguageChange={onTargetLanguageChange}
+              onSwapLanguages={onSwapLanguages}
+              swapLabel={swapLabel}
+              normalizeSourceLanguage={normalizeSourceLanguageFn}
+              normalizeTargetLanguage={normalizeTargetLanguageFn}
+            />
+          </div>
+        ) : null}
+        <div className={styles["input-body"]}>
           <textarea
             ref={textareaRef}
             rows={rows}
@@ -135,30 +137,32 @@ function ActionInput({
             onKeyDown={handleKeyDown}
             className={styles.textarea}
           />
-        </SearchBox>
-      </div>
-      <button
-        type={isEmpty ? "button" : "submit"}
-        className={styles["action-button"]}
-        onClick={handleClick}
-        aria-label={isEmpty ? voiceLabel : sendLabel}
-      >
-        {isEmpty ? (
-          <ThemeIcon
-            name="voice-button"
-            alt={voiceLabel}
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-          />
-        ) : (
-          <ThemeIcon
-            name="send-button"
-            alt={sendLabel}
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-          />
-        )}
-      </button>
+        </div>
+        <div className={styles["trailing-accessory"]}>
+          <button
+            type={isEmpty ? "button" : "submit"}
+            className={styles["action-button"]}
+            onClick={handleClick}
+            aria-label={isEmpty ? voiceLabel : sendLabel}
+          >
+            {isEmpty ? (
+              <ThemeIcon
+                name="voice-button"
+                alt={voiceLabel}
+                width={ICON_SIZE}
+                height={ICON_SIZE}
+              />
+            ) : (
+              <ThemeIcon
+                name="send-button"
+                alt={sendLabel}
+                width={ICON_SIZE}
+                height={ICON_SIZE}
+              />
+            )}
+          </button>
+        </div>
+      </SearchBox>
     </form>
   );
 }

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -5,28 +5,125 @@
 }
 
 .input-wrapper {
-  position: relative;
   width: 100%;
   margin: 0 auto;
+}
+
+.input-surface {
+  --padding-x: 0;
+  --padding-y: 0;
+  --slot-gap: 0;
+
+  padding: 0;
+  align-items: center;
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--color-surface) 94%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 80%, transparent) 80%,
+    color-mix(in srgb, var(--color-surface-alt) 72%, transparent) 100%
+  );
+}
+
+.leading-accessory,
+.trailing-accessory {
+  flex: 0 0 auto;
   display: flex;
-  align-items: stretch;
-  gap: var(--space-3);
+  align-items: center;
+  padding: 16px 20px;
+  min-height: 72px;
+}
+
+.leading-accessory {
+  flex: 0 1 auto;
+  min-width: 0;
+  border-right: 1px solid
+    color-mix(in srgb, var(--border-color) 38%, transparent);
+}
+
+.trailing-accessory {
+  border-left: 1px solid
+    color-mix(in srgb, var(--border-color) 32%, transparent);
+}
+
+.input-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  padding: 20px 16px;
+}
+
+.textarea {
+  width: 100%;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--color-text) 94%, transparent);
+  font-size: 1rem;
+  line-height: 1.6;
+  font-weight: 500;
+  resize: none;
+  outline: none;
+  overflow-y: auto;
+}
+
+.textarea::placeholder {
+  color: color-mix(in srgb, var(--color-text) 52%, transparent);
+}
+
+.action-button {
+  width: 56px;
+  height: 56px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 38%, transparent);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--color-surface) 98%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 74%, transparent) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 76%, transparent),
+    0 18px 34px color-mix(in srgb, var(--shadow-color) 24%, transparent);
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.action-button:hover,
+.action-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--primary-color) 52%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 82%, transparent),
+    0 22px 38px color-mix(in srgb, var(--shadow-color) 28%, transparent);
+  outline: none;
+}
+
+.action-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 48%, transparent);
+  outline-offset: 2px;
 }
 
 .language-controls {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: var(--space-2);
-  padding: 10px 14px;
+  padding: 4px 6px;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 48%, transparent);
-  background: color-mix(in srgb, var(--color-surface-alt) 88%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 68%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 36%, transparent);
   box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 65%, transparent),
-    0 12px 28px color-mix(in srgb, var(--shadow-color) 18%, transparent);
-  backdrop-filter: blur(18px);
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 78%, transparent),
+    0 10px 24px color-mix(in srgb, var(--shadow-color) 16%, transparent);
   min-width: 0;
-  flex: 0 0 auto;
 }
 
 .language-select-wrapper {
@@ -38,67 +135,65 @@
 .language-select-wrapper::after {
   content: "";
   position: absolute;
-  right: 16px;
-  width: 8px;
-  height: 8px;
-  border-right: 2px solid color-mix(in srgb, var(--color-text) 84%, transparent);
+  right: 14px;
+  width: 7px;
+  height: 7px;
+  border-right: 2px solid color-mix(in srgb, var(--color-text) 78%, transparent);
   border-bottom: 2px solid
-    color-mix(in srgb, var(--color-text) 84%, transparent);
+    color-mix(in srgb, var(--color-text) 78%, transparent);
   transform: rotate(45deg);
   pointer-events: none;
 }
 
 .language-select {
   appearance: none;
-  min-width: 132px;
-  padding: 10px 38px 10px 18px;
+  min-width: 124px;
+  padding: 9px 34px 9px 18px;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 52%, transparent);
+  border: none;
   background: linear-gradient(
-    140deg,
-    color-mix(in srgb, var(--color-surface) 94%, transparent) 0%,
-    color-mix(in srgb, var(--color-surface-alt) 82%, transparent) 100%
+    150deg,
+    color-mix(in srgb, var(--color-surface) 96%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 72%, transparent) 100%
   );
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 70%, transparent),
-    0 10px 22px color-mix(in srgb, var(--shadow-color) 16%, transparent);
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--color-surface) 84%, transparent);
   color: color-mix(in srgb, var(--color-text) 92%, transparent);
   font-size: 0.78rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.045em;
   text-transform: uppercase;
   cursor: pointer;
   transition:
-    border-color 0.2s ease,
     box-shadow 0.2s ease,
     transform 0.2s ease;
 }
 
 .language-select:hover,
 .language-select:focus-visible {
-  border-color: color-mix(in srgb, var(--primary-color) 54%, transparent);
   box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 78%, transparent),
-    0 12px 26px color-mix(in srgb, var(--shadow-color) 22%, transparent);
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 88%, transparent),
+    0 8px 18px color-mix(in srgb, var(--shadow-color) 18%, transparent);
   transform: translateY(-1px);
   outline: none;
 }
 
 .language-swap-button {
-  width: 42px;
-  height: 42px;
+  width: 40px;
+  height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 34%, transparent);
   background: linear-gradient(
-    140deg,
-    color-mix(in srgb, var(--color-surface) 96%, transparent) 0%,
-    color-mix(in srgb, var(--color-surface-alt) 76%, transparent) 100%
+    160deg,
+    color-mix(in srgb, var(--color-surface) 98%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 70%, transparent) 100%
   );
-  box-shadow: 0 10px 24px
-    color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 82%, transparent),
+    0 14px 24px color-mix(in srgb, var(--shadow-color) 18%, transparent);
   color: color-mix(in srgb, var(--color-text) 86%, transparent);
   cursor: pointer;
   transition:
@@ -107,42 +202,17 @@
     border-color 0.2s ease;
 }
 
-.language-swap-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--primary-color) 54%, transparent);
-  outline-offset: 2px;
-}
-
 .language-swap-button:hover,
 .language-swap-button:focus-visible {
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--primary-color) 48%, transparent);
-  box-shadow: 0 12px 28px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
-}
-
-.search-area {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.textarea {
-  width: 100%;
-  border: none;
-  padding: 0;
+  border-color: color-mix(in srgb, var(--primary-color) 50%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface) 86%, transparent),
+    0 16px 28px color-mix(in srgb, var(--shadow-color) 22%, transparent);
   outline: none;
-  font-size: 1rem;
-  line-height: 1.5;
-  resize: none;
-  background: transparent;
 }
 
-.action-button {
-  position: absolute;
-  right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  border: none;
-  background: none;
-  padding: 8px;
-  cursor: pointer;
+.language-swap-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 46%, transparent);
+  outline-offset: 2px;
 }

--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -1,11 +1,21 @@
-/* scrollable wrapper for multi-line inputs */
+/* scrollable wrapper for multi-slot chat inputs */
 .search-box {
+  position: relative;
+  display: flex;
+  align-items: stretch;
   width: 100%;
-  padding: var(--padding-y, var(--search-box-padding-y)) 56px
-    var(--padding-y, var(--search-box-padding-y)) 20px;
+  padding: var(--padding-y, var(--search-box-padding-y))
+    var(--padding-x, var(--search-box-padding-x, 24px));
   border-radius: var(--radius-xl);
-  box-shadow: 0 2px 4px var(--shadow-color);
-  background-color: var(--chat-window-bg, var(--body-bg));
-  overflow-y: auto;
+  box-shadow: 0 14px 38px
+    color-mix(in srgb, var(--shadow-color) 14%, transparent);
+  background-color: color-mix(
+    in srgb,
+    var(--chat-window-bg, var(--body-bg)) 96%,
+    transparent
+  );
+  backdrop-filter: blur(18px);
+  gap: var(--slot-gap, var(--space-3, 12px));
+  overflow: hidden;
   box-sizing: border-box;
 }

--- a/website/src/components/ui/SearchBox/index.jsx
+++ b/website/src/components/ui/SearchBox/index.jsx
@@ -6,10 +6,14 @@ import styles from "./SearchBox.module.css";
  * 通过 CSS 变量 `--padding-y` 可灵活调整上下间距，
  * 默认值由主题变量 `--search-box-padding-y` 提供。
  */
-export default function SearchBox({ children, paddingY }) {
+export default function SearchBox({ children, paddingY, className }) {
   const style = paddingY ? { "--padding-y": paddingY } : undefined;
+  const classNames = [styles["search-box"], className]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div className={styles["search-box"]} style={style}>
+    <div className={classNames} style={style}>
       {children}
     </div>
   );
@@ -18,4 +22,5 @@ export default function SearchBox({ children, paddingY }) {
 SearchBox.propTypes = {
   children: PropTypes.node.isRequired,
   paddingY: PropTypes.string,
+  className: PropTypes.string,
 };

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -36,7 +36,7 @@
   padding-block: var(--space-2, 8px);
 }
 
-.sidebar-brand-action {
+.sidebar-brand [data-variant="prominent"] {
   flex: 1;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- embed the language controls directly into the chat search surface so the selector mirrors the send button and aligns with the textarea
- refresh the chat input styling with a cohesive gradient surface, balanced paddings, and elevated control treatments for button and selector states
- enhance the shared SearchBox wrapper with flexible class support and updated unit coverage for the new styling contract

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .
- npm run test -- SearchBox

------
https://chatgpt.com/codex/tasks/task_e_68d5815558dc833291b4a21335697719