### PR TITLE
Simplify output toolbar presentation

### DIFF
--- a/website/src/components/OutputToolbar/OutputToolbar.module.css
+++ b/website/src/components/OutputToolbar/OutputToolbar.module.css
@@ -1,200 +1,95 @@
 .toolbar {
   display: flex;
-  flex-direction: column;
-  gap: 18px;
-  padding: 18px 24px;
-  border-radius: 28px;
-  background: color-mix(in srgb, var(--color-surface-alt) 94%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
-  box-shadow: 0 18px 46px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
-  backdrop-filter: blur(18px);
-  transition:
-    box-shadow 0.3s ease,
-    border-color 0.3s ease;
-}
-
-.toolbar:hover,
-.toolbar:focus-within {
-  box-shadow: 0 22px 54px
-    color-mix(in srgb, var(--shadow-color) 26%, transparent);
-  border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
-}
-
-.primary-cluster {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
   flex-wrap: wrap;
-}
-
-.replay {
-  display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 22px;
-  border-radius: 999px;
-  border: none;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--primary-bg) 90%, transparent) 0%,
-    color-mix(in srgb, var(--primary-color) 28%, var(--primary-bg) 72%) 100%
-  );
-  color: var(--primary-color);
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    opacity 0.2s ease;
-  box-shadow: 0 12px 28px
-    color-mix(in srgb, var(--shadow-color) 20%, transparent);
+  gap: var(--space-3);
+  padding: var(--space-2) calc(var(--space-3) + 8px);
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--color-surface-alt) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
 }
 
-.replay:disabled {
-  cursor: not-allowed;
-  background: color-mix(in srgb, var(--color-surface-alt) 82%, transparent);
-  color: color-mix(in srgb, var(--color-text-secondary) 68%, transparent);
-  box-shadow: none;
-  opacity: 1;
-  transform: none;
-}
-
-.replay:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--primary-color) 42%, transparent);
-  outline-offset: 2px;
-}
-
-.replay:not(:disabled):is(:hover, :focus-visible) {
-  transform: translateY(-1px);
-  box-shadow: 0 14px 32px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
-}
-
-.meta-strip {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 12px 16px;
-  border-radius: 20px;
-  background: color-mix(in srgb, var(--app-bg) 82%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 46%, transparent);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--border-color) 20%, transparent);
-  backdrop-filter: blur(16px);
-}
-
+.left-cluster,
 .action-strip {
   display: flex;
   align-items: center;
-  gap: 12px;
-  flex: 1 1 auto;
-  min-width: 0;
+  gap: var(--space-2);
+  flex-wrap: wrap;
 }
 
-.separator {
-  width: 1px;
-  height: 36px;
-  background: color-mix(in srgb, var(--border-color) 45%, transparent);
-  border-radius: 999px;
+.action-strip {
+  flex: 1 1 auto;
+  justify-content: center;
+  min-width: 160px;
 }
 
 .icon-button {
-  width: 42px;
-  height: 42px;
+  width: 36px;
+  height: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 14px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 45%, transparent);
-  background: color-mix(in srgb, var(--color-surface-alt) 96%, transparent);
-  color: color-mix(in srgb, var(--color-text) 88%, transparent);
+  border: none;
+  background: none;
+  border-radius: var(--radius-lg);
+  color: color-mix(in srgb, var(--color-text-secondary) 86%, transparent);
+  opacity: 0.7;
   cursor: pointer;
-  box-shadow: 0 12px 28px
-    color-mix(in srgb, var(--shadow-color) 18%, transparent);
   transition:
-    background-color 160ms ease,
-    box-shadow 160ms ease,
-    transform 160ms ease,
-    color 160ms ease,
-    border-color 160ms ease;
+    color 0.2s ease,
+    opacity 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .icon-button:hover,
 .icon-button:focus-visible {
-  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
-  box-shadow: 0 14px 34px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 28%, transparent);
+  opacity: 1;
+  color: color-mix(in srgb, var(--accent-color) 82%, var(--app-color) 18%);
+  background: color-mix(in srgb, var(--accent-color) 12%, transparent);
   transform: translateY(-1px);
 }
 
 .icon-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent-color) 42%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 35%, transparent);
   outline-offset: 2px;
 }
 
 .icon-button:disabled {
+  opacity: 0.35;
   cursor: not-allowed;
-  color: color-mix(in srgb, var(--color-text-secondary) 68%, transparent);
-  background: color-mix(in srgb, var(--color-surface-alt) 78%, transparent);
-  border-color: color-mix(in srgb, var(--border-color) 34%, transparent);
-  box-shadow: none;
+  background: none;
   transform: none;
 }
 
 .icon-button[data-active="true"] {
   color: color-mix(in srgb, var(--accent-color) 78%, var(--app-color) 22%);
+  opacity: 1;
 }
 
