### PR TITLE
Optimize Gomemo plan caching and sync behavior

### DIFF
--- a/website/src/pages/Gomemo/Gomemo.jsx
+++ b/website/src/pages/Gomemo/Gomemo.jsx
@@ -126,6 +126,10 @@ function Gomemo() {
     }
   }, [plan, loading, loadPlan, token]);
 
+  const handleRefreshPlan = useCallback(() => {
+    loadPlan({ token, force: true });
+  }, [loadPlan, token]);
+
   const activeWord = plan?.words?.[activeWordIndex] ?? null;
   const activeLookupConfig = useMemo(
     () => resolveLookupConfig(activeWord),
@@ -371,7 +375,7 @@ function Gomemo() {
           <Button
             className={styles["primary-action"]}
             disabled={loading}
-            onClick={() => loadPlan({ token })}
+            onClick={handleRefreshPlan}
           >
             {loading ? (t.loading ?? "加载中") : t.gomemoCtaAction}
           </Button>
@@ -388,7 +392,7 @@ function Gomemo() {
             <Button
               className={styles["primary-action"]}
               disabled={loading}
-              onClick={() => loadPlan({ token })}
+              onClick={handleRefreshPlan}
             >
               {loading ? (t.loading ?? "加载中") : t.gomemoCtaAction}
             </Button>


### PR DESCRIPTION
## Summary
- add freshness tracking and in-flight guards to the Gomemo store to coalesce plan loading and progress sync calls
- expose a dedicated refresh handler on the Gomemo page so manual reloads opt into forced fetches while default loads rely on cached state
- extend Gomemo store tests to cover caching windows, concurrent load deduplication, and synchronized progress refresh flows

## Testing
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w src/pages/Gomemo/Gomemo.jsx src/store/__tests__/gomemoStore.test.js src/store/gomemo/index.ts
- npm test -- gomemoStore

------
https://chatgpt.com/codex/tasks/task_e_68d60fb469ec8332a341f04fa7478b16