### PR TITLE
Add bilingual instruction for English dictionary responses

### DIFF
--- a/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
+++ b/backend/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
@@ -224,8 +224,13 @@ public class WordSearcherImpl implements WordSearcher {
         if (flavor == null) {
             return null;
         }
-        if (language == Language.ENGLISH && flavor == DictionaryFlavor.MONOLINGUAL_ENGLISH) {
-            return "你正在输出高端英语词典条目，请严格使用英文完成所有章节，避免出现任何中文或翻译提示。";
+        if (language == Language.ENGLISH) {
+            if (flavor == DictionaryFlavor.MONOLINGUAL_ENGLISH) {
+                return "你正在输出高端英语词典条目，请严格使用英文完成所有章节，避免出现任何中文或翻译提示。";
+            }
+            if (flavor == DictionaryFlavor.BILINGUAL) {
+                return "请确保每个章节都提供精准的中文译文与注释，让读者能在英语释义旁同步获得优雅的中文理解。";
+            }
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- add an explicit bilingual-system instruction when English queries request the bilingual dictionary flavor so the model returns Chinese translations alongside English definitions
- refresh WordSearcher unit coverage to account for sanitized payloads and assert the bilingual instruction appears in the emitted prompts

## Testing
- mvn -f backend/pom.xml spotless:apply
- mvn -f backend/pom.xml test -Dtest=WordSearcherImplTest

------
https://chatgpt.com/codex/tasks/task_e_68d6b43cff5083328e44591fffdbbddd