-.icon-button[data-active="true"]:disabled {
-  color: color-mix(in srgb, var(--accent-color) 60%, var(--app-color) 40%);
+.icon-button-replay {
+  color: color-mix(in srgb, var(--accent-color) 78%, var(--app-color) 22%);
 }
 
-.icon-button-favorite {
+.icon-button-replay:disabled {
+  color: color-mix(in srgb, var(--color-text-tertiary) 88%, transparent);
+}
+
+.icon-button-favorite,
+.icon-button-share {
   color: color-mix(in srgb, var(--accent-color) 70%, var(--app-color) 30%);
 }
 
-.icon-button-delete {
-  color: color-mix(in srgb, var(--color-danger) 70%, var(--app-color) 30%);
-}
-
-.icon-button-delete:hover,
-.icon-button-delete:focus-visible {
-  background: color-mix(in srgb, var(--color-danger) 16%, transparent);
-  border-color: color-mix(in srgb, var(--color-danger) 30%, transparent);
-}
-
-.icon-button-share {
-  color: color-mix(in srgb, var(--accent-color) 66%, var(--app-color) 34%);
-}
-
-.icon-button-share:hover,
-.icon-button-share:focus-visible {
-  background: color-mix(in srgb, var(--accent-color) 20%, transparent);
-}
-
+.icon-button-delete,
 .icon-button-report {
-  color: color-mix(in srgb, var(--color-danger) 58%, var(--app-color) 42%);
-}
-
-.icon-button-report:hover,
-.icon-button-report:focus-visible {
-  background: color-mix(in srgb, var(--color-danger) 20%, transparent);
+  color: color-mix(in srgb, var(--color-danger) 70%, var(--app-color) 30%);
 }
 
 .version-dial {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 6px 14px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-surface-alt) 88%, transparent);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--border-color) 30%, transparent);
+  gap: var(--space-2);
+  margin-left: auto;
 }
 
 .nav-button {
@@ -203,43 +98,42 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 50%;
-  border: 1px solid color-mix(in srgb, var(--border-color) 52%, transparent);
-  background: color-mix(in srgb, var(--color-surface-alt) 94%, transparent);
-  color: color-mix(in srgb, var(--color-text) 88%, transparent);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 95%, transparent);
+  color: color-mix(in srgb, var(--color-text-secondary) 82%, transparent);
   cursor: pointer;
   transition:
