### PR TITLE
Align web UI with prototype design

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -1,21 +1,57 @@
 .container {
-  --layout-sidebar-min: 248px;
-  --layout-sidebar-max: 392px;
-  --layout-sidebar-width: clamp(
+  --layout-sidebar-min: 240px;
+  --layout-sidebar-max: 420px;
+  --layout-sidebar-default: clamp(
     var(--layout-sidebar-min),
     24vw,
     var(--layout-sidebar-max)
   );
   --layout-content-max: 1080px;
-  --layout-content-padding-x: clamp(24px, 5vw, 72px);
-  --layout-content-padding-top: clamp(32px, 6vw, 88px);
-  --layout-content-padding-bottom: clamp(220px, 28vh, 320px);
+  --layout-content-padding-x: clamp(20px, 5vw, 48px);
+  --layout-content-padding-top: clamp(24px, 5vw, 36px);
+  --layout-content-padding-bottom: clamp(24px, 6vh, 36px);
 
-  display: grid;
-  grid-template-columns: var(--layout-sidebar-width) minmax(0, 1fr);
+  display: flex;
+  align-items: stretch;
   min-height: var(--vh);
-  background: var(--body-bg);
-  color: var(--app-color);
+  background: var(--night-surface, var(--body-bg));
+  color: var(--night-text, var(--app-color));
+  position: relative;
+  overflow: hidden;
+}
+
+.resizer {
+  position: relative;
+  z-index: 2;
+  width: 6px;
+  min-height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+  transition: background 0.2s ease;
+}
+
+.resizer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(
+      in srgb,
+      var(--night-muted, var(--border-color)) 16%,
+      transparent
+    ),
+    transparent
+  );
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.resizer:hover::after,
+.resizer:focus-visible::after,
+.resizer:active::after {
+  opacity: 1;
 }
 
 .main {
@@ -23,36 +59,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  flex: 1 1 auto;
   min-height: var(--vh);
-  background:
-    radial-gradient(
-      140% 120% at 80% 0%,
-      color-mix(in srgb, var(--primary-bg) 6%, transparent) 0%,
-      transparent 58%
-    ),
-    radial-gradient(
-      160% 140% at -10% 30%,
-      color-mix(in srgb, var(--primary-bg) 12%, transparent) 0%,
-      transparent 65%
-    ),
-    color-mix(in srgb, var(--chat-window-bg) 96%, transparent);
-  isolation: isolate;
+  background: var(--night-surface, var(--chat-window-bg));
+  color: inherit;
   overflow: hidden;
-}
-
-.main::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    color-mix(in srgb, var(--chat-window-bg) 94%, transparent) 38%,
-    color-mix(in srgb, var(--chat-window-bg) 92%, transparent) 100%
-  );
-  opacity: 0.92;
-  pointer-events: none;
-  z-index: 0;
 }
 
 .main-top {
@@ -134,8 +145,7 @@
   width: 100%;
   display: flex;
   justify-content: center;
-  overflow-y: auto;
-  overscroll-behavior: contain;
+  overflow: hidden;
 }
 
 .main-middle {
@@ -151,65 +161,56 @@
 }
 
 .main-bottom {
-  position: sticky;
-  bottom: clamp(24px, 6vh, 64px);
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  padding: 0 clamp(16px, 6vw, 72px);
-  pointer-events: none;
-  z-index: 2;
-}
-
-.main-bottom::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  transform: translateY(100%);
-  height: clamp(120px, 18vh, 200px);
-  background: linear-gradient(
-    to top,
-    color-mix(in srgb, var(--chat-window-bg) 96%, transparent) 0%,
-    color-mix(in srgb, var(--chat-window-bg) 88%, transparent) 55%,
-    transparent 100%
+  position: fixed;
+  left: calc(
+    var(--layout-sidebar-width, var(--layout-sidebar-default)) +
+      (100vw - var(--layout-sidebar-width, var(--layout-sidebar-default))) / 2
   );
-  pointer-events: none;
-  z-index: -1;
-}
-
-.main-bottom-inner {
-  width: min(100%, calc(var(--layout-content-max) - 48px));
+  transform: translateX(-50%);
+  bottom: clamp(24px, 6vh, 40px);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
+  width: max-content;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.main-bottom-inner {
+  width: min(
+    clamp(360px, 50vw, 960px),
+    calc(
+      100vw - var(--layout-sidebar-width, var(--layout-sidebar-default)) - 48px
+    )
+  );
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
   pointer-events: auto;
 }
 
 @media (width <= 900px) {
   .container {
-    --layout-sidebar-width: var(--layout-sidebar-min);
-
-    grid-template-columns: minmax(0, 1fr);
+    --layout-sidebar-default: var(--layout-sidebar-min);
   }
 
-  .main {
-    min-height: var(--vh);
-  }
-
-  .main-content {
-    width: 100%;
+  .resizer {
+    display: none;
   }
 
   .main-middle {
-    padding: clamp(20px, 6vw, 36px) clamp(16px, 5vw, 28px)
-      calc(140px + env(safe-area-inset-bottom, 0px));
+    padding: clamp(24px, 6vw, 32px) clamp(16px, 6vw, 28px)
+      calc(160px + env(safe-area-inset-bottom, 0px));
     gap: clamp(20px, 5vw, 28px);
   }
 
   .main-bottom {
-    bottom: clamp(16px, 4vh, 48px);
-    padding-inline: clamp(12px, 6vw, 28px);
+    position: static;
+    transform: none;
+    width: 100%;
+    padding: clamp(16px, 6vw, 24px) clamp(12px, 6vw, 28px);
   }
 
   .main-bottom-inner {
@@ -227,19 +228,8 @@
     min-height: var(--vh);
   }
 
-  .main::after {
-    opacity: 0.98;
-  }
-
   .main-bottom {
-    position: static;
-    width: 100%;
-    padding: clamp(20px, 6vw, 28px);
-    pointer-events: auto;
-  }
-
-  .main-bottom::before {
-    display: none;
+    padding: clamp(16px, 6vw, 24px);
   }
 
   .main-bottom-inner {

--- a/website/src/components/Layout/index.jsx
+++ b/website/src/components/Layout/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useMemo, useCallback, useEffect } from "react";
 import Sidebar from "@/components/Sidebar";
 import ThemeIcon from "@/components/ui/Icon";
 import { useIsMobile } from "@/utils";
@@ -7,15 +7,104 @@ import styles from "./Layout.module.css";
 function Layout({ children, sidebarProps = {}, bottomContent = null }) {
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarWidth, setSidebarWidth] = useState(null);
+  const containerRef = useRef(null);
+  const sidebarRef = useRef(null);
+  const resizeFrame = useRef(null);
+
+  useEffect(() => {
+    if (isMobile) {
+      setSidebarWidth(null);
+    }
+  }, [isMobile]);
+
+  useEffect(
+    () => () => {
+      if (resizeFrame.current) {
+        cancelAnimationFrame(resizeFrame.current);
+        resizeFrame.current = null;
+      }
+      document.body?.style?.removeProperty?.("user-select");
+    },
+    [],
+  );
+
+  const handlePointerDown = useCallback(
+    (event) => {
+      if (isMobile) return;
+      if (!sidebarRef.current || !containerRef.current) return;
+
+      event.preventDefault();
+      document.body.style.userSelect = "none";
+
+      const { clientX: startX } = event;
+      const computed = window.getComputedStyle(containerRef.current);
+      const min = Number.parseFloat(
+        computed.getPropertyValue("--layout-sidebar-min"),
+      );
+      const max = Number.parseFloat(
+        computed.getPropertyValue("--layout-sidebar-max"),
+      );
+      const { width: initialWidth } =
+        sidebarRef.current.getBoundingClientRect();
+      const minWidth = Number.isNaN(min) ? 240 : min;
+      const maxWidth = Number.isNaN(max) ? 420 : max;
+
+      const handlePointerMove = (moveEvent) => {
+        if (resizeFrame.current) {
+          cancelAnimationFrame(resizeFrame.current);
+          resizeFrame.current = null;
+        }
+
+        resizeFrame.current = requestAnimationFrame(() => {
+          const delta = moveEvent.clientX - startX;
+          const nextWidth = Math.max(
+            minWidth,
+            Math.min(maxWidth, initialWidth + delta),
+          );
+          setSidebarWidth(nextWidth);
+        });
+      };
+
+      const handlePointerUp = () => {
+        if (resizeFrame.current) {
+          cancelAnimationFrame(resizeFrame.current);
+          resizeFrame.current = null;
+        }
+        document.removeEventListener("pointermove", handlePointerMove);
+        document.removeEventListener("pointerup", handlePointerUp);
+        document.body.style.removeProperty("user-select");
+      };
+
+      document.addEventListener("pointermove", handlePointerMove);
+      document.addEventListener("pointerup", handlePointerUp);
+    },
+    [isMobile],
+  );
+
+  const containerStyle = useMemo(() => {
+    if (!sidebarWidth || isMobile) return undefined;
+    return { "--layout-sidebar-width": `${Math.round(sidebarWidth)}px` };
+  }, [sidebarWidth, isMobile]);
 
   return (
-    <div className={styles.container}>
+    <div ref={containerRef} className={styles.container} style={containerStyle}>
       <Sidebar
         {...sidebarProps}
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
         isMobile={isMobile}
+        ref={sidebarRef}
       />
+      {!isMobile ? (
+        <div
+          className={styles.resizer}
+          role="separator"
+          aria-orientation="vertical"
+          aria-hidden="true"
+          onPointerDown={handlePointerDown}
+        />
+      ) : null}
       <div className={styles.main}>
         {isMobile ? (
           <div className={styles["main-top"]}>

--- a/website/src/components/Sidebar/Sidebar.jsx
+++ b/website/src/components/Sidebar/Sidebar.jsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import Brand from "@/components/Brand";
 import SidebarQuickActions from "./SidebarQuickActions.jsx";
 import SidebarHistory from "./SidebarHistory.jsx";
@@ -5,13 +6,16 @@ import SidebarUser from "./SidebarUser.jsx";
 import { useIsMobile } from "@/utils";
 import styles from "./Sidebar.module.css";
 
-function Sidebar({
-  isMobile: mobileProp,
-  open = false,
-  onClose,
-  onToggleFavorites,
-  onSelectHistory,
-}) {
+function Sidebar(
+  {
+    isMobile: mobileProp,
+    open = false,
+    onClose,
+    onToggleFavorites,
+    onSelectHistory,
+  },
+  ref,
+) {
   const defaultMobile = useIsMobile();
   const isMobile = mobileProp ?? defaultMobile;
   return (
@@ -20,6 +24,7 @@ function Sidebar({
         <div className="sidebar-overlay" onClick={onClose} />
       )}
       <aside
+        ref={ref}
         className={`sidebar${isMobile ? (open ? " mobile-open" : "") : ""}`}
       >
         <Brand />
@@ -33,4 +38,4 @@ function Sidebar({
   );
 }
 
-export default Sidebar;
+export default forwardRef(Sidebar);

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -2,45 +2,25 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--sidebar-item-gap, 8px);
-  padding-inline: var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
+  gap: clamp(4px, 1vw, 8px);
+  padding-inline: clamp(12px, 2.4vw, 18px);
 }
 
 .sidebar-content {
-  position: relative;
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--sidebar-section-gap, 24px);
-  padding-block: clamp(12px, 2vw, 18px);
+  gap: clamp(16px, 2.6vw, 22px);
+  padding-block: clamp(10px, 2vw, 16px);
   overflow: hidden;
-  isolation: isolate;
-}
-
-.sidebar-content::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    color-mix(in srgb, var(--sidebar-bg) 96%, transparent) 90%
-  );
-  pointer-events: none;
-  z-index: 0;
-}
-
-.sidebar-content > * {
-  position: relative;
-  z-index: 1;
 }
 
 .sidebar-quick-actions {
   display: flex;
   flex-direction: column;
-  gap: var(--sidebar-item-gap, 8px);
-  padding-inline: var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
+  gap: clamp(4px, 1vw, 8px);
+  padding-inline: clamp(12px, 2.4vw, 18px);
 }
 
 .sidebar-history {
@@ -55,8 +35,7 @@
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding-inline: var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
-  padding-bottom: clamp(20px, 3vw, 28px);
+  padding: clamp(4px, 1vw, 8px) clamp(12px, 2.4vw, 18px) clamp(16px, 3vw, 24px);
 }
 
 .history-items {
@@ -65,19 +44,13 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--sidebar-item-gap, 8px);
+  gap: clamp(2px, 0.6vw, 6px);
 }
 
 .history-entry {
-  border-radius: clamp(16px, 2.6vw, 22px);
-  border: 1px solid color-mix(in srgb, var(--border-color) 38%, transparent);
-  background: color-mix(in srgb, var(--sidebar-bg) 94%, transparent);
-  box-shadow: 0 20px 48px
-    color-mix(in srgb, var(--shadow-color) 18%, transparent);
-  transition:
-    transform 160ms ease,
-    box-shadow 160ms ease,
-    border-color 160ms ease;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  transition: border-color 0.16s ease;
 }
 
 .history-entry :global(.sidebar-action) {
@@ -85,10 +58,11 @@
 }
 
 .history-entry:where(:hover, :focus-within) {
-  transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--accent-color) 32%, transparent);
-  box-shadow: 0 26px 56px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--night-input-ring, var(--border-color)) 60%,
+    transparent
+  );
 }
 
 .history-labels {
@@ -106,88 +80,68 @@
   width: 100%;
   display: flex;
   align-items: center;
-  gap: var(--sidebar-action-gap, 12px);
-  padding: var(--sidebar-item-padding-y, 12px)
-    var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
-  border-radius: clamp(16px, 2.6vw, 22px);
-  border: 1px solid color-mix(in srgb, var(--border-color) 32%, transparent);
-  background: color-mix(in srgb, var(--sidebar-bg) 96%, transparent);
+  gap: clamp(8px, 1.6vw, 12px);
+  padding: 0 clamp(12px, 2.4vw, 18px);
+  min-height: clamp(36px, 5vh, 44px);
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
   color: inherit;
   font: inherit;
   font-weight: 600;
-  letter-spacing: 0.015em;
+  letter-spacing: 0.02em;
   text-align: left;
   cursor: pointer;
-  box-shadow: 0 18px 44px
-    color-mix(in srgb, var(--shadow-color) 18%, transparent);
   transition:
     background-color 160ms ease,
     color 160ms ease,
-    box-shadow 160ms ease,
-    transform 160ms ease,
     border-color 160ms ease;
 }
 
 .sidebar-action[data-variant="prominent"] {
-  --sidebar-action-prominent-color: color-mix(
-    in srgb,
-    var(--accent-color) 58%,
-    var(--sidebar-color)
-  );
-  --sidebar-action-icon-shadow: drop-shadow(0 4px 8px rgb(15 23 42 / 22%));
-  --sidebar-action-description-color: color-mix(
-    in srgb,
-    var(--accent-color) 46%,
-    var(--sidebar-color)
-  );
-
-  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 42%, transparent);
-  box-shadow: 0 26px 60px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
-  color: var(--sidebar-action-prominent-color);
+  background: color-mix(in srgb, var(--accent-color) 16%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 40%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 68%, var(--sidebar-color));
 }
 
 .sidebar-action:where(:hover, :focus-visible) {
-  background: color-mix(in srgb, var(--sidebar-bg) 92%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 26%, transparent);
-  box-shadow: 0 26px 60px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
-  transform: translateY(-1px);
+  background: var(
+    --night-hover,
+    color-mix(in srgb, var(--sidebar-bg) 92%, transparent)
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--night-input-ring, var(--border-color)) 60%,
+    transparent
+  );
 }
 
 .sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
