### PR TITLE
Fix dictionary navigation icon tone and hover styling

### DIFF
--- a/website/src/components/Brand/index.jsx
+++ b/website/src/components/Brand/index.jsx
@@ -38,8 +38,8 @@ function Brand({ activeView, onShowDictionary, onShowFavorites }) {
       icon: "glancy-web",
       iconAlt: dictionaryLabel,
       onClick: handleDictionary,
-      variant: SIDEBAR_ACTION_VARIANTS.default,
-      isActive: activeView === "dictionary",
+      variant: SIDEBAR_ACTION_VARIANTS.surface,
+      enableActiveState: false,
       className: "sidebar-nav-item sidebar-nav-item-dictionary",
       title: dictionaryHint,
     },
@@ -49,8 +49,8 @@ function Brand({ activeView, onShowDictionary, onShowFavorites }) {
       icon: "library",
       iconAlt: libraryLabel,
       onClick: handleLibrary,
-      variant: SIDEBAR_ACTION_VARIANTS.default,
-      isActive: activeView === "favorites",
+      variant: SIDEBAR_ACTION_VARIANTS.surface,
+      enableActiveState: true,
       className: "sidebar-nav-item",
       title: libraryHint,
     },
@@ -60,21 +60,24 @@ function Brand({ activeView, onShowDictionary, onShowFavorites }) {
     <div className="sidebar-brand">
       <div className="sidebar-brand-header">
         <nav className="sidebar-primary-nav" aria-label={dictionaryLabel}>
-          {navItems.map((item) => (
-            <SidebarActionItem
-              key={item.key}
-              icon={item.icon}
-              iconAlt={item.iconAlt}
-              iconTone="dark"
-              label={item.label}
-              onClick={item.onClick}
-              variant={item.variant}
-              isActive={item.isActive}
-              className={item.className}
-              aria-current={item.isActive ? "page" : undefined}
-              title={item.title}
-            />
-          ))}
+          {navItems.map((item) => {
+            const isActive = item.enableActiveState && activeView === item.key;
+
+            return (
+              <SidebarActionItem
+                key={item.key}
+                icon={item.icon}
+                iconAlt={item.iconAlt}
+                label={item.label}
+                onClick={item.onClick}
+                variant={item.variant}
+                isActive={isActive}
+                className={item.className}
+                aria-current={isActive ? "page" : undefined}
+                title={item.title}
+              />
+            );
+          })}
         </nav>
         <div className="mobile-user-menu">
           <UserMenu size={28} />

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -92,13 +92,30 @@
     background-color 160ms ease,
     color 160ms ease,
     border-color 160ms ease,
+    box-shadow 160ms ease,
     transform 160ms ease;
+  box-shadow: none;
 }
 
 .sidebar-action[data-variant="prominent"] {
   background: color-mix(in srgb, var(--accent-color) 18%, transparent);
   border-color: color-mix(in srgb, var(--accent-color) 42%, transparent);
   color: color-mix(in srgb, var(--accent-color) 68%, var(--sidebar-color));
+}
+
+.sidebar-action[data-variant="surface"] {
+  background: color-mix(in srgb, var(--sidebar-bg) 96%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 64%,
+    transparent
+  );
+  color: color-mix(
+    in srgb,
+    var(--sidebar-color) 88%,
+    var(--sidebar-muted-color, var(--sidebar-color))
+  );
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--shadow-color) 14%, transparent);
 }
 
 .sidebar-action:where(:hover, :focus-visible) {
@@ -112,6 +129,14 @@
     transparent
   );
   transform: translateY(-1px);
+}
+
+.sidebar-action[data-variant="surface"]:where(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 42%, transparent);
+  color: var(--sidebar-color);
+  box-shadow: 0 8px 20px
+    color-mix(in srgb, var(--shadow-color) 18%, transparent);
 }
 
 .sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
@@ -139,6 +164,14 @@
     transparent
   );
   color: var(--sidebar-color);
+}
+
+.sidebar-action-active[data-variant="surface"] {
+  background: color-mix(in srgb, var(--sidebar-bg) 84%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 46%, transparent);
+  color: var(--sidebar-color);
+  box-shadow: 0 10px 24px
+    color-mix(in srgb, var(--shadow-color) 20%, transparent);
 }
 
 .sidebar-action-active[data-variant="prominent"] {

--- a/website/src/components/Sidebar/sidebarActionVariants.js
+++ b/website/src/components/Sidebar/sidebarActionVariants.js
@@ -1,4 +1,5 @@
 export const SIDEBAR_ACTION_VARIANTS = Object.freeze({
   default: "default",
   prominent: "prominent",
+  surface: "surface",
 });


### PR DESCRIPTION
## Summary
- switch the dictionary sidebar entry to the surface action variant and let its icon pick the appropriate theme asset automatically
- refine sidebar action styling with a dedicated surface treatment so hover and active states match the design reference while preventing default highlighting of the dictionary entry
- extend the sidebar action variants registry to expose the new surface option for reuse

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .

------
https://chatgpt.com/codex/tasks/task_e_68d810bc61b88332bcc6dc2162a19cbd