### PR TITLE
refactor: redesign settings panel layout

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -8,27 +8,234 @@
 
 .layout {
   display: grid;
+  gap: clamp(var(--space-5), 4vw, var(--space-7));
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.sidebar {
+  display: grid;
   gap: clamp(var(--space-4), 3vw, var(--space-5));
+  align-content: start;
+}
+
+.sidebar-card {
+  position: relative;
+  display: grid;
+  gap: var(--space-3);
+  padding: clamp(var(--space-4), 3vw, var(--space-5));
+  border-radius: 26px;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 42%,
+      transparent
+    );
+  background:
+    linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 36%)) 48%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
+  box-shadow: 0 36px 96px
+    color-mix(in srgb, var(--shadow-color) 26%, transparent);
+  overflow: hidden;
+}
+
+.sidebar-card::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 18%,
+      transparent
+    );
+  pointer-events: none;
+}
+
+.sidebar-eyebrow {
+  font-size: var(--text-xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(
+    in srgb,
+    var(--sidebar-muted-color, var(--app-color)) 68%,
+    transparent
+  );
+}
+
+.sidebar-active-title {
+  margin: 0;
+  font-size: clamp(var(--text-lg), 2.6vw, var(--text-2xl));
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sidebar-color, var(--app-color));
+}
+
+.sidebar-description {
+  margin: 0;
+  color: color-mix(
+    in srgb,
+    var(--sidebar-muted-color, var(--app-color)) 72%,
+    transparent
+  );
+  line-height: 1.7;
+  font-size: var(--text-sm);
 }
 
 .tab-list {
   display: grid;
-  gap: 10px;
+  gap: clamp(var(--space-3), 3vw, var(--space-4));
   align-content: start;
 }
 
 .tab-button {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-3);
+  align-items: center;
+  width: 100%;
+  padding: clamp(14px, 2.6vw, 18px) clamp(18px, 4vw, 22px);
+  border-radius: 20px;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 38%,
+      transparent
+    );
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 28%)) 42%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--sidebar-color, var(--app-color)) 88%,
+    transparent
+  );
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.tab-button::after {
+  content: "\203A";
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-end: clamp(14px, 3vw, 20px);
+  transform: translate(0, -50%);
+  font-size: 1.2rem;
+  color: currentcolor;
+  opacity: 0.48;
+  transition:
+    transform 160ms ease,
+    opacity 160ms ease;
+}
+
+.tab-button:hover,
+.tab-button:focus-visible {
+  background:
+    linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 42%)) 52%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 58%,
+    transparent
+  );
+  color: var(--sidebar-color, var(--app-color));
+  transform: translateX(4px);
+  box-shadow: 0 24px 68px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
+}
+
+.tab-button:hover::after,
+.tab-button:focus-visible::after {
+  opacity: 0.84;
+  transform: translate(4px, -50%);
+}
+
+.tab-button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--primary-color) 32%, transparent),
+    0 24px 68px color-mix(in srgb, var(--shadow-color) 24%, transparent);
+}
+
+.tab-button-active {
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 52%)) 66%,
+          transparent
+        )
+        0%,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 62%,
+    transparent
+  );
+  color: var(--sidebar-color, var(--app-color));
+  transform: translateX(6px);
+  box-shadow: 0 30px 82px
+    color-mix(in srgb, var(--shadow-color) 32%, transparent);
+}
+
+.tab-button-active::after {
+  opacity: 1;
+  transform: translate(6px, -50%);
+}
+
+.tab-icon-wrapper {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  width: 100%;
-  min-height: 46px;
-  padding: 0 18px;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
   border-radius: 14px;
   border: 1px solid
     color-mix(
       in srgb,
-      var(--sidebar-border-color, var(--border-color)) 40%,
+      var(--sidebar-border-color, var(--border-color)) 36%,
       transparent
     );
   background: color-mix(
@@ -36,91 +243,100 @@
     var(--sidebar-panel, var(--app-bg)) 90%,
     transparent
   );
-  color: color-mix(
-    in srgb,
-    var(--sidebar-color, var(--app-color)) 86%,
-    transparent
-  );
-  font-size: var(--text-sm);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-weight: var(--font-semibold);
-  cursor: pointer;
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--neutral-0) 20%, transparent);
   transition:
     background-color 160ms ease,
     border-color 160ms ease,
-    transform 160ms ease,
-    color 160ms ease;
+    box-shadow 160ms ease;
 }
 
