### PR TITLE
Optimize search record version assembly

### DIFF
--- a/backend/src/main/java/com/glancy/backend/entity/Word.java
+++ b/backend/src/main/java/com/glancy/backend/entity/Word.java
@@ -11,10 +11,7 @@ import lombok.NoArgsConstructor;
  * Dictionary word entry cached from the external service.
  */
 @Entity
-@Table(
-    name = "words",
-    uniqueConstraints = @UniqueConstraint(columnNames = { "term", "language", "flavor" })
-)
+@Table(name = "words", uniqueConstraints = @UniqueConstraint(columnNames = { "term", "language", "flavor" }))
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)

--- a/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
@@ -156,9 +156,7 @@ public class WordSearcherImpl implements WordSearcher {
         if (flavorInstruction != null) {
             messages.add(new ChatMessage("system", flavorInstruction));
         }
-        messages.add(
-            new ChatMessage("user", renderUserPayload(cleanInput, personalizationContext, language, flavor))
-        );
+        messages.add(new ChatMessage("user", renderUserPayload(cleanInput, personalizationContext, language, flavor)));
         return messages;
     }
 

--- a/backend/src/main/java/com/glancy/backend/repository/SearchResultVersionRepository.java
+++ b/backend/src/main/java/com/glancy/backend/repository/SearchResultVersionRepository.java
@@ -20,6 +20,10 @@ public interface SearchResultVersionRepository extends JpaRepository<SearchResul
 
     Optional<SearchResultVersion> findByIdAndSearchRecordIdAndDeletedFalse(Long id, Long searchRecordId);
 
