### PR TITLE
Refine preferences layout and popup aesthetics

### DIFF
--- a/website/src/components/ui/MessagePopup/MessagePopup.jsx
+++ b/website/src/components/ui/MessagePopup/MessagePopup.jsx
@@ -1,4 +1,5 @@
 import styles from "./MessagePopup.module.css";
+import { useLanguage } from "@/context";
 import { useEscapeKey } from "@/hooks";
 import { withStopPropagation } from "@/utils/stopPropagation.js";
 
@@ -7,16 +8,29 @@ import { withStopPropagation } from "@/utils/stopPropagation.js";
  * Accepts optional children for action buttons.
  */
 function MessagePopup({ open, message, onClose, children }) {
+  const { t } = useLanguage();
+  const closeLabel = t.close;
   useEscapeKey(onClose, open);
 
   if (!open) return null;
   return (
     <div className={styles["popup-overlay"]} onClick={onClose}>
-      <div className={styles.popup} onClick={withStopPropagation()}>
-        <div>{message}</div>
+      <div
+        className={styles.popup}
+        onClick={withStopPropagation()}
+        role="alertdialog"
+        aria-modal="true"
+      >
+        <div className={styles.message}>{message}</div>
         {children && <div className={styles.actions}>{children}</div>}
-        <button type="button" onClick={onClose} className={styles["close-btn"]}>
-          Close
+        <button
+          type="button"
+          onClick={onClose}
+          className={styles["close-btn"]}
+          aria-label={closeLabel}
+        >
+          <span className={styles["close-btn-icon"]} aria-hidden="true" />
+          <span className={styles["close-btn-label"]}>{closeLabel}</span>
         </button>
       </div>
     </div>

--- a/website/src/components/ui/MessagePopup/MessagePopup.module.css
+++ b/website/src/components/ui/MessagePopup/MessagePopup.module.css
@@ -1,27 +1,129 @@
-.close-btn {
-  margin-top: var(--space-3);
-}
-
 .popup-overlay {
   position: fixed;
   inset: 0;
-  background: var(--color-overlay);
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
+  padding: clamp(var(--space-5), 6vw, var(--space-7));
+  background: color-mix(in srgb, var(--color-overlay) 80%, transparent);
+  backdrop-filter: blur(18px);
   z-index: 1000;
 }
 
 .popup {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
-  max-width: 300px;
-  width: 90%;
+  display: grid;
+  gap: clamp(var(--space-3), 3vw, var(--space-4));
+  width: min(420px, 100%);
+  padding: clamp(var(--space-4), 4vw, var(--space-6));
+  border-radius: var(--radius-xxl);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--app-bg) 96%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface-alt) 78%, transparent) 100%
+  );
+  border: 1px solid color-mix(in srgb, var(--border-color) 48%, transparent);
+  box-shadow: 0 40px 120px
+    color-mix(in srgb, var(--shadow-color) 32%, transparent);
   text-align: center;