-.tab-button:hover,
-.tab-button:focus-visible {
+.tab-button-active .tab-icon-wrapper {
+  border-color: color-mix(in srgb, var(--primary-color) 38%, transparent);
   background: color-mix(
     in srgb,
-    var(--sidebar-hover-bg, rgb(24 27 33 / 56%)) 75%,
+    var(--primary-bg, var(--sidebar-panel, var(--app-bg))) 72%,
     transparent
   );
-  border-color: color-mix(
-    in srgb,
-    var(--sidebar-border-color, var(--border-color)) 62%,
-    transparent
-  );
-  color: var(--sidebar-color, var(--app-color));
-  transform: translateX(4px);
-}
-
-.tab-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px
-    color-mix(in srgb, var(--primary-color) 32%, transparent);
-}
-
-.tab-button-active {
-  background: color-mix(
-    in srgb,
-    var(--sidebar-hover-bg, rgb(24 27 33 / 68%)) 80%,
-    transparent
-  );
-  border-color: color-mix(
-    in srgb,
-    var(--sidebar-border-color, var(--border-color)) 70%,
-    transparent
-  );
-  color: var(--sidebar-color, var(--app-color));
-  transform: translateX(4px);
+  box-shadow: 0 12px 28px
+    color-mix(in srgb, var(--shadow-color) 26%, transparent);
 }
 
 .tab-icon {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   color: inherit;
+}
+
+.tab-copy {
+  display: grid;
+  gap: 6px;
+}
+
+.tab-label {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tab-support {
+  font-size: var(--text-xs);
+  color: color-mix(
+    in srgb,
+    var(--sidebar-muted-color, var(--app-color)) 70%,
+    transparent
+  );
+  line-height: 1.6;
 }
 
 .panel-area {
   display: grid;
+  min-height: 100%;
 }
 
 .panel-card {
+  position: relative;
   display: grid;
   gap: clamp(var(--space-4), 3vw, var(--space-5));
   padding: clamp(var(--space-4), 3vw, var(--space-5));
-  border-radius: 22px;
+  border-radius: 28px;
   border: 1px solid
     color-mix(
       in srgb,
-      var(--sidebar-border-color, var(--border-color)) 44%,
+      var(--sidebar-border-color, var(--border-color)) 42%,
       transparent
     );
-  background: color-mix(
-    in srgb,
-    var(--sidebar-panel, var(--app-bg)) 92%,
-    transparent
-  );
-  box-shadow: 0 32px 88px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
+  background:
+    linear-gradient(
+      150deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
+        0%,
+      color-mix(in srgb, var(--color-surface-alt) 72%, transparent) 100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
+  box-shadow: 0 44px 120px
+    color-mix(in srgb, var(--shadow-color) 28%, transparent);
+  overflow: hidden;
+}
+
+.panel-card::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 18%,
+      transparent
+    );
+  pointer-events: none;
 }
 
 .panel-header {
+  position: relative;
+  z-index: 1;
   display: grid;
   gap: var(--space-2);
 }
@@ -156,25 +372,96 @@
   font-size: var(--text-sm);
 }
 
-.setting-list {
+.panel-body {
+  position: relative;
+  z-index: 1;
   display: grid;
-  gap: 18px;
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
+}
+
+.panel-callout {
+  display: grid;
+  gap: 8px;
+  padding: clamp(var(--space-3), 2.4vw, var(--space-4));
+  border-radius: 22px;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 34%,
+      transparent
+    );
+  background:
+    linear-gradient(
+      150deg,
+      color-mix(in srgb, var(--primary-bg, var(--app-bg)) 82%, transparent) 0%,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
+  box-shadow: 0 26px 70px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
+}
+
+.callout-eyebrow {
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--primary-color) 86%, transparent);
+}
+
+.callout-description {
+  margin: 0;
+  color: color-mix(
+    in srgb,
+    var(--sidebar-muted-color, var(--app-color)) 72%,
+    transparent
+  );
+  line-height: 1.7;
+  font-size: var(--text-sm);
+}
+
+.setting-grid {
+  display: grid;
+  gap: clamp(var(--space-3), 2.6vw, var(--space-4));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .setting-row {
   display: grid;
-  gap: 16px;
-  align-items: center;
-  grid-template-columns: minmax(0, 180px) minmax(0, 1fr);
+  gap: var(--space-3);
+  align-content: start;
+  padding: clamp(16px, 2.6vw, 22px);
+  border-radius: 20px;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 36%,
+      transparent
+    );
+  background:
+    linear-gradient(
+      150deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 32%)) 42%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
+  box-shadow: 0 26px 70px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
 }
 
 .setting-label {
-  font-size: var(--text-sm);
-  letter-spacing: 0.06em;
+  font-size: var(--text-xs);
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: color-mix(
     in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 68%,
+    var(--sidebar-muted-color, var(--app-color)) 70%,
     transparent
   );
 }
@@ -183,33 +470,63 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 18px;
-  border-radius: 16px;
+  gap: var(--space-3);
+  padding: clamp(18px, 3vw, 24px);
+  border-radius: 22px;
   border: 1px solid
     color-mix(
       in srgb,
       var(--sidebar-border-color, var(--border-color)) 36%,
       transparent
     );