+    List<SearchResultVersion> findBySearchRecordIdInAndDeletedFalseOrderBySearchRecordIdAscVersionNumberDesc(
+        Collection<Long> recordIds
+    );
+
     @Modifying(clearAutomatically = true)
     @Query(
         "update SearchResultVersion v set v.deleted = true where v.searchRecord.id = :recordId and v.deleted = false"

--- a/backend/src/main/java/com/glancy/backend/service/WordService.java
+++ b/backend/src/main/java/com/glancy/backend/service/WordService.java
@@ -6,8 +6,8 @@ import com.glancy.backend.dto.SearchRecordRequest;
 import com.glancy.backend.dto.SearchRecordResponse;
 import com.glancy.backend.dto.WordPersonalizationContext;
 import com.glancy.backend.dto.WordResponse;
-import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.entity.DictionaryFlavor;
+import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchResultVersion;
 import com.glancy.backend.entity.UserPreference;
@@ -104,11 +104,7 @@ public class WordService {
             return Mono.empty();
         }
         try {
-            ParsedWord parsed = parser.parse(
-                completion.sanitizedContent(),
-                session.term(),
-                session.language()
-            );
+            ParsedWord parsed = parser.parse(completion.sanitizedContent(), session.term(), session.language());
             WordResponse response = applyPersonalization(
                 session.userId(),
                 parsed.parsed(),
@@ -203,26 +199,10 @@ public class WordService {
                     return applyPersonalization(userId, response, personalizationContext);
                 })
                 .orElseGet(() ->
-                    fetchAndPersistWord(
-                        userId,
-                        term,
-                        language,
-                        flavor,
-                        resolvedModel,
-                        record,
-                        personalizationContext
-                    )
+                    fetchAndPersistWord(userId, term, language, flavor, resolvedModel, record, personalizationContext)
                 );
         }
-        return fetchAndPersistWord(
-            userId,
-            term,
-            language,
-            flavor,
-            resolvedModel,
-            record,
-            personalizationContext
-        );
+        return fetchAndPersistWord(userId, term, language, flavor, resolvedModel, record, personalizationContext);
     }
 
     /**
@@ -473,10 +453,9 @@ public class WordService {
         String term = resp.getTerm() != null ? resp.getTerm() : requestedTerm;
         Language lang = resp.getLanguage() != null ? resp.getLanguage() : language;
         DictionaryFlavor resolvedFlavor = resp.getFlavor() != null ? resp.getFlavor() : flavor;
-        Word word =
-            wordRepository
-                .findByTermAndLanguageAndFlavorAndDeletedFalse(term, lang, resolvedFlavor)
-                .orElseGet(Word::new);
+        Word word = wordRepository
+            .findByTermAndLanguageAndFlavorAndDeletedFalse(term, lang, resolvedFlavor)
+            .orElseGet(Word::new);
         word.setTerm(term);
         word.setLanguage(lang);
         word.setFlavor(resolvedFlavor);

--- a/backend/src/main/java/com/glancy/backend/service/support/SearchRecordViewAssembler.java
+++ b/backend/src/main/java/com/glancy/backend/service/support/SearchRecordViewAssembler.java
@@ -1,0 +1,59 @@
+package com.glancy.backend.service.support;
+
+import com.glancy.backend.dto.SearchRecordResponse;
+import com.glancy.backend.dto.SearchRecordVersionSummary;
+import com.glancy.backend.entity.SearchRecord;
+import com.glancy.backend.mapper.SearchRecordMapper;
+import com.glancy.backend.service.SearchResultService;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * Assembles {@link SearchRecordResponse} instances with version metadata in a batch-aware fashion.
+ */
+@Component
+public class SearchRecordViewAssembler {
+
+    private final SearchRecordMapper searchRecordMapper;
+    private final SearchResultService searchResultService;
+
+    public SearchRecordViewAssembler(SearchRecordMapper searchRecordMapper, SearchResultService searchResultService) {
+        this.searchRecordMapper = searchRecordMapper;
+        this.searchResultService = searchResultService;
+    }
+
+    public SearchRecordResponse assembleSingle(Long userId, SearchRecord record) {
+        if (record == null) {
+            return null;
+        }
+        List<SearchRecordResponse> responses = assemble(userId, List.of(record));
+        return responses.isEmpty() ? null : responses.get(0);
+    }
+
+    public List<SearchRecordResponse> assemble(Long userId, List<SearchRecord> records) {
+        if (records == null || records.isEmpty()) {
+            return List.of();
+        }
+        List<Long> recordIds = extractRecordIds(records);
+        Map<Long, List<SearchRecordVersionSummary>> groupedVersions =
+            searchResultService.listVersionSummariesByRecordIds(recordIds);
+        return records
+            .stream()
+            .map(record -> toResponse(record, groupedVersions.getOrDefault(record.getId(), List.of())))
+            .collect(Collectors.toList());
+    }
+
+    private List<Long> extractRecordIds(Collection<SearchRecord> records) {
+        return records.stream().map(SearchRecord::getId).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    private SearchRecordResponse toResponse(SearchRecord record, List<SearchRecordVersionSummary> versions) {
+        SearchRecordResponse base = searchRecordMapper.toResponse(record);
+        SearchRecordVersionSummary latest = versions.isEmpty() ? null : versions.get(0);
+        return base.withVersionDetails(latest, versions);
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -47,8 +47,14 @@ class SearchRecordControllerTest {
     @Test
     void testCreate() throws Exception {
         LocalDateTime createdAt = LocalDateTime.now();
-        SearchRecordVersionSummary version =
-            new SearchRecordVersionSummary(2L, 1, createdAt, "gpt-4", "preview", DictionaryFlavor.BILINGUAL);
+        SearchRecordVersionSummary version = new SearchRecordVersionSummary(
+            2L,
+            1,
+            createdAt,
+            "gpt-4",
+            "preview",
+            DictionaryFlavor.BILINGUAL
+        );
         SearchRecordResponse resp = new SearchRecordResponse(
             1L,
             1L,

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerStreamingTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerStreamingTest.java
@@ -2,6 +2,7 @@ package com.glancy.backend.controller;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -49,9 +50,16 @@ class WordControllerStreamingTest {
 
     @Test
     void testStreamWord() throws Exception {
-        when(wordService.streamWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null), eq(false))).thenReturn(
-            Flux.just(StreamPayload.data("part1"), StreamPayload.version("77"))
-        );
+        when(
+            wordService.streamWordForUser(
+                eq(1L),
+                eq("hello"),
+                eq(Language.ENGLISH),
+                isNull(com.glancy.backend.entity.DictionaryFlavor.class),
+                isNull(String.class),
+                eq(false)
+            )
+        ).thenReturn(Flux.just(StreamPayload.data("part1"), StreamPayload.version("77")));
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 
         MvcResult result = mockMvc
@@ -78,9 +86,16 @@ class WordControllerStreamingTest {
      */
     @Test
     void testStreamWordError() throws Exception {
-        when(wordService.streamWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null), eq(false))).thenReturn(
-            Flux.error(new IllegalStateException("boom"))
-        );
+        when(
+            wordService.streamWordForUser(
+                eq(1L),
+                eq("hello"),
+                eq(Language.ENGLISH),
+                isNull(com.glancy.backend.entity.DictionaryFlavor.class),
+                isNull(String.class),
+                eq(false)
+            )
+        ).thenReturn(Flux.error(new IllegalStateException("boom")));
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 
         MvcResult result = mockMvc

--- a/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -70,9 +70,7 @@ class WordControllerTest {
                 eq(null),
                 eq(false)
             )
-        ).thenReturn(
-            resp
-        );
+        ).thenReturn(resp);
 
         when(userService.authenticateToken("tkn")).thenReturn(1L);
 

--- a/backend/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
+++ b/backend/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
@@ -93,13 +93,7 @@ class WordSearcherImplTest {
         when(factory.get("doubao")).thenReturn(null);
         WordSearcherImpl searcher = new WordSearcherImpl(factory, config, promptManager, searchContentManager, parser);
         assertThrows(IllegalStateException.class, () ->
-            searcher.search(
-                "hi",
-                Language.ENGLISH,
-                DictionaryFlavor.BILINGUAL,
-                "invalid",
-                NO_PERSONALIZATION_CONTEXT
-            )
+            searcher.search("hi", Language.ENGLISH, DictionaryFlavor.BILINGUAL, "invalid", NO_PERSONALIZATION_CONTEXT)
         );
     }
 

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
@@ -138,9 +138,7 @@ class WordServiceStreamPersistenceTest {
                 eq("doubao"),
                 any()
             )
-        ).thenReturn(
-            Flux.just("{\"term\":\"hi\"}", "<END>")
-        );
+        ).thenReturn(Flux.just("{\"term\":\"hi\"}", "<END>"));
         WordResponse resp = new WordResponse(
             null,
             "hi",
@@ -227,9 +225,7 @@ class WordServiceStreamPersistenceTest {
                 eq("doubao"),
                 any()
             )
-        ).thenReturn(
-            Flux.just("{\"term\":\"hi\"}")
-        );
+        ).thenReturn(Flux.just("{\"term\":\"hi\"}"));
 
         Flux<WordService.StreamPayload> flux = wordService.streamWordForUser(
             1L,
@@ -252,7 +248,8 @@ class WordServiceStreamPersistenceTest {
             any(Language.class),
             anyString(),
             anyString(),
-            any(Word.class)
+            any(Word.class),
+            any(DictionaryFlavor.class)
         );
     }
 
@@ -268,16 +265,8 @@ class WordServiceStreamPersistenceTest {
             )
         ).thenReturn(Optional.empty());
         when(
-            wordSearcher.streamSearch(
-                eq("hi"),
-                eq(Language.ENGLISH),
-                eq(DictionaryFlavor.BILINGUAL),
-                any(),
-                any()
-            )
-        ).thenReturn(
-            Flux.concat(Flux.just("part"), Flux.error(new RuntimeException("boom")))
-        );
+            wordSearcher.streamSearch(eq("hi"), eq(Language.ENGLISH), eq(DictionaryFlavor.BILINGUAL), any(), any())
+        ).thenReturn(Flux.concat(Flux.just("part"), Flux.error(new RuntimeException("boom"))));
 
         Flux<WordService.StreamPayload> flux = wordService.streamWordForUser(
             1L,

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -134,11 +134,7 @@ class WordServiceTest {
         assertEquals(Language.ENGLISH, result.getLanguage());
         assertTrue(
             wordRepository
-                .findByTermAndLanguageAndFlavorAndDeletedFalse(
-                    "bye",
-                    Language.ENGLISH,
-                    DictionaryFlavor.BILINGUAL
-                )
+                .findByTermAndLanguageAndFlavorAndDeletedFalse("bye", Language.ENGLISH, DictionaryFlavor.BILINGUAL)
                 .isPresent()
         );
     }
@@ -165,20 +161,12 @@ class WordServiceTest {
 
         assertTrue(
             wordRepository
-                .findByTermAndLanguageAndFlavorAndDeletedFalse(
-                    "hello",
-                    Language.ENGLISH,
-                    DictionaryFlavor.BILINGUAL
-                )
+                .findByTermAndLanguageAndFlavorAndDeletedFalse("hello", Language.ENGLISH, DictionaryFlavor.BILINGUAL)
                 .isPresent()
         );
         assertTrue(
             wordRepository
-                .findByTermAndLanguageAndFlavorAndDeletedFalse(
-                    "hello",
-                    Language.CHINESE,
-                    DictionaryFlavor.BILINGUAL
-                )
+                .findByTermAndLanguageAndFlavorAndDeletedFalse("hello", Language.CHINESE, DictionaryFlavor.BILINGUAL)
                 .isPresent()
         );
     }

--- a/backend/src/test/java/com/glancy/backend/service/gomemo/GomemoWordPrioritizerTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/gomemo/GomemoWordPrioritizerTest.java
@@ -7,8 +7,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.glancy.backend.config.GomemoProperties;
-import com.glancy.backend.entity.GomemoSession;
 import com.glancy.backend.entity.DictionaryFlavor;
+import com.glancy.backend.entity.GomemoSession;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.SearchRecord;
 import com.glancy.backend.entity.Word;
@@ -85,18 +85,14 @@ class GomemoWordPrioritizerTest {
                 Language.ENGLISH,
                 DictionaryFlavor.BILINGUAL
             )
-        ).thenReturn(
-            java.util.Optional.of(innovationWord)
-        );
+        ).thenReturn(java.util.Optional.of(innovationWord));
         when(
             wordRepository.findByTermAndLanguageAndFlavorAndDeletedFalse(
                 "strategy",
                 Language.ENGLISH,
                 DictionaryFlavor.BILINGUAL
             )
-        ).thenReturn(
-            java.util.Optional.of(strategyWord)
-        );
+        ).thenReturn(java.util.Optional.of(strategyWord));
         when(wordRepository.findAll(any(PageRequest.class))).thenReturn(new PageImpl<>(List.of()));
         GomemoPersona persona = new GomemoPersona(
             28,

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -90,3 +90,6 @@ mail:
       login:
         subject: "测试登录验证码"
         body: "登录验证码 {{code}}"
+      change-email:
+        subject: "测试修改邮箱验证码"
+        body: "修改邮箱验证码 {{code}}"


### PR DESCRIPTION
## Summary
- add a SearchRecordViewAssembler that batches version lookups and refactor SearchRecordService to use it
- extend SearchResultVersionRepository/SearchResultService to support bulk queries and cover the new flow with unit tests
- configure test fixtures and streaming controller expectations to align with the updated service contracts

## Testing
- mvn spotless:apply
- mvn test -Dtest=SearchRecordServiceTest

------
https://chatgpt.com/codex/tasks/task_e_68d5ff2c1ba483328581ea277e937af6