+  color: var(--color-text);
+}
+
+.message {
+  font-size: clamp(var(--text-sm), 2.6vw, var(--text-base));
+  line-height: 1.6;
+  letter-spacing: 0.01em;
 }
 
 .actions {
-  margin-top: var(--space-3);
+  display: flex;
+  justify-content: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 0.75rem 1.6rem;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary-bg) 94%, transparent) 0%,
+    color-mix(in srgb, var(--primary-bg) 74%, transparent) 100%
+  );
+  color: var(--primary-color);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 26px 64px
+    color-mix(in srgb, var(--shadow-color) 28%, transparent);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+.close-btn-icon {
+  position: relative;
+  inline-size: 28px;
+  block-size: 28px;
+  border-radius: 50%;
+  background: color-mix(in srgb, currentcolor 14%, transparent);
+  display: grid;
+  place-items: center;
+}
+
+.close-btn-icon::before,
+.close-btn-icon::after {
+  content: "";
+  position: absolute;
+  inline-size: 12px;
+  block-size: 2px;
+  background: currentcolor;
+  border-radius: 999px;
+}
+
+.close-btn-icon::before {
+  transform: rotate(45deg);
+}
+
+.close-btn-icon::after {
+  transform: rotate(-45deg);
+}
+
+.close-btn-label {
+  letter-spacing: inherit;
+}
+
+.close-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 32px 80px
+    color-mix(in srgb, var(--shadow-color) 34%, transparent);
+}
+
+.close-btn:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--highlight-color) 30%, transparent),
+    0 32px 80px color-mix(in srgb, var(--shadow-color) 36%, transparent);
+}
+
+.close-btn:active {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popup-overlay {
+    backdrop-filter: none;
+  }
+
+  .close-btn {
+    transition: none;
+  }
 }

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -4,42 +4,45 @@
 }
 
 .section {
-  margin: 0;
-  padding: 0;
-  border: none;
   display: grid;
-  gap: clamp(var(--space-3), 3vw, var(--space-4));
-  min-inline-size: 0;
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
+  padding: clamp(var(--space-4), 3vw, var(--space-5));
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--app-bg) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 34%, transparent);
+  box-shadow: 0 28px 72px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
+}
+
+.section-header {
+  display: grid;
+  gap: var(--space-2);
 }
 
 .section-title {
   margin: 0;
-  padding: 0;
   font-size: var(--text-xs);
   font-weight: var(--font-semibold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+  color: color-mix(in srgb, var(--color-text) 74%, transparent);
 }
 
 .section-description {
   margin: 0;
   font-size: var(--text-sm);
   line-height: 1.6;
-  color: color-mix(in srgb, var(--color-text) 56%, transparent);
+  color: color-mix(in srgb, var(--color-text) 58%, transparent);
 }
 
 .section-fields {
   display: grid;
   gap: clamp(var(--space-3), 3vw, var(--space-4));
+  align-items: end;
 }
 
-.section-fields-split {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.section-voices {
-  background: none;
+.section-wide {
+  grid-column: 1 / -1;
 }
 
 .field {
@@ -53,32 +56,29 @@
   --form-label-text-transform: uppercase;
   --form-label-weight: var(--font-medium);
   --form-label-width: auto;
+  --form-row-gap: var(--space-2);
 
-  display: grid;
-  gap: var(--space-2);
-  padding: clamp(var(--space-3), 2.5vw, var(--space-4));
-  border-radius: var(--radius-xl);
-  background: color-mix(in srgb, var(--app-bg) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 45%, transparent);
-  box-shadow: 0 20px 48px
-    color-mix(in srgb, var(--shadow-color) 18%, transparent);
-  transition:
-    border-color 160ms ease,
-    box-shadow 160ms ease,
-    transform 160ms ease;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
 }
 
-.field:hover {
-  transform: translateY(-2px);
-  border-color: color-mix(in srgb, var(--border-color) 65%, transparent);
-  box-shadow: 0 24px 56px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
+@media (width >= 640px) {
+  .section-fields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
-.field:focus-within {
-  border-color: color-mix(in srgb, var(--highlight-color) 68%, transparent);
-  box-shadow: 0 26px 60px
-    color-mix(in srgb, var(--shadow-color) 28%, transparent);
+@media (width >= 960px) {
+  .sections {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .section-wide {
+    grid-column: span 2;
+  }
 }
 
 .submit-button {
@@ -123,15 +123,4 @@
 
 .submit-button:active {
   transform: translateY(0);
-}
-
-@media (width >= 960px) {
-  .sections {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: start;
-  }
-
-  .section-voices {
-    grid-column: span 2;
-  }
 }

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -193,7 +193,118 @@ function Preferences({ variant = VARIANTS.PAGE }) {
       ? SETTINGS_SURFACE_VARIANTS.PAGE
       : SETTINGS_SURFACE_VARIANTS.MODAL;
 
-  const splitFieldsClassName = `${styles["section-fields"]} ${styles["section-fields-split"]}`;
+  const preferenceSections = useMemo(
+    () => [
+      {
+        id: "languages",
+        title: t.prefDefaultsTitle,
+        description: t.prefDefaultsDescription,
+        fields: [
+          {
+            key: "source-language",
+            label: t.prefLanguage,
+            id: "source-lang",
+            node: (
+              <SelectField
+                value={sourceLang}
+                onChange={setSourceLang}
+                options={languageOptions}
+              />
+            ),
+          },
+          {
+            key: "target-language",
+            label: t.prefSearchLanguage,
+            id: "target-lang",
+            node: (
+              <SelectField
+                value={targetLang}
+                onChange={setTargetLang}
+                options={searchLanguageOptions}
+              />
+            ),
+          },
+        ],
+      },
+      {
+        id: "interface",
+        title: t.prefInterfaceTitle,
+        description: t.prefInterfaceDescription,
+        fields: [
+          {
+            key: "system-language",
+            label: t.prefSystemLanguage,
+            id: "system-language",
+            node: (
+              <SelectField
+                value={systemLanguage}
+                onChange={handleSystemLanguageChange}
+                options={systemLanguageOptions}
+              />
+            ),
+          },
+          {
+            key: "theme",
+            label: t.prefTheme,
+            id: "theme-select",
+            node: (
+              <SelectField
+                value={theme}
+                onChange={setTheme}
+                options={themeOptions}
+              />
+            ),
+          },
+        ],
+      },
+      {
+        id: "voices",
+        title: t.prefVoicesTitle,
+        description: t.prefVoicesDescription,
+        span: "wide",
+        fields: [
+          {
+            key: "voice-en",
+            label: t.prefVoiceEn,
+            id: "voice-en",
+            node: <VoiceSelector lang="en" />,
+          },
+          {
+            key: "voice-zh",
+            label: t.prefVoiceZh,
+            id: "voice-zh",
+            node: <VoiceSelector lang="zh" />,
+          },
+        ],
+      },
+    ],
+    [
+      handleSystemLanguageChange,
+      languageOptions,
+      searchLanguageOptions,
+      setSourceLang,
+      setTargetLang,
+      setTheme,
+      sourceLang,
+      systemLanguage,
+      systemLanguageOptions,
+      targetLang,
+      t.prefDefaultsDescription,
+      t.prefDefaultsTitle,
+      t.prefInterfaceDescription,
+      t.prefInterfaceTitle,
+      t.prefLanguage,
+      t.prefSearchLanguage,
+      t.prefSystemLanguage,
+      t.prefTheme,
+      t.prefVoiceEn,
+      t.prefVoiceZh,
+      t.prefVoicesDescription,
+      t.prefVoicesTitle,
+      theme,
+      themeOptions,
+    ],
+  );
 
   return (
     <>
@@ -209,96 +320,46 @@ function Preferences({ variant = VARIANTS.PAGE }) {
         }
       >
         <div className={styles.sections}>
-          <fieldset className={styles.section}>
-            <legend className={styles["section-title"]}>
-              {t.prefDefaultsTitle}
-            </legend>
-            <p className={styles["section-description"]}>
-              {t.prefDefaultsDescription}
-            </p>
-            <div className={splitFieldsClassName}>
-              <FormRow
-                label={t.prefLanguage}
-                id="source-lang"
-                className={styles.field}
-              >
-                <SelectField
-                  value={sourceLang}
-                  onChange={setSourceLang}
-                  options={languageOptions}
-                />
-              </FormRow>
-              <FormRow
-                label={t.prefSearchLanguage}
-                id="target-lang"
-                className={styles.field}
-              >
-                <SelectField
-                  value={targetLang}
-                  onChange={setTargetLang}
-                  options={searchLanguageOptions}
-                />
-              </FormRow>
-            </div>
-          </fieldset>
+          {preferenceSections.map((section) => {
+            const sectionClassName = [
+              styles.section,
+              section.span === "wide" ? styles["section-wide"] : "",
+            ]
+              .filter(Boolean)
+              .join(" ");
 
-          <fieldset className={styles.section}>
-            <legend className={styles["section-title"]}>
-              {t.prefInterfaceTitle}
-            </legend>
-            <p className={styles["section-description"]}>
-              {t.prefInterfaceDescription}
-            </p>
-            <div className={splitFieldsClassName}>
-              <FormRow
-                label={t.prefSystemLanguage}
-                id="system-language"
-                className={styles.field}
+            return (
+              <section
+                key={section.id}
+                className={sectionClassName}
+                aria-labelledby={`${section.id}-title`}
               >
-                <SelectField
-                  value={systemLanguage}
-                  onChange={handleSystemLanguageChange}
-                  options={systemLanguageOptions}
-                />
-              </FormRow>
-              <FormRow
-                label={t.prefTheme}
-                id="theme-select"
-                className={styles.field}
-              >
-                <SelectField
-                  value={theme}
-                  onChange={setTheme}
-                  options={themeOptions}
-                />
-              </FormRow>
-            </div>
-          </fieldset>
-
-          <fieldset className={`${styles.section} ${styles["section-voices"]}`}>
-            <legend className={styles["section-title"]}>
-              {t.prefVoicesTitle}
-            </legend>
-            <p className={styles["section-description"]}>
-              {t.prefVoicesDescription}
-            </p>
-            <div className={splitFieldsClassName}>
-              <FormRow
-                label={t.prefVoiceEn}
-                id="voice-en"
-                className={styles.field}
-              >
-                <VoiceSelector lang="en" />
-              </FormRow>
-              <FormRow
-                label={t.prefVoiceZh}
-                id="voice-zh"
-                className={styles.field}
-              >
-                <VoiceSelector lang="zh" />
-              </FormRow>
-            </div>
-          </fieldset>
+                <header className={styles["section-header"]}>
+                  <h3
+                    id={`${section.id}-title`}
+                    className={styles["section-title"]}
+                  >
+                    {section.title}
+                  </h3>
+                  <p className={styles["section-description"]}>
+                    {section.description}
+                  </p>
+                </header>
+                <div className={styles["section-fields"]}>
+                  {section.fields.map((field) => (
+                    <FormRow
+                      key={field.key}
+                      label={field.label}
+                      id={field.id}
+                      className={styles.field}
+                    >
+                      {field.node}
+                    </FormRow>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
         </div>
       </SettingsSurface>
       <MessagePopup


### PR DESCRIPTION
## Summary
- restructure the preferences form into reusable section metadata so paired controls share a single row
- refresh section styling to remove the nested card layer while preserving a high-end, responsive grid layout
- redesign the message popup close control with localized labeling and premium visual detailing

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/pages/preferences/index.jsx src/pages/preferences/Preferences.module.css src/components/ui/MessagePopup/MessagePopup.jsx src/components/ui/MessagePopup/MessagePopup.module.css

------
https://chatgpt.com/codex/tasks/task_e_68d586be2dbc8332a1592de623eb2616