-  background: color-mix(
-    in srgb,
-    var(--sidebar-hover-bg, rgb(24 27 33 / 30%)) 48%,
-    transparent
-  );
+  background:
+    linear-gradient(
+      140deg,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 32%)) 48%,
+          transparent
+        )
+        0%,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
+  box-shadow: 0 24px 64px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
 }
 
 .switch {
   position: relative;
   display: inline-flex;
-  width: 54px;
-  height: 28px;
+  width: 58px;
+  height: 30px;
   border-radius: 999px;
-  background: color-mix(
-    in srgb,
-    var(--sidebar-border-color, var(--border-color)) 50%,
-    transparent
-  );
-  transition: background-color 160ms ease;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 44%,
+      transparent
+    );
+  background:
+    linear-gradient(
+      130deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 28%)) 48%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--neutral-0) 24%, transparent);
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .switch input {
@@ -223,36 +540,82 @@
   position: absolute;
   top: 4px;
   left: 4px;
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  background: var(--app-bg);
-  box-shadow: 0 6px 18px
-    color-mix(in srgb, var(--shadow-color) 28%, transparent);
-  transition: transform 160ms ease;
+  background:
+    linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--app-bg) 96%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-muted) 68%, transparent) 100%
+    ),
+    var(--app-bg);
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 36%,
+      transparent
+    );
+  box-shadow: 0 8px 20px
+    color-mix(in srgb, var(--shadow-color) 30%, transparent);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease;
 }
 
 .switch input:checked + span {
   transform: translateX(26px);
-  box-shadow: 0 10px 24px
+  box-shadow: 0 12px 26px
     color-mix(in srgb, var(--primary-color) 36%, transparent);
-  border: 1px solid color-mix(in srgb, var(--primary-color) 42%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary-color) 46%, transparent);
+  background:
+    linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--primary-color) 80%, transparent) 0%,
+      color-mix(in srgb, var(--primary-color) 60%, transparent) 100%
+    ),
+    var(--primary-color);
 }
 
 .field-grid {
   display: grid;
-  gap: var(--space-4);
+  gap: clamp(var(--space-3), 2.6vw, var(--space-4));
 }
 
 .field-item {
   display: grid;
-  gap: var(--space-2);
+  gap: var(--space-3);
+  padding: clamp(16px, 2.6vw, 22px);
+  border-radius: 22px;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--sidebar-border-color, var(--border-color)) 36%,
+      transparent
+    );
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 30%)) 40%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
+  box-shadow: 0 26px 70px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
   color: inherit;
 }
 
 .field-label {
-  font-size: var(--text-sm);
-  letter-spacing: 0.06em;
+  font-size: var(--text-xs);
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: color-mix(
     in srgb,
@@ -265,18 +628,20 @@
 .field-area {
   width: 100%;
   padding: 12px 16px;
-  border-radius: 14px;
+  border-radius: 16px;
   border: 1px solid
     color-mix(
       in srgb,
-      var(--sidebar-border-color, var(--border-color)) 44%,
+      var(--sidebar-border-color, var(--border-color)) 40%,
       transparent
     );
-  background: color-mix(
-    in srgb,
-    var(--sidebar-panel, var(--app-bg)) 92%,
-    transparent
-  );
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--app-bg) 96%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-muted) 60%, transparent) 100%
+    ),
+    color-mix(in srgb, var(--app-bg) 94%, transparent);
   color: inherit;
   font: inherit;
   resize: vertical;
@@ -310,19 +675,29 @@
   display: flex;
   gap: 16px;
   align-items: center;
-  padding: 14px 18px;
-  border-radius: 14px;
+  padding: clamp(14px, 2.4vw, 20px) clamp(16px, 3vw, 22px);
+  border-radius: 18px;
   border: 1px solid
     color-mix(
       in srgb,
-      var(--sidebar-border-color, var(--border-color)) 36%,
+      var(--sidebar-border-color, var(--border-color)) 34%,
       transparent
     );
-  background: color-mix(
-    in srgb,
-    var(--sidebar-hover-bg, rgb(24 27 33 / 32%)) 48%,
-    transparent
-  );
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 32%)) 44%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
+  box-shadow: 0 22px 64px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
 }
 
 .shortcut-key {
@@ -338,24 +713,35 @@
     var(--sidebar-muted-color, var(--app-color)) 72%,
     transparent
   );
+  font-size: var(--text-sm);
 }
 
 .data-card {
   display: grid;
   gap: var(--space-3);
-  padding: 20px;
-  border-radius: 16px;
+  padding: clamp(18px, 3vw, 24px);
+  border-radius: 20px;
   border: 1px dashed
     color-mix(
       in srgb,
-      var(--sidebar-border-color, var(--border-color)) 40%,
+      var(--sidebar-border-color, var(--border-color)) 42%,
       transparent
     );
-  background: color-mix(
-    in srgb,
-    var(--sidebar-panel, var(--app-bg)) 90%,
-    transparent
-  );
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 24%)) 32%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
+  box-shadow: 0 20px 56px
+    color-mix(in srgb, var(--shadow-color) 20%, transparent);
 }
 
 .data-text {
@@ -378,56 +764,65 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.65rem 1.4rem;
-  border-radius: 14px;
+  padding: 0.7rem 1.5rem;
+  border-radius: 18px;
   border: 1px solid
     color-mix(
       in srgb,
-      var(--sidebar-border-color, var(--border-color)) 42%,
+      var(--sidebar-border-color, var(--border-color)) 44%,
       transparent
     );
-  background: transparent;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
+        0%,
+      color-mix(
+          in srgb,
+          var(--sidebar-hover-bg, rgb(24 27 33 / 28%)) 48%,
+          transparent
+        )
+        100%
+    ),
+    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
   color: color-mix(
     in srgb,
     var(--sidebar-color, var(--app-color)) 88%,
     transparent
   );
   font-size: var(--text-sm);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
   transition:
     background-color 160ms ease,
     transform 160ms ease,