-  background: color-mix(in srgb, var(--accent-color) 22%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 52%, transparent);
-  box-shadow: 0 32px 72px
-    color-mix(in srgb, var(--shadow-color) 28%, transparent);
-  transform: translateY(-2px);
+  background: color-mix(in srgb, var(--accent-color) 24%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 56%, transparent);
 }
 
 .sidebar-action:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent-color) 60%, transparent);
-  outline-offset: 3px;
-}
-
-.sidebar-action[data-variant="prominent"]:focus-visible {
-  outline-color: color-mix(in srgb, var(--accent-color) 72%, transparent);
-  outline-offset: 4px;
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 50%, transparent);
+  outline-offset: 2px;
 }
 
 .sidebar-action-active {
-  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 46%, transparent);
-  box-shadow: 0 30px 72px
-    color-mix(in srgb, var(--shadow-color) 26%, transparent);
-  color: color-mix(in srgb, var(--accent-color) 62%, var(--sidebar-color));
+  background: var(
+    --night-active,
+    color-mix(in srgb, var(--sidebar-bg) 88%, transparent)
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--night-input-ring, var(--border-color)) 70%,
+    transparent
+  );
+  color: var(--night-text, var(--sidebar-color));
 }
 
 .sidebar-action-active[data-variant="prominent"] {
-  background: color-mix(in srgb, var(--accent-color) 26%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 58%, transparent);
-  box-shadow: 0 36px 84px
-    color-mix(in srgb, var(--shadow-color) 30%, transparent);
-  color: color-mix(in srgb, var(--accent-color) 78%, var(--sidebar-color));
+  background: color-mix(in srgb, var(--accent-color) 30%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 62%, transparent);
 }
 
 .sidebar-action-icon {
@@ -195,13 +149,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 20px;
+  height: 20px;
   color: inherit;
-  filter: var(
-    --sidebar-action-icon-shadow,
-    drop-shadow(0 2px 4px rgb(15 23 42 / 18%))
-  );
 }
 
 .sidebar-action-body {
@@ -215,7 +165,7 @@
 .sidebar-action-label {
   display: flex;
   align-items: center;
-  gap: var(--space-1, 4px);
+  gap: 6px;
   font-weight: 600;
   letter-spacing: 0.02em;
 }
@@ -224,10 +174,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding-inline: var(--space-1, 4px);
-  min-width: 32px;
-  height: 18px;
-  border-radius: var(--radius-pill, 999px);
+  padding-inline: 6px;
+  min-width: 30px;
+  height: 16px;
+  border-radius: 999px;
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -239,9 +189,10 @@
 .sidebar-action-description {
   font-size: 12px;
   line-height: 1.4;
-  color: var(
-    --sidebar-action-description-color,
-    color-mix(in srgb, var(--sidebar-color) 60%, transparent)
+  color: color-mix(
+    in srgb,
+    var(--night-muted, var(--sidebar-color)) 80%,
+    transparent
   );
   letter-spacing: 0.02em;
 }
@@ -250,20 +201,22 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: color-mix(in srgb, var(--sidebar-color) 70%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--night-muted, var(--sidebar-color)) 80%,
+    transparent
+  );
 }
 
 .sidebar-user {
   --user-menu-width: 100%;
 
   margin-top: auto;
-  padding: clamp(12px, 2vw, 18px)
-    var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
+  padding: clamp(12px, 2vw, 18px) clamp(14px, 2.4vw, 18px);
   position: sticky;
   bottom: 0;
-  background: color-mix(in srgb, var(--sidebar-bg) 96%, transparent);
-  border-top: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
-  backdrop-filter: blur(18px);
+  background: var(--night-surface, var(--sidebar-bg));
+  border-top: 1px solid var(--night-border, var(--border-color));
 }
 
 .sidebar-user-trigger {
@@ -271,44 +224,33 @@
 }
 
 .sidebar-user-trigger .sidebar-action {
-  padding-inline: var(--sidebar-inline-padding, var(--sidebar-padding, 24px));
+  padding-inline: clamp(12px, 2.4vw, 18px);
 }
 
 .sidebar-user-trigger .sidebar-action-icon {
-  width: 34px;
-  height: 34px;
-  border-radius: var(--radius-pill, 999px);
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
   overflow: hidden;
-  box-shadow: 0 1px 4px rgb(15 23 42 / 20%);
 }
 
 .sidebar-user-trigger .sidebar-action-description {
   font-weight: 500;
-  color: color-mix(in srgb, var(--accent-color) 40%, var(--sidebar-color));
+  color: color-mix(
+    in srgb,
+    var(--night-muted, var(--sidebar-color)) 75%,
+    transparent
+  );
 }
 
 .sidebar-user-trigger :global(.menu) {
   inset: auto 0 calc(100% + 0.75rem);
   width: var(--user-menu-width);
-  background: color-mix(in srgb, var(--sidebar-bg) 96%, transparent);
-  color: var(--sidebar-color);
-  border: 1px solid color-mix(in srgb, var(--border-color) 62%, transparent);
-  box-shadow: 0 28px 64px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
-  backdrop-filter: blur(18px);
-}
-
-:root[data-theme="dark"] .sidebar-action:where(:hover, :focus-visible) {
-  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 36%, transparent);
-  box-shadow: 0 32px 72px
-    color-mix(in srgb, var(--shadow-color) 32%, transparent);
-}
-
-:root[data-theme="dark"]
-  .sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
-  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 58%, transparent);
-  box-shadow: 0 40px 88px
-    color-mix(in srgb, var(--shadow-color) 36%, transparent);
+  background: var(
+    --night-panel,
+    color-mix(in srgb, var(--sidebar-bg) 92%, transparent)
+  );
+  color: var(--night-text, var(--sidebar-color));
+  border: 1px solid var(--night-border, var(--border-color));
+  box-shadow: var(--night-shadow, 0 12px 30px rgb(0 0 0 / 40%));
 }

