### PR TITLE
refactor: remove gomemo dictionary model support

### DIFF
--- a/backend/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
@@ -1,8 +1,6 @@
 package com.glancy.backend.dto;
 
-import com.glancy.backend.entity.DictionaryModel;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 /**
@@ -19,7 +17,4 @@ public class UserPreferenceRequest {
 
     @NotBlank(message = "{validation.userPreference.searchLanguage.notblank}")
     private String searchLanguage;
-
-    @NotNull(message = "{validation.userPreference.dictionaryModel.notnull}")
-    private DictionaryModel dictionaryModel;
 }

--- a/backend/src/main/java/com/glancy/backend/dto/UserPreferenceResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserPreferenceResponse.java
@@ -1,6 +1,5 @@
 package com.glancy.backend.dto;
 
-import com.glancy.backend.entity.DictionaryModel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -16,5 +15,4 @@ public class UserPreferenceResponse {
     private String theme;
     private String systemLanguage;
     private String searchLanguage;
-    private DictionaryModel dictionaryModel;
 }

--- a/backend/src/main/java/com/glancy/backend/dto/UserPreferenceUpdateRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserPreferenceUpdateRequest.java
@@ -1,7 +1,6 @@
 package com.glancy.backend.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.glancy.backend.entity.DictionaryModel;
 import lombok.Data;
 import org.springframework.lang.Nullable;
 
@@ -20,7 +19,4 @@ public class UserPreferenceUpdateRequest {
 
     @Nullable
     private String searchLanguage;
-
-    @Nullable
-    private DictionaryModel dictionaryModel;
 }

--- a/backend/src/main/java/com/glancy/backend/entity/UserPreference.java
+++ b/backend/src/main/java/com/glancy/backend/entity/UserPreference.java
@@ -29,8 +29,4 @@ public class UserPreference {
 
     @Column(nullable = false, length = 20)
     private String searchLanguage;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private DictionaryModel dictionaryModel = DictionaryModel.DOUBAO;
 }

--- a/backend/src/main/java/com/glancy/backend/service/UserPreferenceService.java
+++ b/backend/src/main/java/com/glancy/backend/service/UserPreferenceService.java
@@ -3,7 +3,6 @@ package com.glancy.backend.service;
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
 import com.glancy.backend.dto.UserPreferenceUpdateRequest;
-import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.UserPreference;
 import com.glancy.backend.exception.ResourceNotFoundException;
@@ -27,7 +26,6 @@ public class UserPreferenceService {
     private static final String DEFAULT_THEME = "light";
     private static final String DEFAULT_SYSTEM_LANGUAGE = "en";
     private static final String DEFAULT_SEARCH_LANGUAGE = "en";
-    private static final DictionaryModel DEFAULT_DICTIONARY_MODEL = DictionaryModel.DOUBAO;
 
     public UserPreferenceService(UserPreferenceRepository userPreferenceRepository, UserRepository userRepository) {
         this.userPreferenceRepository = userPreferenceRepository;
@@ -41,7 +39,6 @@ public class UserPreferenceService {
         pref.setTheme(DEFAULT_THEME);
         pref.setSystemLanguage(DEFAULT_SYSTEM_LANGUAGE);
         pref.setSearchLanguage(DEFAULT_SEARCH_LANGUAGE);
-        pref.setDictionaryModel(DEFAULT_DICTIONARY_MODEL);
         return pref;
     }
 
@@ -57,7 +54,6 @@ public class UserPreferenceService {
         pref.setTheme(req.getTheme());
         pref.setSystemLanguage(req.getSystemLanguage());
         pref.setSearchLanguage(req.getSearchLanguage());
-        pref.setDictionaryModel(req.getDictionaryModel());
         UserPreference saved = userPreferenceRepository.save(pref);
         return toResponse(saved);
     }
@@ -93,11 +89,6 @@ public class UserPreferenceService {
         if (req.getSearchLanguage() != null) {
             pref.setSearchLanguage(req.getSearchLanguage());
         }
-        if (req.getDictionaryModel() != null) {
-            pref.setDictionaryModel(req.getDictionaryModel());
-        } else if (pref.getDictionaryModel() == null) {
-            pref.setDictionaryModel(DEFAULT_DICTIONARY_MODEL);
-        }
 
         UserPreference saved = userPreferenceRepository.save(pref);
         return toResponse(saved);
@@ -109,8 +100,7 @@ public class UserPreferenceService {
             pref.getUser().getId(),
             pref.getTheme(),
             pref.getSystemLanguage(),
-            pref.getSearchLanguage(),
-            pref.getDictionaryModel()
+            pref.getSearchLanguage()
         );
     }
 }

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -9,7 +9,6 @@ validation.thirdPartyAccount.externalId.notblank=External ID must not be blank
 validation.userPreference.theme.notblank=Theme must not be blank
 validation.userPreference.systemLanguage.notblank=System language must not be blank
 validation.userPreference.searchLanguage.notblank=Search language must not be blank
-validation.userPreference.dictionaryModel.notnull=Dictionary model must not be null
 validation.userRegistration.username.notblank=Username must not be blank
 validation.userRegistration.password.notblank=Password must not be blank
 validation.userRegistration.email.notblank=Email must not be blank

--- a/backend/src/main/resources/messages_zh.properties
+++ b/backend/src/main/resources/messages_zh.properties
@@ -9,7 +9,6 @@ validation.thirdPartyAccount.externalId.notblank=外部ID不能为空
 validation.userPreference.theme.notblank=主题不能为空
 validation.userPreference.systemLanguage.notblank=系统语言不能为空
 validation.userPreference.searchLanguage.notblank=搜索语言不能为空
-validation.userPreference.dictionaryModel.notnull=查词模型不能为空
 validation.userRegistration.username.notblank=用户名不能为空
 validation.userRegistration.password.notblank=密码不能为空
 validation.userRegistration.email.notblank=邮箱不能为空

--- a/backend/src/main/resources/sql/schema.sql
+++ b/backend/src/main/resources/sql/schema.sql
@@ -104,6 +104,5 @@ CREATE TABLE IF NOT EXISTS user_preferences (
   theme VARCHAR(20) NOT NULL,
   systemLanguage VARCHAR(20) NOT NULL,
   searchLanguage VARCHAR(20) NOT NULL,
-  dictionaryModel VARCHAR(20) NOT NULL DEFAULT 'DOUBAO',
   CONSTRAINT fk_user_pref_user FOREIGN KEY (user_id) REFERENCES users (id)
 );

--- a/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
 import com.glancy.backend.dto.UserPreferenceUpdateRequest;
-import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.service.UserPreferenceService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,14 +46,13 @@ class UserPreferenceControllerTest {
      */
     @Test
     void savePreference() throws Exception {
-        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en", DictionaryModel.DOUBAO);
+        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en");
         when(userPreferenceService.savePreference(eq(2L), any(UserPreferenceRequest.class))).thenReturn(resp);
 
         UserPreferenceRequest req = new UserPreferenceRequest();
         req.setTheme("dark");
         req.setSystemLanguage("en");
         req.setSearchLanguage("en");
-        req.setDictionaryModel(DictionaryModel.DOUBAO);
 
         when(userService.authenticateToken("tkn")).thenReturn(2L);
 
@@ -74,7 +72,7 @@ class UserPreferenceControllerTest {
      */
     @Test
     void getPreference() throws Exception {
-        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en", DictionaryModel.DOUBAO);
+        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en");
         when(userPreferenceService.getPreference(2L)).thenReturn(resp);
 
         when(userService.authenticateToken("tkn")).thenReturn(2L);
@@ -90,7 +88,7 @@ class UserPreferenceControllerTest {
      */
     @Test
     void updatePreference() throws Exception {
-        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en", DictionaryModel.DOUBAO);
+        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en");
         when(userPreferenceService.updatePreference(eq(2L), any(UserPreferenceUpdateRequest.class))).thenReturn(resp);
 
         UserPreferenceUpdateRequest req = new UserPreferenceUpdateRequest();

--- a/backend/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
@@ -5,9 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
 import com.glancy.backend.dto.UserPreferenceUpdateRequest;
-import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.entity.User;
-import com.glancy.backend.entity.UserPreference;
 import com.glancy.backend.repository.UserPreferenceRepository;
 import com.glancy.backend.repository.UserRepository;
 import io.github.cdimascio.dotenv.Dotenv;
@@ -62,7 +60,6 @@ class UserPreferenceServiceTest {
         req.setTheme("light");
         req.setSystemLanguage("en");
         req.setSearchLanguage("zh");
-        req.setDictionaryModel(DictionaryModel.DOUBAO);
         UserPreferenceResponse saved = userPreferenceService.savePreference(user.getId(), req);
 
         assertNotNull(saved.getId());
@@ -71,7 +68,6 @@ class UserPreferenceServiceTest {
         UserPreferenceResponse fetched = userPreferenceService.getPreference(user.getId());
         assertEquals(saved.getId(), fetched.getId());
         assertEquals("zh", fetched.getSearchLanguage());
-        assertEquals(DictionaryModel.DOUBAO, fetched.getDictionaryModel());
     }
 
     /**
@@ -89,7 +85,6 @@ class UserPreferenceServiceTest {
         UserPreferenceResponse fetched = userPreferenceService.getPreference(user.getId());
         assertEquals("light", fetched.getTheme());
         assertEquals("en", fetched.getSystemLanguage());
-        assertEquals(DictionaryModel.DOUBAO, fetched.getDictionaryModel());
     }
 
     /**
@@ -108,12 +103,7 @@ class UserPreferenceServiceTest {
         req.setTheme("light");
         req.setSystemLanguage("en");
         req.setSearchLanguage("en");
-        req.setDictionaryModel(DictionaryModel.DOUBAO);
         userPreferenceService.savePreference(user.getId(), req);
-
-        UserPreference stored = userPreferenceRepository.findByUserId(user.getId()).orElseThrow();
-        stored.setDictionaryModel(null);
-        userPreferenceRepository.save(stored);
 
         UserPreferenceUpdateRequest updateRequest = new UserPreferenceUpdateRequest();
         updateRequest.setTheme("dark");
@@ -123,7 +113,6 @@ class UserPreferenceServiceTest {
         assertEquals("dark", updated.getTheme());
         assertEquals("en", updated.getSystemLanguage());
         assertEquals("en", updated.getSearchLanguage());
-        assertEquals(DictionaryModel.DOUBAO, updated.getDictionaryModel());
     }
 
     /**
@@ -142,20 +131,17 @@ class UserPreferenceServiceTest {
         req.setTheme("light");
         req.setSystemLanguage("en");
         req.setSearchLanguage("en");
-        req.setDictionaryModel(DictionaryModel.DOUBAO);
         userPreferenceService.savePreference(user.getId(), req);
 
         UserPreferenceUpdateRequest updateRequest = new UserPreferenceUpdateRequest();
         updateRequest.setTheme("dark");
         updateRequest.setSystemLanguage("fr");
         updateRequest.setSearchLanguage("es");
-        updateRequest.setDictionaryModel(DictionaryModel.DOUBAO);
 
         UserPreferenceResponse updated = userPreferenceService.updatePreference(user.getId(), updateRequest);
 
         assertEquals("dark", updated.getTheme());
         assertEquals("fr", updated.getSystemLanguage());
         assertEquals("es", updated.getSearchLanguage());
-        assertEquals(DictionaryModel.DOUBAO, updated.getDictionaryModel());
     }
 }

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
@@ -14,7 +14,6 @@ import com.glancy.backend.entity.Word;
 import com.glancy.backend.llm.parser.ParsedWord;
 import com.glancy.backend.llm.parser.WordResponseParser;
 import com.glancy.backend.llm.service.WordSearcher;
-import com.glancy.backend.repository.UserPreferenceRepository;
 import com.glancy.backend.repository.WordRepository;
 import com.glancy.backend.service.personalization.WordPersonalizationService;
 import java.time.LocalDateTime;
@@ -39,9 +38,6 @@ class WordServiceStreamPersistenceTest {
 
     @Mock
     private WordRepository wordRepository;
-
-    @Mock
-    private UserPreferenceRepository userPreferenceRepository;
 
     @Mock
     private SearchRecordService searchRecordService;
@@ -73,11 +69,9 @@ class WordServiceStreamPersistenceTest {
         when(wordPersonalizationService.personalize(any(WordPersonalizationContext.class), any())).thenReturn(
             new PersonalizedWordExplanation("persona", "key", "context", List.of(), List.of())
         );
-        when(userPreferenceRepository.findByUserId(anyLong())).thenReturn(Optional.empty());
         wordService = new WordService(
             wordSearcher,
             wordRepository,
-            userPreferenceRepository,
             searchRecordService,
             searchResultService,
             parser,

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
@@ -13,12 +13,10 @@ import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.Word;
 import com.glancy.backend.llm.parser.WordResponseParser;
 import com.glancy.backend.llm.service.WordSearcher;
-import com.glancy.backend.repository.UserPreferenceRepository;
 import com.glancy.backend.repository.WordRepository;
 import com.glancy.backend.service.personalization.WordPersonalizationService;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -38,9 +36,6 @@ class WordServiceStreamingErrorTest {
 
     @Mock
     private WordRepository wordRepository;
-
-    @Mock
-    private UserPreferenceRepository userPreferenceRepository;
 
     @Mock
     private SearchRecordService searchRecordService;
@@ -72,11 +67,9 @@ class WordServiceStreamingErrorTest {
         when(wordPersonalizationService.personalize(any(WordPersonalizationContext.class), any())).thenReturn(
             new PersonalizedWordExplanation("persona", "key", "context", List.of(), List.of())
         );
-        when(userPreferenceRepository.findByUserId(anyLong())).thenReturn(Optional.empty());
         wordService = new WordService(
             wordSearcher,
             wordRepository,
-            userPreferenceRepository,
             searchRecordService,
             searchResultService,
             parser,


### PR DESCRIPTION
## Summary
- remove the legacy dictionary model preference fields from user preference DTOs and entity
- default word searches to the doubao client and drop the dependency on stored dictionary model preferences
- sync validation messages, schema definition, and related unit tests with the simplified model handling

## Testing
- mvn spotless:apply
- mvn -Dtest=UserPreferenceServiceTest,UserPreferenceControllerTest,WordServiceStreamPersistenceTest,WordServiceStreamingErrorTest test *(fails: missing OSS credentials for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d7365ef08332ae936c660aa3fa1e