### PR TITLE
Refine front-end composition architecture

### DIFF
--- a/website/src/components/providers/AppProviders/index.jsx
+++ b/website/src/components/providers/AppProviders/index.jsx
@@ -1,0 +1,36 @@
+import { Suspense } from "react";
+import PropTypes from "prop-types";
+import ErrorBoundary from "@/components/ui/ErrorBoundary";
+import Loader from "@/components/ui/Loader";
+import AuthWatcher from "@/components/AuthWatcher";
+import CookieConsent from "@/components/CookieConsent";
+import {
+  LanguageProvider,
+  ThemeProvider,
+  AppProvider,
+  ApiProvider,
+} from "@/context";
+
+function AppProviders({ children }) {
+  return (
+    <AppProvider>
+      <ApiProvider>
+        <LanguageProvider>
+          <ThemeProvider>
+            <CookieConsent />
+            <AuthWatcher />
+            <ErrorBoundary>
+              <Suspense fallback={<Loader />}>{children}</Suspense>
+            </ErrorBoundary>
+          </ThemeProvider>
+        </LanguageProvider>
+      </ApiProvider>
+    </AppProvider>
+  );
+}
+
+AppProviders.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default AppProviders;

--- a/website/src/components/system/ViewportHeightUpdater/index.jsx
+++ b/website/src/components/system/ViewportHeightUpdater/index.jsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+const VH_CUSTOM_PROPERTY = "--vh";
+
+function ViewportHeightUpdater() {
+  useEffect(() => {
+    const updateViewportHeight = () => {
+      document.documentElement.style.setProperty(
+        VH_CUSTOM_PROPERTY,
+        `${window.innerHeight}px`,
+      );
+    };
+
+    updateViewportHeight();
+    window.addEventListener("resize", updateViewportHeight, { passive: true });
+
+    return () => {
+      window.removeEventListener("resize", updateViewportHeight);
+    };
+  }, []);
+
+  return null;
+}
+
+export default ViewportHeightUpdater;

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -1,71 +1,21 @@
-import { StrictMode, Suspense, lazy, useEffect } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import ErrorBoundary from "./components/ui/ErrorBoundary";
+import { BrowserRouter } from "react-router-dom";
+import AppProviders from "@/components/providers/AppProviders";
+import ViewportHeightUpdater from "@/components/system/ViewportHeightUpdater";
+import AppRouter from "@/routes/AppRouter";
+import registerServiceWorker from "@/utils/registerServiceWorker";
 import "./styles/index.css";
-import Loader from "./components/ui/Loader";
-import AuthWatcher from "./components/AuthWatcher";
-import CookieConsent from "./components/CookieConsent";
-import FallbackRedirect from "./components/FallbackRedirect.jsx";
-
-const App = lazy(() => import("./pages/App"));
-const Gomemo = lazy(() => import("./pages/Gomemo"));
-const Login = lazy(() => import("./pages/auth/Login"));
-const Register = lazy(() => import("./pages/auth/Register"));
-import {
-  LanguageProvider,
-  ThemeProvider,
-  AppProvider,
-  ApiProvider,
-} from "@/context";
-
-// eslint-disable-next-line react-refresh/only-export-components
-function ViewportHeightUpdater() {
-  useEffect(() => {
-    const updateVh = () => {
-      document.documentElement.style.setProperty(
-        "--vh",
-        `${window.innerHeight}px`,
-      );
-    };
-    updateVh();
-    window.addEventListener("resize", updateVh);
-    return () => window.removeEventListener("resize", updateVh);
-  }, []);
-  return null;
-}
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
       <ViewportHeightUpdater />
-      <AppProvider>
-        <ApiProvider>
-          <LanguageProvider>
-            <ThemeProvider>
-              <CookieConsent />
-              <AuthWatcher />
-              <ErrorBoundary>
-                <Suspense fallback={<Loader />}>
-                  <Routes>
-                    <Route path="/gomemo" element={<Gomemo />} />
-                    <Route path="/login" element={<Login />} />
-                    <Route path="/register" element={<Register />} />
-                    <Route path="/" element={<App />} />
-                    <Route path="*" element={<FallbackRedirect />} />
-                  </Routes>
-                </Suspense>
-              </ErrorBoundary>
-            </ThemeProvider>
-          </LanguageProvider>
-        </ApiProvider>
-      </AppProvider>
+      <AppProviders>
+        <AppRouter />
+      </AppProviders>
     </BrowserRouter>
   </StrictMode>,
 );
 
-if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/sw.js");
-  });
-}
+registerServiceWorker();

--- a/website/src/routes/AppRouter.jsx
+++ b/website/src/routes/AppRouter.jsx
@@ -1,0 +1,22 @@
+import { useMemo } from "react";
+import { useRoutes } from "react-router-dom";
+import ROUTES_BLUEPRINT from "./config";
+
+function AppRouter() {
+  const routes = useMemo(
+    () =>
+      ROUTES_BLUEPRINT.map(({ path, component }) => {
+        const RouteComponent = component;
+
+        return {
+          path,
+          element: <RouteComponent />,
+        };
+      }),
+    [],
+  );
+
+  return useRoutes(routes);
+}
+
+export default AppRouter;

--- a/website/src/routes/config.js
+++ b/website/src/routes/config.js
@@ -1,0 +1,26 @@
+import { lazy } from "react";
+
+export const ROUTES_BLUEPRINT = Object.freeze([
+  {
+    path: "/",
+    component: lazy(() => import("@/pages/App")),
+  },
+  {
+    path: "/gomemo",
+    component: lazy(() => import("@/pages/Gomemo")),
+  },
+  {
+    path: "/login",
+    component: lazy(() => import("@/pages/auth/Login")),
+  },
+  {
+    path: "/register",
+    component: lazy(() => import("@/pages/auth/Register")),
+  },
+  {
+    path: "*",
+    component: lazy(() => import("@/components/FallbackRedirect.jsx")),
+  },
+]);
+
+export default ROUTES_BLUEPRINT;

--- a/website/src/utils/registerServiceWorker.js
+++ b/website/src/utils/registerServiceWorker.js
@@ -1,0 +1,26 @@
+const SERVICE_WORKER_PATH = "/sw.js";
+let isRegistrationQueued = false;
+
+function queueServiceWorkerRegistration(path = SERVICE_WORKER_PATH) {
+  if (isRegistrationQueued || typeof window === "undefined") {
+    return;
+  }
+
+  if (!("serviceWorker" in navigator)) {
+    return;
+  }
+
+  isRegistrationQueued = true;
+
+  window.addEventListener("load", async () => {
+    try {
+      await navigator.serviceWorker.register(path);
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error("Service worker registration failed", error);
+      }
+    }
+  });
+}
+
+export default queueServiceWorkerRegistration;


### PR DESCRIPTION
## Summary
- consolidate application providers and suspense handling into a dedicated component to minimise re-renders and centralise global concerns
- introduce a declarative router configuration with memoised route objects for leaner navigation orchestration and bundle-friendly lazy loading
- extract viewport height tracking and service worker registration into focused utilities for clearer responsibilities and reuse

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .

------
https://chatgpt.com/codex/tasks/task_e_68d5ff1f95308332b54e301e61922df1