--- a/website/src/components/Sidebar/SidebarActionItem.jsx
+++ b/website/src/components/Sidebar/SidebarActionItem.jsx
@@ -15,8 +15,8 @@ function renderIcon(icon, alt, label) {
     <ThemeIcon
       name={icon}
       alt={alt || label}
-      width={22}
-      height={22}
+      width={18}
+      height={18}
       aria-hidden={alt ? undefined : "true"}
       className={styles["sidebar-action-icon"]}
     />

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -5,30 +5,14 @@
 }
 
 .input-wrapper {
-  width: min(100%, 960px);
-  margin: 0 auto;
+  width: 100%;
 }
 
 .input-surface {
-  --padding-x: 0;
-  --padding-y: 0;
-  --slot-gap: 0;
+  --padding-x: clamp(18px, 5vw, 24px);
+  --slot-gap: clamp(10px, 2vw, 14px);
 
-  border-radius: clamp(36px, 5vw, 44px);
-  border: 1px solid color-mix(in srgb, var(--border-color) 42%, transparent);
-  background:
-    linear-gradient(
-      155deg,
-      color-mix(in srgb, var(--input-bg) 96%, transparent) 0%,
-      color-mix(in srgb, var(--input-bg) 88%, transparent) 60%,
-      color-mix(in srgb, var(--input-bg) 84%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--input-bg) 94%, transparent);
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 82%, transparent),
-    0 32px 90px color-mix(in srgb, var(--shadow-color) 28%, transparent);
-  backdrop-filter: blur(24px);
+  min-height: clamp(56px, 9vh, 72px);
 }
 
 .leading-accessory,
