### PR TITLE
feat: respect dictionary flavor for localized outputs

### DIFF
--- a/backend/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.dto;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -16,4 +17,6 @@ public class SearchRecordRequest {
 
     @NotNull(message = "{validation.searchRecord.language.notnull}")
     private Language language;
+
+    private DictionaryFlavor flavor = DictionaryFlavor.BILINGUAL;
 }

--- a/backend/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.dto;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +13,7 @@ public record SearchRecordResponse(
     Long userId,
     String term,
     Language language,
+    DictionaryFlavor flavor,
     LocalDateTime createdAt,
     Boolean favorite,
     SearchRecordVersionSummary latestVersion,
@@ -30,6 +32,7 @@ public record SearchRecordResponse(
             userId,
             term,
             language,
+            flavor,
             createdAt,
             favorite,
             latest,

--- a/backend/src/main/java/com/glancy/backend/dto/SearchRecordVersionSummary.java
+++ b/backend/src/main/java/com/glancy/backend/dto/SearchRecordVersionSummary.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.dto;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import java.time.LocalDateTime;
 
 /**
@@ -10,5 +11,6 @@ public record SearchRecordVersionSummary(
     Integer versionNumber,
     LocalDateTime createdAt,
     String model,
-    String preview
+    String preview,
+    DictionaryFlavor flavor
 ) {}

--- a/backend/src/main/java/com/glancy/backend/dto/WordResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/WordResponse.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.dto;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -25,4 +26,5 @@ public class WordResponse {
     private String markdown;
     private Long versionId;
     private PersonalizedWordExplanation personalization;
+    private DictionaryFlavor flavor;
 }

--- a/backend/src/main/java/com/glancy/backend/entity/DictionaryFlavor.java
+++ b/backend/src/main/java/com/glancy/backend/entity/DictionaryFlavor.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.entity;
+
+/**
+ * Dictionary output modes that control how entries should be rendered.
+ */
+public enum DictionaryFlavor {
+    /**
+     * Bilingual presentation mixing English explanations with supporting Chinese context.
+     */
+    BILINGUAL,
+
+    /**
+     * Monolingual English presentation without any translated content.
+     */
+    MONOLINGUAL_ENGLISH;
+
+    public static DictionaryFlavor fromNullable(String raw, DictionaryFlavor fallback) {
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        try {
+            return DictionaryFlavor.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return fallback;
+        }
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/entity/SearchRecord.java
+++ b/backend/src/main/java/com/glancy/backend/entity/SearchRecord.java
@@ -26,6 +26,10 @@ public class SearchRecord extends BaseEntity {
     @Column(nullable = false, length = 10)
     private Language language;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private DictionaryFlavor flavor = DictionaryFlavor.BILINGUAL;
+
     @Column(nullable = false)
     private Boolean favorite = false;
 }

--- a/backend/src/main/java/com/glancy/backend/entity/SearchResultVersion.java
+++ b/backend/src/main/java/com/glancy/backend/entity/SearchResultVersion.java
@@ -34,6 +34,10 @@ public class SearchResultVersion extends BaseEntity {
     @Column(nullable = false, length = 10)
     private Language language;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private DictionaryFlavor flavor = DictionaryFlavor.BILINGUAL;
+
     @Column(nullable = false, length = 64)
     private String model;
 

--- a/backend/src/main/java/com/glancy/backend/entity/Word.java
+++ b/backend/src/main/java/com/glancy/backend/entity/Word.java
@@ -11,7 +11,10 @@ import lombok.NoArgsConstructor;
  * Dictionary word entry cached from the external service.
  */
 @Entity
-@Table(name = "words", uniqueConstraints = @UniqueConstraint(columnNames = { "term", "language" }))
+@Table(
+    name = "words",
+    uniqueConstraints = @UniqueConstraint(columnNames = { "term", "language", "flavor" })
+)
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
@@ -53,6 +56,10 @@ public class Word extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
     private Language language;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private DictionaryFlavor flavor = DictionaryFlavor.BILINGUAL;
 
     @Column(length = 100)
     private String phonetic;

--- a/backend/src/main/java/com/glancy/backend/llm/config/LLMConfig.java
+++ b/backend/src/main/java/com/glancy/backend/llm/config/LLMConfig.java
@@ -1,10 +1,12 @@
 package com.glancy.backend.llm.config;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import java.util.Map;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Data
 @Component
@@ -16,6 +18,7 @@ public class LLMConfig {
     private Map<String, String> apiKeys;
     private String promptPath = "prompts/english_to_chinese.txt";
     private Map<String, String> promptPaths;
+    private Map<String, Map<String, String>> promptFlavorPaths;
 
     public String resolvePromptPath(Language language) {
         if (promptPaths != null && language != null) {
@@ -26,5 +29,26 @@ public class LLMConfig {
             }
         }
         return promptPath;
+    }
+
+    public String resolvePromptPath(Language language, DictionaryFlavor flavor) {
+        if (language != null && flavor != null && promptFlavorPaths != null) {
+            String languageKey = language.name();
+            Map<String, String> flavorMap = promptFlavorPaths.get(languageKey);
+            if (flavorMap == null) {
+                flavorMap = promptFlavorPaths.get(languageKey.toLowerCase());
+            }
+            if (flavorMap != null) {
+                String flavorKey = flavor.name();
+                String candidate = flavorMap.get(flavorKey);
+                if (!StringUtils.hasText(candidate)) {
+                    candidate = flavorMap.get(flavorKey.toLowerCase());
+                }
+                if (StringUtils.hasText(candidate)) {
+                    return candidate;
+                }
+            }
+        }
+        return resolvePromptPath(language);
     }
 }

--- a/backend/src/main/java/com/glancy/backend/llm/parser/JacksonWordResponseParser.java
+++ b/backend/src/main/java/com/glancy/backend/llm/parser/JacksonWordResponseParser.java
@@ -75,6 +75,7 @@ public class JacksonWordResponseParser implements WordResponseParser {
             phrases,
             markdown,
             null,
+            null,
             null
         );
         return new ParsedWord(response, markdown);
@@ -95,6 +96,7 @@ public class JacksonWordResponseParser implements WordResponseParser {
             snapshot.related(),
             snapshot.phrases(),
             markdown,
+            null,
             null,
             null
         );

--- a/backend/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
@@ -2,6 +2,7 @@ package com.glancy.backend.llm.service;
 
 import com.glancy.backend.dto.WordPersonalizationContext;
 import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import reactor.core.publisher.Flux;
 
@@ -9,6 +10,7 @@ public interface WordSearcher {
     WordResponse search(
         String term,
         Language language,
+        DictionaryFlavor flavor,
         String clientName,
         WordPersonalizationContext personalizationContext
     );
@@ -16,6 +18,7 @@ public interface WordSearcher {
     Flux<String> streamSearch(
         String term,
         Language language,
+        DictionaryFlavor flavor,
         String clientName,
         WordPersonalizationContext personalizationContext
     );

--- a/backend/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
+++ b/backend/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.repository;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
 import java.time.LocalDateTime;
@@ -19,12 +20,18 @@ public interface SearchRecordRepository extends JpaRepository<SearchRecord, Long
 
     long countByUserIdAndDeletedFalseAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
-    boolean existsByUserIdAndTermAndLanguageAndDeletedFalse(Long userId, String term, Language language);
-
-    SearchRecord findTopByUserIdAndTermAndLanguageAndDeletedFalseOrderByCreatedAtDesc(
+    boolean existsByUserIdAndTermAndLanguageAndFlavorAndDeletedFalse(
         Long userId,
         String term,
-        Language language
+        Language language,
+        DictionaryFlavor flavor
+    );
+
+    SearchRecord findTopByUserIdAndTermAndLanguageAndFlavorAndDeletedFalseOrderByCreatedAtDesc(
+        Long userId,
+        String term,
+        Language language,
+        DictionaryFlavor flavor
     );
 
     java.util.Optional<SearchRecord> findByIdAndUserIdAndDeletedFalse(Long id, Long userId);

--- a/backend/src/main/java/com/glancy/backend/repository/WordRepository.java
+++ b/backend/src/main/java/com/glancy/backend/repository/WordRepository.java
@@ -1,5 +1,6 @@
 package com.glancy.backend.repository;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.Word;
 import java.util.Optional;
@@ -11,5 +12,9 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface WordRepository extends JpaRepository<Word, Long> {
-    Optional<Word> findByTermAndLanguageAndDeletedFalse(String term, Language language);
+    Optional<Word> findByTermAndLanguageAndFlavorAndDeletedFalse(
+        String term,
+        Language language,
+        DictionaryFlavor flavor
+    );
 }

--- a/backend/src/main/java/com/glancy/backend/service/SearchResultService.java
+++ b/backend/src/main/java/com/glancy/backend/service/SearchResultService.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.service;
 
 import com.glancy.backend.dto.SearchRecordVersionSummary;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
 import com.glancy.backend.entity.SearchResultVersion;
@@ -46,7 +47,8 @@ public class SearchResultService {
         Language language,
         String model,
         String content,
-        Word word
+        Word word,
+        DictionaryFlavor flavor
     ) {
         Objects.requireNonNull(recordId, "recordId must not be null");
         Objects.requireNonNull(userId, "userId must not be null");
@@ -73,17 +75,19 @@ public class SearchResultService {
         version.setTerm(effectiveTerm);
         version.setLanguage(effectiveLanguage);
         version.setModel(effectiveModel);
+        version.setFlavor(flavor != null ? flavor : DictionaryFlavor.BILINGUAL);
         version.setVersionNumber(nextVersionNumber);
         version.setContent(content);
         version.setPreview(SensitiveDataUtil.previewText(content));
 
         SearchResultVersion saved = searchResultVersionRepository.save(version);
         log.info(
-            "Persisted search result version {} for record {} (term='{}', language={}, model={}, versionNumber={})",
+            "Persisted search result version {} for record {} (term='{}', language={}, flavor={}, model={}, versionNumber={})",
             saved.getId(),
             recordId,
             saved.getTerm(),
             saved.getLanguage(),
+            saved.getFlavor(),
             saved.getModel(),
             saved.getVersionNumber()
         );
@@ -159,7 +163,8 @@ public class SearchResultService {
             version.getVersionNumber(),
             version.getCreatedAt(),
             version.getModel(),
-            version.getPreview()
+            version.getPreview(),
+            version.getFlavor()
         );
     }
 }

--- a/backend/src/main/java/com/glancy/backend/service/gomemo/GomemoWordPrioritizer.java
+++ b/backend/src/main/java/com/glancy/backend/service/gomemo/GomemoWordPrioritizer.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.service.gomemo;
 
 import com.glancy.backend.config.GomemoProperties;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.GomemoSession;
 import com.glancy.backend.entity.GomemoSessionWord;
 import com.glancy.backend.entity.Language;
@@ -119,7 +120,11 @@ public class GomemoWordPrioritizer {
         GomemoProperties.Scoring scoring
     ) {
         Word word = wordRepository
-            .findByTermAndLanguageAndDeletedFalse(candidate.term, candidate.language)
+            .findByTermAndLanguageAndFlavorAndDeletedFalse(
+                candidate.term,
+                candidate.language,
+                DictionaryFlavor.BILINGUAL
+            )
             .orElse(null);
         List<String> rationales = new ArrayList<>();
         int score = scoring.getBaseScore();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -58,6 +58,9 @@ llm:
   prompt-paths:
     ENGLISH: prompts/english_to_chinese.txt
     CHINESE: prompts/chinese_to_english_markdown.txt
+  prompt-flavor-paths:
+    ENGLISH:
+      MONOLINGUAL_ENGLISH: prompts/english_to_english.txt
 
 gomemo:
   default-daily-target: 12

--- a/backend/src/main/resources/prompts/english_to_english.txt
+++ b/backend/src/main/resources/prompts/english_to_english.txt
@@ -1,0 +1,49 @@
+You are an elite monolingual English lexicographer crafting entries for discerning learners.
+Output pure Markdown (no tables, no code fences) following the structure and rules below. If a section
+lacks confident data, omit it entirely. Always end the response with the sentinel <END>.
+
+## Parameters (override via prompt variables)
+- min_examples_per_sense: {min_examples_per_sense=2}
+- max_examples_per_sense: {max_examples_per_sense=3}
+- max_senses: {max_senses=10}
+- max_collocations: {max_collocations=6}
+- max_idioms: {max_idioms=6}
+- max_patterns: {max_patterns=6}
+
+## Global Rules
+1. Produce only English content. Do **not** include Chinese characters, pinyin, or translations.
+2. Respect the Markdown hierarchy exactly as specified, keeping tone polished and instructive.
+3. Provide phonetic transcription in IPA using slashes (e.g., /ˈdignɪti/), including British and American lines.
+4. Enumerate senses as s1, s2, … up to `max_senses`. Each sense must provide the part of speech and a concise
+yet nuanced definition.
+5. Supply between `min_examples_per_sense` and `max_examples_per_sense` examples for every sense. Structure each example as:
+   - **Example n**: {English sentence}
+     **Usage Insight**: {Concise commentary on tone, register, or nuance}
+6. Summaries, collocations, idioms, derivatives, usage notes, and patterns must align with the selected senses.
+Reference the originating sense with `[ref: s#]` markers where relevant.
+7. Maintain terminology consistent with high-end British & American editorial standards.
+8. Conclude with `<END>` as the final line.
+
+## Output Layout
+- # Entry: {term}
+- ## Pronunciation
+  - British: /ˈ.../
+  - American: /ˈ.../
+- ## Core Definition Overview
+  - Premium one-sentence synopsis of the word's essence.
+- ## Senses
+  - ### s# Definition ({part_of_speech_abbr}. {part_of_speech_full}): {definition}
+    - **Register**: {formal / informal / technical / etc.}
+    - **Nuance**: {subtle guidance on emotional color or usage}
+    - **Examples**: list of examples as specified above
+- ## Collocations & Patterns (optional)
+  - Bullet list with `[ref: s#]` markers.
+- ## Idioms & Set Phrases (optional)
+  - Bullet list with explanations and `[ref: s#]` markers.
+- ## Derivatives & Morphology (optional)
+  - Bullet list with succinct descriptions.
+- ## Usage Notes (optional)
+  - Address common confusions, register alerts, or stylistic finesse.
+- ## Practice Prompts (optional)
+  - Provide 2–3 actionable exercises fully in English.
+- <END>

--- a/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.glancy.backend.dto.SearchRecordRequest;
 import com.glancy.backend.dto.SearchRecordResponse;
 import com.glancy.backend.dto.SearchRecordVersionSummary;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.service.SearchRecordService;
 import com.glancy.backend.service.UserService;
@@ -46,12 +47,14 @@ class SearchRecordControllerTest {
     @Test
     void testCreate() throws Exception {
         LocalDateTime createdAt = LocalDateTime.now();
-        SearchRecordVersionSummary version = new SearchRecordVersionSummary(2L, 1, createdAt, "gpt-4", "preview");
+        SearchRecordVersionSummary version =
+            new SearchRecordVersionSummary(2L, 1, createdAt, "gpt-4", "preview", DictionaryFlavor.BILINGUAL);
         SearchRecordResponse resp = new SearchRecordResponse(
             1L,
             1L,
             "hello",
             Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
             createdAt,
             false,
             version,
@@ -80,19 +83,28 @@ class SearchRecordControllerTest {
     @Test
     void testList() throws Exception {
         LocalDateTime createdAt = LocalDateTime.now();
-        SearchRecordVersionSummary latestVersion = new SearchRecordVersionSummary(3L, 2, createdAt, "gpt-4", "preview");
+        SearchRecordVersionSummary latestVersion = new SearchRecordVersionSummary(
+            3L,
+            2,
+            createdAt,
+            "gpt-4",
+            "preview",
+            DictionaryFlavor.BILINGUAL
+        );
         SearchRecordVersionSummary previousVersion = new SearchRecordVersionSummary(
             4L,
             1,
             createdAt.minusMinutes(1),
             "gpt-3.5",
-            "older"
+            "older",
+            DictionaryFlavor.BILINGUAL
         );
         SearchRecordResponse resp = new SearchRecordResponse(
             1L,
             1L,
             "hello",
             Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
             createdAt,
             true,
             latestVersion,

--- a/backend/src/test/java/com/glancy/backend/controller/SearchResultVersionControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/SearchResultVersionControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.glancy.backend.dto.SearchRecordVersionSummary;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
 import com.glancy.backend.entity.SearchResultVersion;
@@ -56,7 +57,8 @@ class SearchResultVersionControllerTest {
             2,
             LocalDateTime.now(),
             "model-x",
-            "sample"
+            "sample",
+            DictionaryFlavor.BILINGUAL
         );
         when(searchResultService.listVersionSummaries(eq(1L), eq(10L))).thenReturn(List.of(summary));
 
@@ -84,6 +86,7 @@ class SearchResultVersionControllerTest {
         version.setUser(user);
         version.setTerm("term");
         version.setLanguage(Language.ENGLISH);
+        version.setFlavor(DictionaryFlavor.BILINGUAL);
         version.setModel("model-y");
         version.setVersionNumber(3);
         version.setContent("full content");

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.service.UserService;
 import com.glancy.backend.service.WordService;
@@ -57,9 +58,19 @@ class WordControllerTest {
             List.of(),
             null,
             null,
-            null
+            null,
+            DictionaryFlavor.BILINGUAL
         );
-        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null), eq(false))).thenReturn(
+        when(
+            wordService.findWordForUser(
+                eq(1L),
+                eq("hello"),
+                eq(Language.ENGLISH),
+                eq(DictionaryFlavor.BILINGUAL),
+                eq(null),
+                eq(false)
+            )
+        ).thenReturn(
             resp
         );
 
@@ -98,10 +109,18 @@ class WordControllerTest {
             List.of(),
             null,
             null,
-            null
+            null,
+            DictionaryFlavor.BILINGUAL
         );
         when(
-            wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq("doubao"), eq(false))
+            wordService.findWordForUser(
+                eq(1L),
+                eq("hello"),
+                eq(Language.ENGLISH),
+                eq(DictionaryFlavor.BILINGUAL),
+                eq("doubao"),
+                eq(false)
+            )
         ).thenReturn(resp);
 
         when(userService.authenticateToken("tkn")).thenReturn(1L);
@@ -169,9 +188,19 @@ class WordControllerTest {
             List.of(),
             null,
             null,
-            null
+            null,
+            DictionaryFlavor.BILINGUAL
         );
-        when(wordService.findWordForUser(eq(1L), eq("hi"), eq(Language.ENGLISH), eq(null), eq(false))).thenReturn(resp);
+        when(
+            wordService.findWordForUser(
+                eq(1L),
+                eq("hi"),
+                eq(Language.ENGLISH),
+                eq(DictionaryFlavor.BILINGUAL),
+                eq(null),
+                eq(false)
+            )
+        ).thenReturn(resp);
 
         mockMvc
             .perform(

--- a/backend/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import com.glancy.backend.dto.WordPersonalizationContext;
 import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.llm.config.LLMConfig;
 import com.glancy.backend.llm.llm.LLMClient;
@@ -68,7 +69,13 @@ class WordSearcherImplTest {
         expected.setMarkdown("content");
         when(parser.parse("content", "hello", Language.ENGLISH)).thenReturn(new ParsedWord(expected, "content"));
         WordSearcherImpl searcher = new WordSearcherImpl(factory, config, promptManager, searchContentManager, parser);
-        WordResponse result = searcher.search("hello", Language.ENGLISH, "invalid", NO_PERSONALIZATION_CONTEXT);
+        WordResponse result = searcher.search(
+            "hello",
+            Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
+            "invalid",
+            NO_PERSONALIZATION_CONTEXT
+        );
 
         assertSame(expected, result);
         verify(factory).get("invalid");
@@ -86,7 +93,13 @@ class WordSearcherImplTest {
         when(factory.get("doubao")).thenReturn(null);
         WordSearcherImpl searcher = new WordSearcherImpl(factory, config, promptManager, searchContentManager, parser);
         assertThrows(IllegalStateException.class, () ->
-            searcher.search("hi", Language.ENGLISH, "invalid", NO_PERSONALIZATION_CONTEXT)
+            searcher.search(
+                "hi",
+                Language.ENGLISH,
+                DictionaryFlavor.BILINGUAL,
+                "invalid",
+                NO_PERSONALIZATION_CONTEXT
+            )
         );
     }
 
@@ -103,7 +116,7 @@ class WordSearcherImplTest {
         when(parser.parse("content<END>", "汉", Language.CHINESE)).thenReturn(new ParsedWord(expected, "content<END>"));
 
         WordSearcherImpl searcher = new WordSearcherImpl(factory, config, promptManager, searchContentManager, parser);
-        searcher.search("汉", Language.CHINESE, "doubao", NO_PERSONALIZATION_CONTEXT);
+        searcher.search("汉", Language.CHINESE, DictionaryFlavor.BILINGUAL, "doubao", NO_PERSONALIZATION_CONTEXT);
 
         ArgumentCaptor<List<ChatMessage>> messagesCaptor = ArgumentCaptor.forClass(List.class);
         verify(defaultClient).chat(messagesCaptor.capture(), eq(0.5));

--- a/backend/src/test/java/com/glancy/backend/repository/SearchRecordRepositoryTest.java
+++ b/backend/src/test/java/com/glancy/backend/repository/SearchRecordRepositoryTest.java
@@ -2,6 +2,7 @@ package com.glancy.backend.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
 import com.glancy.backend.entity.User;
@@ -56,10 +57,11 @@ class SearchRecordRepositoryTest {
         assertEquals(2, count);
 
         assertTrue(
-            searchRecordRepository.existsByUserIdAndTermAndLanguageAndDeletedFalse(
+            searchRecordRepository.existsByUserIdAndTermAndLanguageAndFlavorAndDeletedFalse(
                 user.getId(),
                 "term1",
-                Language.ENGLISH
+                Language.ENGLISH,
+                DictionaryFlavor.BILINGUAL
             )
         );
 
@@ -70,11 +72,13 @@ class SearchRecordRepositoryTest {
             LocalDateTime.now().plusMinutes(1)
         );
         searchRecordRepository.save(r3);
-        SearchRecord top = searchRecordRepository.findTopByUserIdAndTermAndLanguageAndDeletedFalseOrderByCreatedAtDesc(
-            user.getId(),
-            "term1",
-            Language.ENGLISH
-        );
+        SearchRecord top =
+            searchRecordRepository.findTopByUserIdAndTermAndLanguageAndFlavorAndDeletedFalseOrderByCreatedAtDesc(
+                user.getId(),
+                "term1",
+                Language.ENGLISH,
+                DictionaryFlavor.BILINGUAL
+            );
         assertEquals(r3.getId(), top.getId());
 
         assertTrue(searchRecordRepository.findByIdAndUserIdAndDeletedFalse(r1.getId(), user.getId()).isPresent());

--- a/backend/src/test/java/com/glancy/backend/repository/TestEntityFactory.java
+++ b/backend/src/test/java/com/glancy/backend/repository/TestEntityFactory.java
@@ -26,6 +26,7 @@ final class TestEntityFactory {
         record.setUser(user);
         record.setTerm(term);
         record.setLanguage(language);
+        record.setFlavor(DictionaryFlavor.BILINGUAL);
         record.setCreatedAt(createdAt);
         return record;
     }
@@ -34,6 +35,7 @@ final class TestEntityFactory {
         Word word = new Word();
         word.setTerm(term);
         word.setLanguage(language);
+        word.setFlavor(DictionaryFlavor.BILINGUAL);
         word.setDefinitions(Collections.singletonList("def"));
         return word;
     }

--- a/backend/src/test/java/com/glancy/backend/repository/WordRepositoryTest.java
+++ b/backend/src/test/java/com/glancy/backend/repository/WordRepositoryTest.java
@@ -2,6 +2,7 @@ package com.glancy.backend.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.Word;
 import java.util.Optional;
@@ -16,11 +17,15 @@ class WordRepositoryTest {
     private WordRepository wordRepository;
 
     @Test
-    void findByTermAndLanguageAndDeletedFalse() {
+    void findByTermAndLanguageAndFlavorAndDeletedFalse() {
         Word word = TestEntityFactory.word("hello", Language.ENGLISH);
         wordRepository.save(word);
 
-        Optional<Word> found = wordRepository.findByTermAndLanguageAndDeletedFalse("hello", Language.ENGLISH);
+        Optional<Word> found = wordRepository.findByTermAndLanguageAndFlavorAndDeletedFalse(
+            "hello",
+            Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL
+        );
         assertTrue(found.isPresent());
         assertEquals("hello", found.get().getTerm());
     }

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.glancy.backend.dto.PersonalizedWordExplanation;
 import com.glancy.backend.dto.SearchRecordResponse;
 import com.glancy.backend.dto.WordPersonalizationContext;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.Word;
 import com.glancy.backend.llm.parser.WordResponseParser;
@@ -92,11 +93,12 @@ class WordServiceStreamingErrorTest {
     @Test
     void wrapsExceptionFromSearcher() {
         when(searchRecordService.saveRecord(eq(1L), any())).thenReturn(sampleRecordResponse());
-        when(wordSearcher.streamSearch(any(), any(), any(), any())).thenThrow(new RuntimeException("boom"));
+        when(wordSearcher.streamSearch(any(), any(), any(), any(), any())).thenThrow(new RuntimeException("boom"));
         Flux<WordService.StreamPayload> result = wordService.streamWordForUser(
             1L,
             "hello",
             Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
             null,
             false
         );
@@ -111,6 +113,7 @@ class WordServiceStreamingErrorTest {
             1L,
             "hello",
             Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
             LocalDateTime.now(),
             Boolean.FALSE,
             null,

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -3,6 +3,7 @@ package com.glancy.backend.service;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.Word;
@@ -77,7 +78,14 @@ class WordServiceTest {
      */
     @Test
     void testFetchAndCacheWord() {
-        WordResponse result = wordService.findWordForUser(userId, "hello", Language.ENGLISH, null, false);
+        WordResponse result = wordService.findWordForUser(
+            userId,
+            "hello",
+            Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
+            null,
+            false
+        );
 
         assertNotNull(result.getId());
         assertTrue(wordRepository.findById(Long.parseLong(result.getId())).isPresent());
@@ -91,11 +99,19 @@ class WordServiceTest {
         Word word = new Word();
         word.setTerm("cached");
         word.setLanguage(Language.ENGLISH);
+        word.setFlavor(DictionaryFlavor.BILINGUAL);
         word.setDefinitions(List.of("store"));
         word.setMarkdown("md");
         wordRepository.save(word);
 
-        WordResponse result = wordService.findWordForUser(userId, "cached", Language.ENGLISH, null, false);
+        WordResponse result = wordService.findWordForUser(
+            userId,
+            "cached",
+            Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
+            null,
+            false
+        );
 
         assertEquals(String.valueOf(word.getId()), result.getId());
         assertEquals("md", result.getMarkdown());
@@ -106,10 +122,25 @@ class WordServiceTest {
      */
     @Test
     void testCacheWordWhenLanguageMissing() {
-        WordResponse result = wordService.findWordForUser(userId, "bye", Language.ENGLISH, null, false);
+        WordResponse result = wordService.findWordForUser(
+            userId,
+            "bye",
+            Language.ENGLISH,
+            DictionaryFlavor.BILINGUAL,
+            null,
+            false
+        );
 
         assertEquals(Language.ENGLISH, result.getLanguage());
-        assertTrue(wordRepository.findByTermAndLanguageAndDeletedFalse("bye", Language.ENGLISH).isPresent());
+        assertTrue(
+            wordRepository
+                .findByTermAndLanguageAndFlavorAndDeletedFalse(
+                    "bye",
+                    Language.ENGLISH,
+                    DictionaryFlavor.BILINGUAL
+                )
+                .isPresent()
+        );
     }
 
     /**
@@ -120,17 +151,35 @@ class WordServiceTest {
         Word wordEn = new Word();
         wordEn.setTerm("hello");
         wordEn.setLanguage(Language.ENGLISH);
+        wordEn.setFlavor(DictionaryFlavor.BILINGUAL);
         wordEn.setDefinitions(List.of("greet"));
         wordRepository.save(wordEn);
 
         Word wordZh = new Word();
         wordZh.setTerm("hello");
         wordZh.setLanguage(Language.CHINESE);
+        wordZh.setFlavor(DictionaryFlavor.BILINGUAL);
         wordZh.setDefinitions(List.of("\u4f60\u597d"));
 
         assertDoesNotThrow(() -> wordRepository.save(wordZh));
 
-        assertTrue(wordRepository.findByTermAndLanguageAndDeletedFalse("hello", Language.ENGLISH).isPresent());
-        assertTrue(wordRepository.findByTermAndLanguageAndDeletedFalse("hello", Language.CHINESE).isPresent());
+        assertTrue(
+            wordRepository
+                .findByTermAndLanguageAndFlavorAndDeletedFalse(
+                    "hello",
+                    Language.ENGLISH,
+                    DictionaryFlavor.BILINGUAL
+                )
+                .isPresent()
+        );
+        assertTrue(
+            wordRepository
+                .findByTermAndLanguageAndFlavorAndDeletedFalse(
+                    "hello",
+                    Language.CHINESE,
+                    DictionaryFlavor.BILINGUAL
+                )
+                .isPresent()
+        );
     }
 }

--- a/backend/src/test/java/com/glancy/backend/service/gomemo/GomemoWordPrioritizerTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/gomemo/GomemoWordPrioritizerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.glancy.backend.config.GomemoProperties;
 import com.glancy.backend.entity.GomemoSession;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
 import com.glancy.backend.entity.Word;
@@ -71,15 +72,29 @@ class GomemoWordPrioritizerTest {
         Word innovationWord = new Word();
         innovationWord.setTerm("innovation");
         innovationWord.setLanguage(Language.ENGLISH);
+        innovationWord.setFlavor(DictionaryFlavor.BILINGUAL);
         innovationWord.setDefinitions(List.of("business innovation in design"));
         Word strategyWord = new Word();
         strategyWord.setTerm("strategy");
         strategyWord.setLanguage(Language.ENGLISH);
+        strategyWord.setFlavor(DictionaryFlavor.BILINGUAL);
         strategyWord.setDefinitions(List.of("long-term corporate planning"));
-        when(wordRepository.findByTermAndLanguageAndDeletedFalse("innovation", Language.ENGLISH)).thenReturn(
+        when(
+            wordRepository.findByTermAndLanguageAndFlavorAndDeletedFalse(
+                "innovation",
+                Language.ENGLISH,
+                DictionaryFlavor.BILINGUAL
+            )
+        ).thenReturn(
             java.util.Optional.of(innovationWord)
         );
-        when(wordRepository.findByTermAndLanguageAndDeletedFalse("strategy", Language.ENGLISH)).thenReturn(
+        when(
+            wordRepository.findByTermAndLanguageAndFlavorAndDeletedFalse(
+                "strategy",
+                Language.ENGLISH,
+                DictionaryFlavor.BILINGUAL
+            )
+        ).thenReturn(
             java.util.Optional.of(strategyWord)
         );
         when(wordRepository.findAll(any(PageRequest.class))).thenReturn(new PageImpl<>(List.of()));

--- a/backend/src/test/java/com/glancy/backend/service/personalization/DefaultWordPersonalizationServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/personalization/DefaultWordPersonalizationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.glancy.backend.dto.PersonalizedWordExplanation;
 import com.glancy.backend.dto.WordPersonalizationContext;
 import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.DictionaryFlavor;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
 import com.glancy.backend.entity.User;
@@ -80,7 +81,8 @@ class DefaultWordPersonalizationServiceTest {
             List.of("financial leverage"),
             "# leverage",
             null,
-            null
+            null,
+            DictionaryFlavor.BILINGUAL
         );
 
         WordPersonalizationContext context = service.resolveContext(1L);

--- a/website/src/api/words.js
+++ b/website/src/api/words.js
@@ -73,10 +73,12 @@ export function createWordsApi(request = apiRequest) {
     flavor = WORD_FLAVOR_BILINGUAL,
     token,
   }) => {
-    const key = resolveKey({ term, language, flavor, model });
+    const resolvedFlavor = flavor ?? WORD_FLAVOR_BILINGUAL;
+    const key = resolveKey({ term, language, flavor: resolvedFlavor, model });
     const cached = store.getState().getEntry(key);
     if (cached) return cached;
-    const params = new URLSearchParams({ userId, term, language, flavor });
+    const params = new URLSearchParams({ userId, term, language });
+    if (resolvedFlavor) params.append("flavor", resolvedFlavor);
     if (model) params.append("model", model);
     const result = await request(`${API_PATHS.words}?${params.toString()}`, {
       token,
@@ -114,7 +116,9 @@ export function createWordsApi(request = apiRequest) {
     forceNew = false,
     versionId,
   }) {
-    const params = new URLSearchParams({ userId, term, language, flavor });
+    const resolvedFlavor = flavor ?? WORD_FLAVOR_BILINGUAL;
+    const params = new URLSearchParams({ userId, term, language });
+    if (resolvedFlavor) params.append("flavor", resolvedFlavor);
     if (model) params.append("model", model);
     if (forceNew) params.append("forceNew", "true");
     if (versionId) params.append("versionId", versionId);

--- a/website/src/hooks/useFetchWord.js
+++ b/website/src/hooks/useFetchWord.js
@@ -1,5 +1,9 @@
 import { useApi } from "@/hooks/useApi.js";
-import { resolveWordLanguage, WORD_LANGUAGE_AUTO } from "@/utils";
+import {
+  resolveWordLanguage,
+  WORD_LANGUAGE_AUTO,
+  WORD_FLAVOR_BILINGUAL,
+} from "@/utils";
 import { DEFAULT_MODEL } from "@/config";
 
 export function useFetchWord() {
@@ -11,19 +15,32 @@ export function useFetchWord() {
     term,
     model = DEFAULT_MODEL,
     language = WORD_LANGUAGE_AUTO,
+    flavor = WORD_FLAVOR_BILINGUAL,
   }) => {
     const resolvedLanguage = resolveWordLanguage(term, language);
+    const resolvedFlavor = flavor ?? WORD_FLAVOR_BILINGUAL;
     try {
       const data = await fetchWord({
         userId: user.id,
         term,
         language: resolvedLanguage,
+        flavor: resolvedFlavor,
         model,
         token: user.token,
       });
-      return { data, error: null, language: resolvedLanguage };
+      return {
+        data,
+        error: null,
+        language: resolvedLanguage,
+        flavor: resolvedFlavor,
+      };
     } catch (error) {
-      return { data: null, error, language: resolvedLanguage };
+      return {
+        data: null,
+        error,
+        language: resolvedLanguage,
+        flavor: resolvedFlavor,
+      };
     }
   };
 


### PR DESCRIPTION
## Summary
- introduce `DictionaryFlavor` to distinguish bilingual and monolingual dictionary entries and persist the flavor across words, search records, and result versions
- propagate flavor through controllers, services, repositories, and LLM orchestration so cached and streamed results honour both source and target language settings
- extend prompt resolution with flavor-aware overrides and add an English-only prompt template for monolingual requests, updating tests accordingly

## Testing
- `mvn spotless:apply` *(fails: requires downloading plugins/dependencies from Maven Central, network unreachable in container)*
- `mvn test` *(fails: requires downloading dependencies from Maven Central, network unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5860f7b448332a07a2fe5bf444711