-    border-color 160ms ease;
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+  box-shadow: 0 18px 48px
+    color-mix(in srgb, var(--shadow-color) 20%, transparent);
 }
 
 .secondary-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .secondary-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px
-    color-mix(in srgb, var(--primary-color) 32%, transparent);
-  background: color-mix(
-    in srgb,
-    var(--sidebar-hover-bg, rgb(24 27 33 / 52%)) 68%,
-    transparent
-  );
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--primary-color) 32%, transparent),
+    0 22px 60px color-mix(in srgb, var(--shadow-color) 24%, transparent);
   border-color: color-mix(in srgb, var(--primary-color) 38%, transparent);
   transform: translateY(-1px);
 }
 
 .secondary-button:not(:disabled):hover {
-  background: color-mix(
-    in srgb,
-    var(--sidebar-hover-bg, rgb(24 27 33 / 52%)) 68%,
-    transparent
-  );
   border-color: color-mix(in srgb, var(--primary-color) 38%, transparent);
   transform: translateY(-1px);
+  box-shadow: 0 22px 60px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
 }
 
 .primary-button {
@@ -548,11 +943,11 @@
 
 @media (width >= 960px) {
   .layout {
-    grid-template-columns: 240px minmax(0, 1fr);
+    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
   }
 
   .panel-area {
-    min-height: 520px;
+    min-height: 560px;
   }
 
   .field-grid {

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -181,6 +181,16 @@ function Preferences({
   }, [lang]);
 
   const tabLabelMap = useMemo(() => buildTabLabelMap(t), [t]);
+  const tabDescriptionMap = useMemo(
+    () => ({
+      [TAB_KEYS.GENERAL]: t.settingsGeneralDescription || "",
+      [TAB_KEYS.PERSONALIZATION]: t.settingsPersonalizationDescription || "",
+      [TAB_KEYS.KEYBOARD]: t.settingsKeyboardDescription || "",
+      [TAB_KEYS.DATA]: t.settingsDataDescription || "",
+      [TAB_KEYS.ACCOUNT]: t.settingsAccountDescription || "",
+    }),
+    [t],
+  );
 
   const formatLanguageLabel = useCallback(
     (code) => {
@@ -418,99 +428,130 @@ function Preferences({
     setActiveTab(resolveInitialTab(tab));
   }, []);
 
-  const renderGeneralPanel = () => (
-    <section
-      className={styles["panel-card"]}
-      aria-labelledby="settings-general"
-    >
-      <header className={styles["panel-header"]}>
-        <div className={styles["panel-title-group"]}>
-          <ThemeIcon
-            name={TAB_ICONS[TAB_KEYS.GENERAL]}
-            width={18}
-            height={18}
-            className={styles["panel-icon"]}
-          />
-          <h3 id="settings-general" className={styles["panel-title"]}>
-            {tabLabelMap[TAB_KEYS.GENERAL]}
-          </h3>
+  const renderGeneralPanel = () => {
+    const defaultsTitle = t.prefDefaultsTitle || tabLabelMap[TAB_KEYS.GENERAL];
+    const defaultsDescription =
+      t.prefDefaultsDescription || tabDescriptionMap[TAB_KEYS.GENERAL];
+    const voicesTitle = t.prefVoicesTitle || t.prefVoiceEn;
+    const voicesDescription =
+      t.prefVoicesDescription || tabDescriptionMap[TAB_KEYS.GENERAL];
+
+    return (
+      <section
+        id={`settings-panel-${TAB_KEYS.GENERAL}`}
+        className={styles["panel-card"]}
+        aria-labelledby="settings-general"
+      >
+        <header className={styles["panel-header"]}>
+          <div className={styles["panel-title-group"]}>
+            <ThemeIcon
+              name={TAB_ICONS[TAB_KEYS.GENERAL]}
+              width={18}
+              height={18}
+              className={styles["panel-icon"]}
+            />
+            <h3 id="settings-general" className={styles["panel-title"]}>
+              {tabLabelMap[TAB_KEYS.GENERAL]}
+            </h3>
+          </div>
+          <p className={styles["panel-description"]}>
+            {tabDescriptionMap[TAB_KEYS.GENERAL]}
+          </p>
+        </header>
+        <div className={styles["panel-body"]}>
+          <div className={styles["panel-callout"]}>
+            <span className={styles["callout-eyebrow"]}>{defaultsTitle}</span>
+            <p className={styles["callout-description"]}>
+              {defaultsDescription}
+            </p>
+          </div>
+          <div className={styles["setting-grid"]}>
+            <div className={styles["setting-row"]}>
+              <label htmlFor="pref-theme" className={styles["setting-label"]}>
+                {t.prefTheme}
+              </label>
+              <SelectField
+                id="pref-theme"
+                value={theme}
+                onChange={setTheme}
+                options={themeOptions}
+              />
+            </div>
+            <div className={styles["setting-row"]}>
+              <label
+                htmlFor="pref-system-language"
+                className={styles["setting-label"]}
+              >
+                {t.prefSystemLanguage}
+              </label>
+              <SelectField
+                id="pref-system-language"
+                value={systemLanguage}
+                onChange={handleSystemLanguageChange}
+                options={systemLanguageOptions}
+              />
+            </div>
+            <div className={styles["setting-row"]}>
+              <label
+                htmlFor="pref-source-language"
+                className={styles["setting-label"]}
+              >
+                {t.prefLanguage}
+              </label>
+              <SelectField
+                id="pref-source-language"
+                value={sourceLang}
+                onChange={handleSourceLanguageChange}
+                options={languageOptions}
+              />
+            </div>
+            <div className={styles["setting-row"]}>
+              <label
+                htmlFor="pref-target-language"
+                className={styles["setting-label"]}
+              >
+                {t.prefSearchLanguage}
+              </label>
+              <SelectField
+                id="pref-target-language"
+                value={targetLang}
+                onChange={handleTargetLanguageChange}
+                options={searchLanguageOptions}
+              />
+            </div>
+          </div>
+          <div className={styles["panel-callout"]}>
+            <span className={styles["callout-eyebrow"]}>{voicesTitle}</span>
+            <p className={styles["callout-description"]}>{voicesDescription}</p>
+          </div>
+          <div className={styles["setting-grid"]}>
+            <div className={styles["setting-row"]}>
+              <label
+                htmlFor="pref-voice-en"
+                className={styles["setting-label"]}
+              >
+                {t.prefVoiceEn}
+              </label>
+              <VoiceSelector lang="en" id="pref-voice-en" />
+            </div>
+            <div className={styles["setting-row"]}>
+              <label
+                htmlFor="pref-voice-zh"
+                className={styles["setting-label"]}
+              >
+                {t.prefVoiceZh}
+              </label>
+              <VoiceSelector lang="zh" id="pref-voice-zh" />
+            </div>
+          </div>
         </div>
-        <p className={styles["panel-description"]}>
-          {t.settingsGeneralDescription || ""}
-        </p>
-      </header>
-      <div className={styles["setting-list"]}>
-        <div className={styles["setting-row"]}>
-          <label htmlFor="pref-theme" className={styles["setting-label"]}>
-            {t.prefTheme}
-          </label>
-          <SelectField
-            id="pref-theme"
-            value={theme}
-            onChange={setTheme}
-            options={themeOptions}
-          />
-        </div>
-        <div className={styles["setting-row"]}>
-          <label
-            htmlFor="pref-system-language"
-            className={styles["setting-label"]}
-          >
-            {t.prefSystemLanguage}
-          </label>
-          <SelectField
-            id="pref-system-language"
-            value={systemLanguage}
-            onChange={handleSystemLanguageChange}
-            options={systemLanguageOptions}
-          />
-        </div>
-        <div className={styles["setting-row"]}>
-          <label
-            htmlFor="pref-source-language"
-            className={styles["setting-label"]}
-          >
-            {t.prefLanguage}
-          </label>
-          <SelectField
-            id="pref-source-language"
-            value={sourceLang}
-            onChange={handleSourceLanguageChange}
-            options={languageOptions}
-          />
-        </div>
-        <div className={styles["setting-row"]}>
-          <label
-            htmlFor="pref-target-language"
-            className={styles["setting-label"]}
-          >
-            {t.prefSearchLanguage}
-          </label>
-          <SelectField
-            id="pref-target-language"
-            value={targetLang}
-            onChange={handleTargetLanguageChange}
-            options={searchLanguageOptions}
-          />
-        </div>
-        <div className={styles["setting-row"]}>
-          <label htmlFor="pref-voice-en" className={styles["setting-label"]}>
-            {t.prefVoiceEn}
-          </label>
-          <VoiceSelector lang="en" id="pref-voice-en" />
-        </div>
-        <div className={styles["setting-row"]}>
-          <label htmlFor="pref-voice-zh" className={styles["setting-label"]}>
-            {t.prefVoiceZh}
-          </label>
-          <VoiceSelector lang="zh" id="pref-voice-zh" />
-        </div>
-      </div>
-    </section>
-  );
+      </section>
+    );
+  };
 
   const renderPersonalizationPanel = () => (
     <section
+      id={`settings-panel-${TAB_KEYS.PERSONALIZATION}`}
       className={styles["panel-card"]}
       aria-labelledby="settings-personalization"
     >
@@ -527,79 +568,84 @@ function Preferences({
           </h3>
         </div>
         <p className={styles["panel-description"]}>
-          {t.settingsPersonalizationDescription || ""}
+          {tabDescriptionMap[TAB_KEYS.PERSONALIZATION]}
         </p>
       </header>
-      <div className={styles["setting-toggle-row"]}>
-        <label
-          htmlFor="personalization-toggle"
-          className={styles["setting-label"]}
-        >
-          {t.settingsEnableCustomization || "Enable customization"}
-        </label>
-        <label className={styles.switch}>
-          <input
-            id="personalization-toggle"
-            type="checkbox"
-            checked={personalizationEnabled}
-            onChange={(event) =>
-              setPersonalizationEnabled(event.target.checked)
-            }
-          />
-          <span aria-hidden="true" />
-        </label>
-      </div>
-      <div className={styles["field-grid"]}>
-        <label className={styles["field-item"]} htmlFor="personal-occupation">
-          <span className={styles["field-label"]}>{t.settingsOccupation}</span>
-          <input
-            id="personal-occupation"
-            type="text"
-            className={styles["field-input"]}
-            value={occupation}
-            onChange={(event) => setOccupation(event.target.value)}
-            placeholder={t.settingsOccupationPlaceholder || "e.g. Student"}
-            disabled={!personalizationEnabled}
-          />
-        </label>
-        <label className={styles["field-item"]} htmlFor="personal-about">
-          <span className={styles["field-label"]}>{t.settingsAboutYou}</span>
-          <textarea
-            id="personal-about"
-            rows={3}
-            className={styles["field-area"]}
-            value={persona}
-            onChange={(event) => setPersona(event.target.value)}
-            placeholder={
-              t.settingsAboutYouPlaceholder ||
-              "Share your expertise, interests, or context."
-            }
-            disabled={!personalizationEnabled}
-          />
-        </label>
-        <label className={styles["field-item"]} htmlFor="personal-goal">
-          <span className={styles["field-label"]}>
-            {t.settingsLearningGoal}
-          </span>
-          <textarea
-            id="personal-goal"
-            rows={3}
-            className={styles["field-area"]}
-            value={learningGoal}
-            onChange={(event) => setLearningGoal(event.target.value)}
-            placeholder={
-              t.settingsLearningGoalPlaceholder ||
-              "Tell us the outcome you're aiming for."
-            }
-            disabled={!personalizationEnabled}
-          />
-        </label>
+      <div className={styles["panel-body"]}>
+        <div className={styles["setting-toggle-row"]}>
+          <label
+            htmlFor="personalization-toggle"
+            className={styles["setting-label"]}
+          >
+            {t.settingsEnableCustomization || "Enable customization"}
+          </label>
+          <label className={styles.switch}>
+            <input
+              id="personalization-toggle"
+              type="checkbox"
+              checked={personalizationEnabled}
+              onChange={(event) =>
+                setPersonalizationEnabled(event.target.checked)
+              }
+            />
+            <span aria-hidden="true" />
+          </label>
+        </div>
+        <div className={styles["field-grid"]}>
+          <label className={styles["field-item"]} htmlFor="personal-occupation">
+            <span className={styles["field-label"]}>
+              {t.settingsOccupation}
+            </span>
+            <input
+              id="personal-occupation"
+              type="text"
+              className={styles["field-input"]}
+              value={occupation}
+              onChange={(event) => setOccupation(event.target.value)}
+              placeholder={t.settingsOccupationPlaceholder || "e.g. Student"}
+              disabled={!personalizationEnabled}
+            />
+          </label>
+          <label className={styles["field-item"]} htmlFor="personal-about">
+            <span className={styles["field-label"]}>{t.settingsAboutYou}</span>
+            <textarea
+              id="personal-about"
+              rows={3}
+              className={styles["field-area"]}
+              value={persona}
+              onChange={(event) => setPersona(event.target.value)}
+              placeholder={
+                t.settingsAboutYouPlaceholder ||
+                "Share your expertise, interests, or context."
+              }
+              disabled={!personalizationEnabled}
+            />
+          </label>
+          <label className={styles["field-item"]} htmlFor="personal-goal">
+            <span className={styles["field-label"]}>
+              {t.settingsLearningGoal}
+            </span>
+            <textarea
+              id="personal-goal"
+              rows={3}
+              className={styles["field-area"]}
+              value={learningGoal}
+              onChange={(event) => setLearningGoal(event.target.value)}
+              placeholder={
+                t.settingsLearningGoalPlaceholder ||
+                "Tell us the outcome you're aiming for."
+              }
+              disabled={!personalizationEnabled}
+            />
+          </label>
+        </div>
       </div>
     </section>
   );
 
   const renderKeyboardPanel = () => (
     <section
+      id={`settings-panel-${TAB_KEYS.KEYBOARD}`}
       className={styles["panel-card"]}
       aria-labelledby="settings-keyboard"
     >
@@ -616,24 +662,30 @@ function Preferences({
           </h3>
         </div>
         <p className={styles["panel-description"]}>
-          {t.settingsKeyboardDescription || ""}
+          {tabDescriptionMap[TAB_KEYS.KEYBOARD]}
         </p>
       </header>
-      <ul className={styles["shortcut-list"]}>
-        {KEYBOARD_SHORTCUTS.map((shortcut) => (
-          <li key={shortcut.labelKey} className={styles["shortcut-item"]}>
-            <span className={styles["shortcut-key"]}>{shortcut.combo}</span>
-            <span className={styles["shortcut-label"]}>
-              {t[shortcut.labelKey] || shortcut.labelKey}
-            </span>
-          </li>
-        ))}
-      </ul>
+      <div className={styles["panel-body"]}>
+        <ul className={styles["shortcut-list"]}>
+          {KEYBOARD_SHORTCUTS.map((shortcut) => (
+            <li key={shortcut.labelKey} className={styles["shortcut-item"]}>
+              <span className={styles["shortcut-key"]}>{shortcut.combo}</span>
+              <span className={styles["shortcut-label"]}>
+                {t[shortcut.labelKey] || shortcut.labelKey}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 
   const renderDataPanel = () => (
-    <section className={styles["panel-card"]} aria-labelledby="settings-data">
+    <section
+      id={`settings-panel-${TAB_KEYS.DATA}`}
+      className={styles["panel-card"]}
+      aria-labelledby="settings-data"
+    >
       <header className={styles["panel-header"]}>
         <div className={styles["panel-title-group"]}>
           <ThemeIcon
@@ -647,18 +699,28 @@ function Preferences({
           </h3>
         </div>
         <p className={styles["panel-description"]}>
-          {t.settingsDataDescription || ""}
+          {tabDescriptionMap[TAB_KEYS.DATA]}
         </p>
       </header>
-      <div className={styles["data-card"]}>
-        <p className={styles["data-text"]}>{t.settingsDataNotice || ""}</p>
-        <div className={styles["data-actions"]}>
-          <button type="button" className={styles["secondary-button"]} disabled>
-            {t.settingsExportData}
-          </button>
-          <button type="button" className={styles["secondary-button"]} disabled>
-            {t.settingsEraseHistory}
-          </button>
+      <div className={styles["panel-body"]}>
+        <div className={styles["data-card"]}>
+          <p className={styles["data-text"]}>{t.settingsDataNotice || ""}</p>
+          <div className={styles["data-actions"]}>
+            <button
+              type="button"
+              className={styles["secondary-button"]}
+              disabled
+            >
+              {t.settingsExportData}
+            </button>
+            <button
+              type="button"
+              className={styles["secondary-button"]}
+              disabled
+            >
+              {t.settingsEraseHistory}
+            </button>
+          </div>
         </div>
       </div>
     </section>
@@ -671,6 +733,7 @@ function Preferences({
       : "";
     return (
       <section
+        id={`settings-panel-${TAB_KEYS.ACCOUNT}`}
         className={styles["panel-card"]}
         aria-labelledby="settings-account"
       >
@@ -687,49 +750,51 @@ function Preferences({
             </h3>
           </div>
           <p className={styles["panel-description"]}>
-            {t.settingsAccountDescription || ""}
+            {tabDescriptionMap[TAB_KEYS.ACCOUNT]}
           </p>
         </header>
-        <div className={styles["account-header"]}>
-          <Avatar width={56} height={56} />
-          <div className={styles["account-meta"]}>
-            <span className={styles["account-name"]}>
-              {user?.username || ""}
-            </span>
-            <span className={styles["account-plan"]}>{planLabel}</span>
+        <div className={styles["panel-body"]}>
+          <div className={styles["account-header"]}>
+            <Avatar width={56} height={56} />
+            <div className={styles["account-meta"]}>
+              <span className={styles["account-name"]}>
+                {user?.username || ""}
+              </span>
+              <span className={styles["account-plan"]}>{planLabel}</span>
+            </div>
+            {typeof onOpenAccountManager === "function" ? (
+              <button
+                type="button"
+                className={styles["secondary-button"]}
+                onClick={onOpenAccountManager}
+              >
+                {t.settingsManageProfile || "Manage profile"}
+              </button>
+            ) : null}
           </div>
-          {typeof onOpenAccountManager === "function" ? (
-            <button
-              type="button"
-              className={styles["secondary-button"]}
-              onClick={onOpenAccountManager}
-            >
-              {t.settingsManageProfile || "Manage profile"}
-            </button>
-          ) : null}
+          <dl className={styles["account-list"]}>
+            <div className={styles["account-row"]}>
+              <dt>{t.settingsAccountUsername}</dt>
+              <dd>{user?.username || t.settingsEmptyValue || ""}</dd>
+            </div>
+            <div className={styles["account-row"]}>
+              <dt>{t.settingsAccountEmail}</dt>
+              <dd>{user?.email || t.settingsEmptyValue || ""}</dd>
+            </div>
+            <div className={styles["account-row"]}>
+              <dt>{t.settingsAccountPhone}</dt>
+              <dd>{user?.phone || t.settingsEmptyValue || ""}</dd>
+            </div>
+            <div className={styles["account-row"]}>
+              <dt>{t.settingsAccountAge}</dt>
+              <dd>{profileMeta.age || t.settingsEmptyValue || ""}</dd>
+            </div>
+            <div className={styles["account-row"]}>
+              <dt>{t.settingsAccountGender}</dt>
+              <dd>{profileMeta.gender || t.settingsEmptyValue || ""}</dd>
+            </div>
+          </dl>
         </div>
-        <dl className={styles["account-list"]}>
-          <div className={styles["account-row"]}>
-            <dt>{t.settingsAccountUsername}</dt>
-            <dd>{user?.username || t.settingsEmptyValue || ""}</dd>
-          </div>
-          <div className={styles["account-row"]}>
-            <dt>{t.settingsAccountEmail}</dt>
-            <dd>{user?.email || t.settingsEmptyValue || ""}</dd>
-          </div>
-          <div className={styles["account-row"]}>
-            <dt>{t.settingsAccountPhone}</dt>
-            <dd>{user?.phone || t.settingsEmptyValue || ""}</dd>
-          </div>
-          <div className={styles["account-row"]}>
-            <dt>{t.settingsAccountAge}</dt>
-            <dd>{profileMeta.age || t.settingsEmptyValue || ""}</dd>
-          </div>
-          <div className={styles["account-row"]}>
-            <dt>{t.settingsAccountGender}</dt>
-            <dd>{profileMeta.gender || t.settingsEmptyValue || ""}</dd>
-          </div>
-        </dl>
       </section>
     );
   };
@@ -778,37 +843,66 @@ function Preferences({
         }
       >
         <div className={styles.layout}>
-          <nav className={styles["tab-list"]} role="tablist">
-            {TAB_ORDER.map((tab) => {
-              const isActive = activeTab === tab;
-              const icon = TAB_ICONS[tab];
-              return (
-                <button
-                  key={tab}
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive}
-                  className={
-                    isActive
-                      ? `${styles["tab-button"]} ${styles["tab-button-active"]}`
-                      : styles["tab-button"]
-                  }
-                  onClick={() => handleTabClick(tab)}
-                >
-                  {icon ? (
-                    <ThemeIcon
-                      name={icon}
-                      width={16}
-                      height={16}
-                      className={styles["tab-icon"]}
+          <aside className={styles.sidebar} aria-label={t.prefTitle}>
+            <div className={styles["sidebar-card"]}>
+              <span className={styles["sidebar-eyebrow"]}>{t.prefTitle}</span>
+              <h3 className={styles["sidebar-active-title"]}>
+                {tabLabelMap[activeTab]}
+              </h3>
+              <p className={styles["sidebar-description"]}>
+                {tabDescriptionMap[activeTab]}
+              </p>
+            </div>
+            <nav
+              className={styles["tab-list"]}
+              role="tablist"
+              aria-orientation="vertical"
+            >
+              {TAB_ORDER.map((tab) => {
+                const isActive = activeTab === tab;
+                const icon = TAB_ICONS[tab];
+                const panelId = `settings-panel-${tab}`;
+                return (
+                  <button
+                    key={tab}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls={panelId}
+                    tabIndex={isActive ? 0 : -1}
+                    className={
+                      isActive
+                        ? `${styles["tab-button"]} ${styles["tab-button-active"]}`
+                        : styles["tab-button"]
+                    }
+                    onClick={() => handleTabClick(tab)}
+                  >
+                    <span
+                      className={styles["tab-icon-wrapper"]}
                       aria-hidden="true"
-                    />
-                  ) : null}
-                  <span>{tabLabelMap[tab]}</span>
-                </button>
-              );
-            })}
-          </nav>
+                    >
+                      {icon ? (
+                        <ThemeIcon
+                          name={icon}
+                          width={18}
+                          height={18}
+                          className={styles["tab-icon"]}
+                        />
+                      ) : null}
+                    </span>
+                    <span className={styles["tab-copy"]}>
+                      <span className={styles["tab-label"]}>
+                        {tabLabelMap[tab]}
+                      </span>
+                      <span className={styles["tab-support"]}>
+                        {tabDescriptionMap[tab]}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </nav>
+          </aside>
           <div className={styles["panel-area"]}>{renderActivePanel()}</div>
         </div>
       </SettingsSurface>


### PR DESCRIPTION
## Summary
- redesign the preferences page layout with a dedicated navigation sidebar and descriptive tab metadata
- refresh individual settings sections with callout cards, responsive grids, and elevated control styling for the new panel aesthetic

## Testing
- npx eslint --fix src
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src
- mvn spotless:apply

------
https://chatgpt.com/codex/tasks/task_e_68d817a6c2408332b590b87eae519825