@@ -36,20 +20,19 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  padding: clamp(18px, 4vw, 22px) clamp(20px, 4vw, 26px);
-  min-height: clamp(72px, 12vh, 88px);
+  padding: 0;
 }
 
 .leading-accessory {
   flex: 0 1 auto;
   min-width: 0;
-  border-right: 1px solid
-    color-mix(in srgb, var(--border-color) 32%, transparent);
+  padding-left: clamp(4px, 1vw, 12px);
+  padding-right: clamp(12px, 2vw, 18px);
+  border-right: 1px solid var(--night-input-ring, var(--border-color));
 }
 
 .trailing-accessory {
-  border-left: 1px solid
-    color-mix(in srgb, var(--border-color) 28%, transparent);
+  padding-left: clamp(12px, 2vw, 16px);
 }
 
 .input-body {
@@ -57,7 +40,7 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  padding: clamp(20px, 4vw, 26px) clamp(18px, 4vw, 24px);
+  padding: clamp(14px, 3vw, 20px) clamp(12px, 3vw, 16px);
 }
 
 .textarea {
@@ -66,8 +49,11 @@
   padding: 0;
   margin: 0;
   background: transparent;
-  color: color-mix(in srgb, var(--color-text) 94%, transparent);
-  font-size: 1.02rem;
+  color: var(
+    --night-text,
+    color-mix(in srgb, var(--color-text) 94%, transparent)
+  );
+  font-size: 1rem;
   line-height: 1.6;
   font-weight: 500;
   resize: none;
@@ -76,50 +62,43 @@
 }
 
 .textarea::placeholder {
-  color: color-mix(in srgb, var(--color-text) 58%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--night-muted, var(--color-text)) 58%,
+    transparent
+  );
   letter-spacing: 0.02em;
 }
 
 .action-button {
-  width: 60px;
-  height: 60px;
+  width: 48px;
+  height: 48px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 20px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
-  background:
-    linear-gradient(
-      150deg,
-      color-mix(in srgb, var(--color-surface-muted) 98%, transparent) 0%,
-      color-mix(in srgb, var(--color-surface-alt) 72%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--color-surface-alt) 92%, transparent);
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 84%, transparent),
-    0 26px 54px color-mix(in srgb, var(--shadow-color) 28%, transparent);
-  color: color-mix(in srgb, var(--color-text) 88%, transparent);
+  border-radius: 999px;
+  border: 1px solid var(--night-input-ring, var(--border-color));
+  background: transparent;
+  color: var(--night-text, var(--color-text));
   cursor: pointer;
   transition:
     transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
