### PR TITLE
Refine chat input language selector presentation

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -184,7 +184,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: clamp(8px, 1.4vw, 12px);
+  justify-content: center;
   padding: clamp(8px, 1.8vw, 12px) clamp(28px, 5vw, 36px)
     clamp(8px, 1.8vw, 12px) clamp(16px, 3vw, 24px);
   width: 100%;
@@ -196,7 +196,7 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  text-align: left;
+  text-align: center;
   cursor: pointer;
   transition:
     transform 0.2s ease,
@@ -240,15 +240,6 @@
   );
 }
 
-.language-trigger-label {
-  flex: 1;
-  min-width: 0;
-  color: var(--sidebar-color, var(--color-text));
-  letter-spacing: 0.04em;
-  font-weight: 600;
-  text-transform: none;
-}
-
 .language-menu {
   list-style: none;
   margin: 0;
@@ -282,7 +273,8 @@
   width: 100%;
   display: flex;
   align-items: center;
-  gap: clamp(10px, 2vw, 14px);
+  gap: clamp(16px, 3vw, 20px);
+  justify-content: space-between;
   padding: clamp(10px, 2vw, 14px) clamp(12px, 2.6vw, 18px);
   border-radius: 14px;
   border: none;
@@ -359,29 +351,14 @@
   );
 }
 
-.language-option-copy {
+.language-option-label {
   flex: 1 1 auto;
   min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
   color: var(--sidebar-color, var(--color-text));
-}
-
-.language-option-label {
   font-size: 0.92rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.language-option-description {
-  font-size: 0.78rem;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--color-text)) 72%,
-    transparent
-  );
-  letter-spacing: 0.01em;
+  letter-spacing: 0.04em;
+  text-align: right;
 }
 
 .language-swap-button {

--- a/website/src/components/ui/ChatInput/parts/LanguageMenu.jsx
+++ b/website/src/components/ui/ChatInput/parts/LanguageMenu.jsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import Popover from "@/components/ui/Popover/Popover.jsx";
 import useMenuNavigation from "@/hooks/useMenuNavigation.js";
+import { resolveLanguageBadge } from "@/utils/language.js";
 import styles from "../ChatInput.module.css";
 
 function resolveNormalizedValue(value, normalizeValue) {
@@ -31,8 +32,15 @@ function toNormalizedOptions(options, normalizeValue) {
         return null;
       }
 
+      const badge = resolveLanguageBadge(stringValue);
+
+      if (!badge) {
+        return null;
+      }
+
       return {
         value: stringValue,
+        badge,
         label,
         description,
       };
@@ -125,10 +133,7 @@ export default function LanguageMenu({
         data-open={open}
       >
         <span className={styles["language-trigger-code"]}>
-          {currentOption.value}
-        </span>
-        <span className={styles["language-trigger-label"]}>
-          {currentOption.label}
+          {currentOption.badge}
         </span>
       </button>
       <Popover
@@ -152,17 +157,10 @@ export default function LanguageMenu({
                     onClick={() => handleSelect(option.value)}
                   >
                     <span className={styles["language-option-code"]}>
-                      {option.value}
+                      {option.badge}
                     </span>
-                    <span className={styles["language-option-copy"]}>
-                      <span className={styles["language-option-label"]}>
-                        {option.label}
-                      </span>
-                      {option.description ? (
-                        <span className={styles["language-option-description"]}>
-                          {option.description}
-                        </span>
-                      ) : null}
+                    <span className={styles["language-option-label"]}>
+                      {option.label}
                     </span>
                   </button>
                 </li>

--- a/website/src/utils/index.js
+++ b/website/src/utils/index.js
@@ -19,6 +19,7 @@ export {
   resolveDictionaryFlavor,
   WORD_TARGET_LANGUAGES,
   WORD_DEFAULT_TARGET_LANGUAGE,
+  resolveLanguageBadge,
 } from "./language.js";
 export { getBrandText, BRAND_TEXT } from "./brand.js";
 export { validateEmail, validatePhone, validateAccount } from "./validators.js";

--- a/website/src/utils/language.js
+++ b/website/src/utils/language.js
@@ -3,6 +3,12 @@ export const WORD_LANGUAGE_ENGLISH_MONO = "ENGLISH_MONOLINGUAL";
 export const WORD_FLAVOR_BILINGUAL = "BILINGUAL";
 export const WORD_FLAVOR_MONOLINGUAL_ENGLISH = "MONOLINGUAL_ENGLISH";
 
+const LANGUAGE_BADGES = Object.freeze({
+  AUTO: "AUTO",
+  CHINESE: "ZH",
+  ENGLISH: "EN",
+});
+
 const SUPPORTED_WORD_LANGUAGES = Object.freeze([
   WORD_LANGUAGE_AUTO,
   "CHINESE",
@@ -83,6 +89,20 @@ export function normalizeWordTargetLanguage(value) {
   return SUPPORTED_TARGET_LANGUAGES.includes(upper)
     ? upper
     : DEFAULT_TARGET_LANGUAGE;
+}
+
+export function resolveLanguageBadge(value) {
+  if (value == null) {
+    return LANGUAGE_BADGES.AUTO;
+  }
+
+  const upper = String(value).toUpperCase();
+
+  if (upper === WORD_LANGUAGE_ENGLISH_MONO) {
+    return LANGUAGE_BADGES.ENGLISH;
+  }
+
+  return LANGUAGE_BADGES[upper] ?? upper;
 }
 
 /**


### PR DESCRIPTION
## Summary
- display only language abbreviations in the chat input trigger and align the menu with two-column badges and labels
- add a shared `resolveLanguageBadge` helper so abbreviation rendering stays consistent across the app

## Testing
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w src/components/ui/ChatInput/parts/LanguageMenu.jsx src/components/ui/ChatInput/ChatInput.module.css src/utils/language.js src/utils/index.js

------
https://chatgpt.com/codex/tasks/task_e_68d82139abac8332bb6f750ed8378954