### PR TITLE
feat: add resilient avatar fallback

### DIFF
--- a/website/src/components/ui/Avatar/Avatar.jsx
+++ b/website/src/components/ui/Avatar/Avatar.jsx
@@ -1,30 +1,87 @@
 import { useUser } from "@/context";
-import { useMemo } from "react";
+import { useMemo, useState, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
 import { cacheBust } from "@/utils";
 import ThemeIcon from "@/components/ui/Icon";
 import styles from "./Avatar.module.css";
 
+const ELEVATIONS = Object.freeze({
+  soft: "soft",
+  none: "none",
+});
+
+const VISUAL_SLOT = "avatar-visual";
+
 // 基于当前主题切换默认头像
-function Avatar({ src, alt = "User Avatar", ...props }) {
+function Avatar({
+  src,
+  alt = "User Avatar",
+  className,
+  onError,
+  elevation = ELEVATIONS.soft,
+  ...props
+}) {
   const { user } = useUser();
   const finalSrc = src || user?.avatar;
-  const displaySrc = useMemo(
-    () => (finalSrc ? cacheBust(finalSrc) : null),
-    [finalSrc],
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    setHasError(false);
+  }, [finalSrc]);
+
+  const mergedClassName = useMemo(
+    () => [styles.avatar, className].filter(Boolean).join(" "),
+    [className],
   );
-  if (finalSrc) {
+
+  const displaySrc = useMemo(() => {
+    if (!finalSrc || hasError) {
+      return null;
+    }
+    return cacheBust(finalSrc);
+  }, [finalSrc, hasError]);
+
+  const handleImageError = useCallback(
+    (event) => {
+      setHasError(true);
+      if (typeof onError === "function") {
+        onError(event);
+      }
+    },
+    [onError],
+  );
+
+  if (displaySrc) {
     return (
-      <img src={displaySrc} alt={alt} className={styles.avatar} {...props} />
+      <img
+        src={displaySrc}
+        alt={alt}
+        className={mergedClassName}
+        onError={handleImageError}
+        data-elevation={elevation}
+        data-slot={VISUAL_SLOT}
+        {...props}
+      />
     );
   }
   return (
     <ThemeIcon
       name="default-user-avatar"
       alt={alt}
-      className={styles.avatar}
+      className={mergedClassName}
+      data-elevation={elevation}
+      data-slot={VISUAL_SLOT}
       {...props}
     />
   );
 }
 
 export default Avatar;
+
+Avatar.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string,
+  className: PropTypes.string,
+  onError: PropTypes.func,
+  elevation: PropTypes.oneOf(Object.values(ELEVATIONS)),
+};

--- a/website/src/components/ui/Avatar/Avatar.module.css
+++ b/website/src/components/ui/Avatar/Avatar.module.css
@@ -2,4 +2,10 @@
   border-radius: var(--radius-avatar);
   object-fit: cover;
   box-shadow: 0 0 4px var(--shadow-color);
+  display: block;
+  transition: box-shadow 0.2s ease;
+}
+
+.avatar[data-elevation="none"] {
+  box-shadow: none;
 }

--- a/website/src/pages/profile/Profile.module.css
+++ b/website/src/pages/profile/Profile.module.css
@@ -30,11 +30,10 @@
   box-shadow: 0 24px 40px rgb(0 0 0 / 18%);
 }
 
-.avatar-area img {
+.profile-avatar[data-slot="avatar-visual"] {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  border-radius: var(--radius-avatar);
+  display: block;
 }
 
 .avatar-hint {

--- a/website/src/pages/profile/index.jsx
+++ b/website/src/pages/profile/index.jsx
@@ -228,15 +228,11 @@ function Profile({ onCancel }) {
       <h2>{t.profileTitle}</h2>
       <form onSubmit={handleSave} className={styles["profile-card"]}>
         <div className={styles["avatar-area"]}>
-          {avatar && typeof avatar === "string" ? (
-            <img src={avatar} alt="avatar" />
-          ) : (
-            <Avatar
-              width={100}
-              height={100}
-              style={{ borderRadius: "var(--radius-xl)" }}
-            />
-          )}
+          <Avatar
+            src={typeof avatar === "string" && avatar ? avatar : undefined}
+            className={styles["profile-avatar"]}
+            elevation="none"
+          />
           <span className={styles["avatar-hint"]}>{t.avatarHint}</span>
           <input
             type="file"


### PR DESCRIPTION
## Summary
- make the shared Avatar component resilient to broken image sources and expose elevation controls
- update the profile page to always consume the Avatar component so user portraits fall back to the default svg

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/ui/Avatar/Avatar.jsx src/components/ui/Avatar/Avatar.module.css src/pages/profile/index.jsx src/pages/profile/Profile.module.css
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68d584d5c1b8833297cf3e1764047cda