+    background 0.2s ease;
 }
 
 .action-button:hover,
 .action-button:focus-visible {
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--primary-color) 52%, transparent);
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 86%, transparent),
-    0 32px 64px color-mix(in srgb, var(--shadow-color) 32%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--night-input-ring, var(--primary-color)) 14%,
+    transparent
+  );
   outline: none;
 }
 
 .action-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--primary-color) 46%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 40%, transparent);
   outline-offset: 2px;
 }
 
@@ -128,14 +107,10 @@
   align-items: center;
   justify-content: center;
   gap: clamp(6px, 1vw, 10px);
-  padding: 6px 10px;
+  padding: 4px clamp(4px, 1vw, 6px);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--color-surface-alt) 68%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 32%, transparent);
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 80%, transparent),
-    0 16px 32px color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  background: transparent;
+  color: var(--night-text, var(--color-text));
   min-width: 0;
 }
 
@@ -143,97 +118,81 @@
   position: relative;
   display: flex;
   align-items: center;
+  background: var(--night-panel, transparent);
+  border-radius: 999px;
+  border: 1px solid var(--night-input-ring, var(--border-color));
+  padding-inline: clamp(8px, 1.6vw, 12px);
+  min-height: 34px;
 }
 
 .language-select-wrapper::after {
   content: "";
   position: absolute;
-  right: 14px;
-  width: 7px;
-  height: 7px;
-  border-right: 2px solid color-mix(in srgb, var(--color-text) 76%, transparent);
+  right: clamp(8px, 1.4vw, 12px);
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid
+    color-mix(in srgb, var(--night-text, var(--color-text)) 76%, transparent);
   border-bottom: 2px solid
-    color-mix(in srgb, var(--color-text) 76%, transparent);
+    color-mix(in srgb, var(--night-text, var(--color-text)) 76%, transparent);
   transform: rotate(45deg);
   pointer-events: none;
 }
 
 .language-select {
   appearance: none;
-  min-width: 128px;
-  padding: 10px 34px 10px 18px;
+  min-width: 112px;
+  padding: 6px clamp(26px, 4vw, 32px) 6px clamp(12px, 2vw, 16px);
   border-radius: 999px;
   border: none;
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(in srgb, var(--color-surface-muted) 96%, transparent) 0%,
-      color-mix(in srgb, var(--color-surface-alt) 72%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--color-surface-muted) 92%, transparent);
-  box-shadow: inset 0 1px 0
-    color-mix(in srgb, var(--color-surface-muted) 84%, transparent);
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
+  background: transparent;
+  color: var(--night-text, var(--color-text));
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
   cursor: pointer;