-    transform 0.2s ease,
+    border-color 0.2s ease,
     color 0.2s ease,
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
+    background-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .nav-button:disabled {
   cursor: not-allowed;
-  color: color-mix(in srgb, var(--color-text-secondary) 70%, transparent);
-  background: color-mix(in srgb, var(--color-surface-alt) 74%, transparent);
-  border-color: color-mix(in srgb, var(--border-color) 36%, transparent);
-  box-shadow: none;
+  color: color-mix(in srgb, var(--color-text-tertiary) 90%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 80%, transparent);
+  border-color: color-mix(in srgb, var(--border-color) 40%, transparent);
   transform: none;
 }
 
 .nav-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--primary-color) 40%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 35%, transparent);
   outline-offset: 2px;
 }
 
 .nav-button:not(:disabled):is(:hover, :focus-visible) {
+  border-color: color-mix(in srgb, var(--accent-color) 40%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 80%, var(--app-color) 20%);
+  background: color-mix(in srgb, var(--accent-color) 12%, transparent);
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--primary-color) 46%, transparent);
-  box-shadow: 0 10px 22px
-    color-mix(in srgb, var(--shadow-color) 18%, transparent);
 }
 
 .indicator {
-  min-width: 56px;
+  min-width: 48px;
   text-align: center;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   color: color-mix(in srgb, var(--color-text-secondary) 80%, transparent);
@@ -247,31 +141,11 @@
 
 @media (width <= 768px) {
   .toolbar {
-    padding: 16px;
-    gap: 16px;
-  }
-
-  .meta-strip {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 14px;
-  }
-
-  .action-strip {
     justify-content: center;
-    flex-wrap: wrap;
-  }
-
-  .separator {
-    display: none;
+    gap: var(--space-2);
   }
 
   .version-dial {
-    justify-content: center;
-  }
-
-  .icon-button {
-    width: 38px;
-    height: 38px;
+    margin-left: 0;
   }
 }

--- a/website/src/components/OutputToolbar/index.jsx
+++ b/website/src/components/OutputToolbar/index.jsx
@@ -170,12 +170,14 @@ function OutputToolbar({
     return items;
   }, [actionContext, canCopy, copyLabel, disabled, onCopy, user]);
 
-  const showPrimaryCluster = showTts || typeof onReoutput === "function";
+  const showReplay = typeof onReoutput === "function";
+  const showLeftCluster = showTts || showReplay;
+  const hasActions = actionItems.length > 0;
 
   return (
     <div className={styles.toolbar} data-testid="output-toolbar">
-      {showPrimaryCluster ? (
-        <div className={styles["primary-cluster"]}>
+      {showLeftCluster ? (
+        <div className={styles["left-cluster"]}>
           {showTts ? (
             <TtsComponent
               text={term}
@@ -184,10 +186,10 @@ function OutputToolbar({
               disabled={!speakableTerm}
             />
           ) : null}
-          {typeof onReoutput === "function" ? (
+          {showReplay ? (
             <button
               type="button"
-              className={styles.replay}
+              className={`${styles["icon-button"]} ${styles["icon-button-replay"]}`}
               onClick={onReoutput}
               disabled={disabled || !speakableTerm}
               aria-label={t.reoutput}
@@ -198,12 +200,11 @@ function OutputToolbar({
                 height={16}
                 aria-hidden="true"
               />
-              <span>{t.reoutput}</span>
             </button>
           ) : null}
         </div>
       ) : null}
-      <div className={styles["meta-strip"]}>
+      {hasActions ? (
         <div className={styles["action-strip"]}>
           {actionItems.map(
             ({
@@ -240,38 +241,37 @@ function OutputToolbar({
             },
           )}
         </div>
-        <span className={styles.separator} aria-hidden="true" />
-        <div className={styles["version-dial"]}>
-          <button
-            type="button"
-            className={styles["nav-button"]}
-            onClick={() => onNavigate?.("previous")}
-            disabled={!hasPrevious || disabled}
-            aria-label={t.previousVersion}
-          >
-            <ThemeIcon
-              name="arrow-left"
-              width={14}
-              height={14}
-              aria-hidden="true"
-            />
-          </button>
-          <span className={styles.indicator}>{indicator}</span>
-          <button
-            type="button"
-            className={styles["nav-button"]}
-            onClick={() => onNavigate?.("next")}
-            disabled={!hasNext || disabled}
-            aria-label={t.nextVersion}
-          >
-            <ThemeIcon
-              name="arrow-right"
-              width={14}
-              height={14}
-              aria-hidden="true"
-            />
-          </button>
-        </div>
+      ) : null}
+      <div className={styles["version-dial"]}>
+        <button
+          type="button"
+          className={styles["nav-button"]}
+          onClick={() => onNavigate?.("previous")}
+          disabled={!hasPrevious || disabled}
+          aria-label={t.previousVersion}
+        >
+          <ThemeIcon
+            name="arrow-left"
+            width={14}
+            height={14}
+            aria-hidden="true"
+          />
+        </button>
+        <span className={styles.indicator}>{indicator}</span>
+        <button
+          type="button"
+          className={styles["nav-button"]}
+          onClick={() => onNavigate?.("next")}
+          disabled={!hasNext || disabled}
+          aria-label={t.nextVersion}
+        >
+          <ThemeIcon
+            name="arrow-right"
+            width={14}
+            height={14}
+            aria-hidden="true"
+          />
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- restructure the output toolbar cluster so the replay control becomes an icon button and the navigation dial is rendered inline
- refresh the toolbar button styling to remove gradients, simplify hover states, and align with the lightweight reference layout

## Testing
- npx eslint --fix src
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/OutputToolbar/index.jsx src/components/OutputToolbar/OutputToolbar.module.css

------
https://chatgpt.com/codex/tasks/task_e_68d8175ace60833294fec1f13b3114f6