-  transition:
-    box-shadow 0.2s ease,
-    transform 0.2s ease;
+  transition: transform 0.2s ease;
 }
 
 .language-select:hover,
 .language-select:focus-visible {
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 88%, transparent),
-    0 12px 24px color-mix(in srgb, var(--shadow-color) 18%, transparent);
   transform: translateY(-1px);
   outline: none;
 }
 
 .language-swap-button {
-  width: 42px;
-  height: 42px;
+  width: 38px;
+  height: 38px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 16px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 34%, transparent);
-  background:
-    linear-gradient(
-      160deg,
-      color-mix(in srgb, var(--color-surface-muted) 98%, transparent) 0%,
-      color-mix(in srgb, var(--color-surface-alt) 70%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--color-surface-alt) 90%, transparent);
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 82%, transparent),
-    0 18px 36px color-mix(in srgb, var(--shadow-color) 20%, transparent);
-  color: color-mix(in srgb, var(--color-text) 86%, transparent);
+  border-radius: 999px;
+  border: 1px solid var(--night-input-ring, var(--border-color));
+  background: transparent;
+  color: var(--night-muted, var(--color-text));
   cursor: pointer;
   transition:
     transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
+    background 0.2s ease;
 }
 
 .language-swap-button:hover,
 .language-swap-button:focus-visible {
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--primary-color) 48%, transparent);
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 86%, transparent),
-    0 22px 40px color-mix(in srgb, var(--shadow-color) 24%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--night-input-ring, var(--primary-color)) 18%,
+    transparent
+  );
   outline: none;
 }
 
 .language-swap-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--primary-color) 44%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 46%, transparent);
   outline-offset: 2px;
 }
 
@@ -242,24 +201,26 @@
     width: min(100%, 720px);
   }
 
-  .leading-accessory,
+  .leading-accessory {
+    padding-left: clamp(6px, 2vw, 12px);
+    padding-right: clamp(10px, 3vw, 16px);
+  }
+
   .trailing-accessory {
-    padding: clamp(16px, 5vw, 20px) clamp(16px, 6vw, 22px);
-    min-height: clamp(68px, 12vh, 80px);
+    padding-left: clamp(10px, 3vw, 14px);
   }
 
   .input-body {
-    padding: clamp(18px, 6vw, 22px) clamp(16px, 6vw, 20px);
+    padding: clamp(12px, 4vw, 18px) clamp(12px, 4vw, 16px);
   }
 
   .language-controls {
     gap: clamp(4px, 1.4vw, 8px);
-    padding: 4px 8px;
   }
 
   .language-select {
-    min-width: 112px;
-    font-size: 0.72rem;
+    min-width: 100px;
+    font-size: 0.76rem;
   }
 }
 
@@ -272,32 +233,22 @@
     width: 100%;
   }
 
-  .leading-accessory {
-    border-right: none;
-    padding-bottom: 0;
-  }
-
-  .trailing-accessory {
-    border-left: none;
-    padding-top: 0;
-  }
-
   .input-surface {
     flex-direction: column;
     align-items: stretch;
     border-radius: clamp(28px, 8vw, 36px);
-    gap: 0;
+    gap: clamp(10px, 4vw, 16px);
   }
 
   .input-body {
     width: 100%;
-    padding: clamp(16px, 7vw, 22px) clamp(14px, 7vw, 20px);
+    padding: clamp(14px, 7vw, 20px);
   }
 
   .language-controls {
     width: 100%;
-    justify-content: space-between;
-    padding: 6px 10px;
+    justify-content: center;
+    padding: clamp(10px, 4vw, 14px);
   }
 
   .language-select-wrapper {
@@ -311,5 +262,19 @@
   .language-swap-button {
     width: 40px;
     height: 40px;
+  }
+
+  .leading-accessory {
+    width: 100%;
+    padding: clamp(12px, 5vw, 18px);
+    border-right: none;
+    border-bottom: 1px solid var(--night-input-ring, var(--border-color));
+    justify-content: center;
+  }
+
+  .trailing-accessory {
+    border-left: none;
+    padding: 0;
+    justify-content: center;
   }
 }

--- a/website/src/components/ui/ChatInput/LanguageControls.jsx
+++ b/website/src/components/ui/ChatInput/LanguageControls.jsx
@@ -153,8 +153,8 @@ export default function LanguageControls({
         >
           <ThemeIcon
             name="arrow-right"
-            width={18}
-            height={18}
+            width={16}
+            height={16}
             aria-hidden="true"
           />
         </button>

--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -2,26 +2,15 @@
 .search-box {
   position: relative;
   display: flex;
-  align-items: stretch;
+  align-items: center;
   width: 100%;
-  padding: var(--padding-y, var(--search-box-padding-y))
-    var(--padding-x, clamp(18px, 5vw, 28px));
-  border-radius: clamp(36px, 5vw, 44px);
-  border: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
-  box-shadow:
-    inset 0 1px 0
-      color-mix(in srgb, var(--color-surface-muted) 82%, transparent),
-    0 36px 96px color-mix(in srgb, var(--shadow-color) 28%, transparent);
-  background:
-    linear-gradient(
-      150deg,
-      color-mix(in srgb, var(--input-bg) 96%, transparent) 0%,
-      color-mix(in srgb, var(--input-bg) 88%, transparent) 60%,
-      color-mix(in srgb, var(--input-bg) 84%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--input-bg) 94%, transparent);
-  backdrop-filter: blur(26px);
-  gap: var(--slot-gap, var(--space-3, 12px));
-  overflow: hidden;
+  padding: var(--padding-y, 0) var(--padding-x, clamp(16px, 4vw, 20px));
+  border-radius: 999px;
+  border: 1px solid var(--night-input-ring, var(--border-color));
+  background: var(--night-input-bg, var(--input-bg));
+  box-shadow: 0 12px 30px rgb(0 0 0 / 40%);
+  color: var(--night-text, var(--color-text));
+  gap: var(--slot-gap, 0);
   box-sizing: border-box;
+  overflow: hidden;
 }

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -1,54 +1,30 @@
 .sidebar {
-  --sidebar-padding: clamp(18px, 3vw, 28px);
-  --sidebar-inline-padding: clamp(20px, 3vw, 32px);
-  --sidebar-section-gap: clamp(16px, 2.8vw, 28px);
+  --sidebar-padding: clamp(14px, 2.8vw, 20px);
+  --sidebar-inline-padding: clamp(18px, 3vw, 26px);
+  --sidebar-section-gap: clamp(16px, 2.6vw, 24px);
   --sidebar-item-gap: 8px;
-  --sidebar-brand-gap: 12px;
+  --sidebar-brand-gap: 10px;
   --sidebar-item-padding-y: 12px;
-  --sidebar-item-padding-x: clamp(18px, 3vw, 24px);
-  --sidebar-item-padding: var(--sidebar-item-padding-y)
-    var(--sidebar-item-padding-x);
+  --sidebar-item-padding-x: clamp(16px, 3vw, 22px);
 
-  width: var(--layout-sidebar-width, clamp(240px, 24vw, 380px));
+  width: var(
+    --layout-sidebar-width,
+    var(--layout-sidebar-default, clamp(240px, 24vw, 380px))
+  );
   min-width: var(--layout-sidebar-min, 240px);
   max-width: var(--layout-sidebar-max, 392px);
   height: var(--vh);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--sidebar-bg) 96%, transparent) 0%,
-      color-mix(in srgb, var(--sidebar-bg) 92%, transparent) 42%,
-      color-mix(in srgb, var(--sidebar-bg) 88%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--sidebar-bg) 96%, transparent);
-  color: var(--sidebar-color);
-  border-right: 1px solid
-    color-mix(in srgb, var(--border-color) 48%, transparent);
+  background: var(--night-surface, var(--sidebar-bg));
+  color: var(--night-text, var(--sidebar-color));
+  border-right: 1px solid var(--night-border, var(--border-color));
   display: grid;
   grid-template-rows: auto 1fr auto;
   position: sticky;
   top: 0;
   align-self: start;
   overflow: hidden;
-  box-shadow:
-    inset -1px 0 0 color-mix(in srgb, var(--border-color) 34%, transparent),
-    0 32px 80px color-mix(in srgb, var(--shadow-color) 22%, transparent);
-  backdrop-filter: blur(24px);
-  isolation: isolate;
-}
-
-.sidebar::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    140% 120% at -20% 0%,
-    color-mix(in srgb, var(--primary-bg) 14%, transparent) 0%,
-    transparent 68%
-  );
-  opacity: 0.4;
-  pointer-events: none;
-  z-index: 0;
+  box-shadow: var(--night-shadow, 0 12px 30px rgb(0 0 0 / 40%));
+  z-index: 1;
 }
 
 .sidebar-brand {
@@ -57,12 +33,11 @@
   display: flex;
   align-items: center;
   gap: var(--sidebar-brand-gap);
-  padding: clamp(20px, 3vw, 28px) var(--sidebar-inline-padding)
-    clamp(12px, 2.4vw, 18px);
-  background: color-mix(in srgb, var(--sidebar-bg) 96%, transparent);
-  border-bottom: 1px solid
-    color-mix(in srgb, var(--border-color) 40%, transparent);
-  z-index: 1;
+  padding: clamp(18px, 3vw, 24px) var(--sidebar-inline-padding)
+    clamp(10px, 2vw, 16px);
+  background: var(--night-surface, var(--sidebar-bg));
+  border-bottom: 1px solid var(--night-border, var(--border-color));
+  z-index: 2;
 }
 
 .sidebar-brand [data-variant="prominent"] {
@@ -70,14 +45,10 @@
   width: 100%;
 }
 
-.sidebar-brand img {
-  width: 36px;
-  height: 36px;
-}
-
 .sidebar-brand span {
-  font-size: 1.3rem;
-  letter-spacing: 0.02em;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+  font-weight: 600;
 }
 
 .mobile-user-menu {
@@ -87,57 +58,27 @@
 .sidebar-overlay {
   position: fixed;
   inset: 0;
-  background: color-mix(in srgb, rgb(8 10 16) 55%, transparent);
-  backdrop-filter: blur(8px);
+  background: rgb(8 10 16 / 60%);
+  backdrop-filter: blur(6px);
   z-index: 998;
 }
 
 .display {
   position: relative;
-  width: min(100%, 920px);
+  width: min(100%, 960px);
   margin: 0 auto;
-  padding: clamp(32px, 5vw, 48px) clamp(28px, 5vw, 44px);
-  border-radius: clamp(24px, 4vw, 38px);
-  border: 1px solid color-mix(in srgb, var(--border-color) 42%, transparent);
-  background:
-    linear-gradient(
-      160deg,
-      color-mix(in srgb, var(--app-bg) 94%, transparent) 0%,
-      color-mix(in srgb, var(--app-bg) 88%, transparent) 60%,
-      color-mix(in srgb, var(--app-bg) 82%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--app-bg) 92%, transparent);
-  box-shadow: 0 44px 120px
-    color-mix(in srgb, var(--shadow-color) 26%, transparent);
+  padding: clamp(24px, 5vw, 32px) clamp(20px, 5vw, 28px)
+    clamp(140px, 22vh, 200px);
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: clamp(24px, 3vw, 32px);
-  color: var(--app-color);
-  text-align: left;
-  overflow: hidden;
-}
-
-.display::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    120% 120% at 80% -10%,
-    color-mix(in srgb, var(--primary-bg) 10%, transparent) 0%,
-    transparent 65%
-  );
-  opacity: 0.4;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.display > * {
-  position: relative;
-  z-index: 1;
+  justify-content: center;
+  align-items: flex-start;
+  color: var(--night-text, var(--app-color));
+  overflow: auto;
 }
 
 .display-empty {
+  flex: 1;
+  display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
@@ -146,14 +87,12 @@
 
 .stream-text {
   width: 100%;
-  padding: clamp(20px, 3vw, 28px);
-  background: color-mix(in srgb, var(--app-bg) 88%, transparent);
-  color: var(--app-color);
-  border-radius: clamp(18px, 3vw, 24px);
-  border: 1px solid color-mix(in srgb, var(--border-color) 36%, transparent);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--app-bg) 86%, transparent),
-    0 28px 64px color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  padding: clamp(18px, 3vw, 24px);
+  background: var(--night-panel, var(--app-bg));
+  color: inherit;
+  border-radius: 16px;
+  border: 1px solid var(--night-border, var(--border-color));
+  box-shadow: 0 12px 28px rgb(0 0 0 / 24%);
   line-height: 1.6;
 }
 
@@ -167,26 +106,24 @@
 }
 
 .app-bottom {
-  width: min(100%, 960px);
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
-  padding: 0 clamp(12px, 4vw, 20px);
+  gap: 8px;
 }
 
 @media (width <= 900px) {
   .sidebar {
     position: fixed;
     inset: 0 auto 0 0;
-    width: min(80vw, 320px);
-    max-width: min(80vw, 360px);
+    width: min(82vw, 320px);
+    max-width: min(82vw, 360px);
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 999;
-    border-right: none;
-    box-shadow: 0 24px 80px
-      color-mix(in srgb, var(--shadow-color) 32%, transparent);
+    border-right: 1px solid var(--night-border, var(--border-color));
+    box-shadow: var(--night-shadow, 0 12px 30px rgb(0 0 0 / 40%));
   }
 
   .sidebar.mobile-open {
@@ -199,10 +136,8 @@
 
   .display {
     width: 100%;
-    padding: clamp(24px, 6vw, 36px);
-    border-radius: clamp(20px, 6vw, 28px);
-    box-shadow: 0 28px 80px
-      color-mix(in srgb, var(--shadow-color) 30%, transparent);
+    padding: clamp(24px, 6vw, 32px) clamp(18px, 6vw, 28px)
+      clamp(160px, 30vh, 220px);
   }
 
   .display-empty {
@@ -212,12 +147,7 @@
 
 @media (width <= 600px) {
   .sidebar {
-    width: min(84vw, 300px);
-  }
-
-  .display {
-    padding: clamp(20px, 7vw, 32px);
-    border-radius: clamp(18px, 7vw, 24px);
+    width: min(86vw, 300px);
   }
 
   .stream-text {
@@ -226,10 +156,5 @@
 
   .app-bottom {
     width: 100%;
-    padding: 0;
   }
-}
-
-.app h2 {
-  text-align: center;
 }

--- a/website/src/theme/colors.css
+++ b/website/src/theme/colors.css
@@ -30,6 +30,18 @@
   --hl-light: var(--neutral-0);
   --hl-dark: var(--neutral-950);
 
+  /* prototype midnight palette */
+  --night-surface: #0f1115;
+  --night-panel: #1f232b;
+  --night-border: #2a2e37;
+  --night-hover: #1a1e24;
+  --night-active: #242935;
+  --night-text: #eef0f3;
+  --night-muted: #a2a9b4;
+  --night-shadow: 0 12px 30px rgb(0 0 0 / 40%);
+  --night-input-bg: #2b2f34;
+  --night-input-ring: #3a3f46;
+
   /* link colors */
   --color-link-light: #d49f0a;
   --color-link-dark: #ffe899;


### PR DESCRIPTION
## Summary
- add midnight design tokens and apply them throughout the app shell to mirror the provided prototype
- refactor the layout with a resizable sidebar and repositioned bottom search area
- restyle sidebar navigation, history list, and chat input (including language controls) to match the prototype visuals

## Testing
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w src

------
https://chatgpt.com/codex/tasks/task_e_68d7f0c1500c8332ba68ce9e6073e551