### PR TITLE
Refine sidebar styling to mirror premium reference

### DIFF
--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -3,7 +3,19 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  padding: 0;
+  gap: clamp(18px, 4vh, 26px);
+  padding: clamp(20px, 4vw, 28px);
+  border-radius: clamp(20px, 3vw, 26px);
+  border: 1px solid
+    color-mix(in srgb, var(--sidebar-border-color, var(--border-color)) 42%, transparent);
+  background: linear-gradient(
+    142deg,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 96%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-bg) 88%, transparent) 100%
+  );
+  box-shadow: 0 20px 48px
+    color-mix(in srgb, var(--shadow-color) 16%, transparent);
+  backdrop-filter: blur(16px);
   overflow: hidden;
 }
 
@@ -20,7 +32,18 @@
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 6px 12px 8px;
+  padding: clamp(12px, 2.6vw, 16px);
+  border-radius: clamp(16px, 2vw, 20px);
+  border: 1px solid
+    color-mix(in srgb, var(--sidebar-border-color, var(--border-color)) 26%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--sidebar-panel, var(--sidebar-bg)) 98%,
+    transparent
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 40%, transparent),
+    inset 0 -1px 0 color-mix(in srgb, var(--shadow-color) 6%, transparent);
   scrollbar-gutter: stable both-edges;
 }
 
@@ -30,30 +53,41 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: clamp(6px, 1.2vw, 12px);
 }
 
 .history-entry {
-  --sidebar-action-height: 32px;
-  --sidebar-action-padding-x: 10px;
-  --sidebar-action-radius: 8px;
-  --sidebar-action-gap: 8px;
-
-  border-radius: var(--sidebar-action-radius);
-  border: 1px solid transparent;
-  transition:
-    border-color 160ms ease,
-    transform 160ms ease,
-    background-color 160ms ease;
+  --sidebar-action-height: clamp(40px, 4vh, 48px);
+  --sidebar-action-padding-x: clamp(12px, 2.4vw, 18px);
+  --sidebar-action-radius: clamp(12px, 2vw, 16px);
+  --sidebar-action-gap: clamp(10px, 1.8vw, 14px);
+  --sidebar-action-background: color-mix(
+    in srgb,
+    var(--sidebar-bg) 96%,
+    transparent
+  );
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 34%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 10px 26px
+    color-mix(in srgb, var(--shadow-color) 12%, transparent);
 }
 
 .history-entry:where(:hover, :focus-within) {
-  border-color: color-mix(
+  --sidebar-action-background: color-mix(
     in srgb,
-    var(--sidebar-input-ring, var(--border-color)) 65%,
+    var(--sidebar-bg) 92%,
     transparent
   );
-  transform: translateY(-1px);
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 48%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 16px 32px
+    color-mix(in srgb, var(--shadow-color) 16%, transparent);
 }
 
 .history-labels {
@@ -68,127 +102,255 @@
 }
 
 .sidebar-action {
-  --sidebar-action-height: clamp(36px, 5vh, 46px);
-  --sidebar-action-padding-x: clamp(12px, 2.4vw, 18px);
-  --sidebar-action-radius: 12px;
-  --sidebar-action-gap: clamp(8px, 1.6vw, 12px);
+  --sidebar-action-height: clamp(44px, 5vh, 56px);
+  --sidebar-action-padding-x: clamp(16px, 3vw, 22px);
+  --sidebar-action-radius: clamp(14px, 2vw, 18px);
+  --sidebar-action-gap: clamp(12px, 2vw, 18px);
+  --sidebar-action-background: color-mix(
+    in srgb,
+    var(--sidebar-panel, var(--sidebar-bg)) 96%,
+    transparent
+  );
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 38%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 18px 42px
+    color-mix(in srgb, var(--shadow-color) 16%, transparent);
+  --sidebar-action-color: color-mix(
+    in srgb,
+    var(--sidebar-color) 94%,
+    transparent
+  );
+  --sidebar-action-muted: color-mix(
+    in srgb,
+    var(--sidebar-muted-color, var(--sidebar-color)) 78%,
+    transparent
+  );
 
   width: 100%;
   display: flex;
   align-items: center;
-  gap: var(--sidebar-action-gap, clamp(8px, 1.6vw, 12px));
+  gap: var(--sidebar-action-gap);
   padding: 0 var(--sidebar-action-padding-x);
   min-height: var(--sidebar-action-height);
   border-radius: var(--sidebar-action-radius);
-  border: 1px solid transparent;
-  background: transparent;
-  color: inherit;
+  border: 1px solid var(--sidebar-action-border-color);
+  background: var(--sidebar-action-background);
+  color: var(--sidebar-action-color);
   font: inherit;
   font-weight: 600;
   letter-spacing: 0.02em;
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 160ms ease,
-    color 160ms ease,
-    border-color 160ms ease,
-    box-shadow 160ms ease,
-    transform 160ms ease;
-  box-shadow: none;
+    background-color 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    opacity 180ms ease;
+  box-shadow: var(--sidebar-action-shadow);
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
 }
 
-.sidebar-action[data-variant="prominent"] {
-  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 42%, transparent);
-  color: color-mix(in srgb, var(--accent-color) 68%, var(--sidebar-color));
+.sidebar-action::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    140% 140% at 12% 8%,
+    color-mix(in srgb, var(--accent-color) 18%, transparent) 0%,
+    transparent 70%
+  );
+  opacity: 0;
+  transition: opacity 180ms ease;
+  z-index: -1;
 }
 
-.sidebar-action[data-variant="surface"] {
-  background: color-mix(
+.sidebar-action:where(:hover, :focus-visible) {
+  transform: translateY(-2px);
+  --sidebar-action-shadow: 0 22px 48px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 52%,
+    transparent
+  );
+  --sidebar-action-background: color-mix(
     in srgb,
     var(--sidebar-panel, var(--sidebar-bg)) 94%,
     transparent
   );
-  border-color: transparent;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-color) 90%,
-    var(--sidebar-muted-color, var(--sidebar-color))
-  );
-  box-shadow: 0 4px 16px
-    color-mix(in srgb, var(--shadow-color) 16%, transparent);
 }
 
-.sidebar-action:where(:hover, :focus-visible) {
-  transform: translateY(-1px);
-}
-
-.sidebar-action:not([data-variant="surface"]):where(:hover, :focus-visible) {
-  background: var(
-    --sidebar-hover-bg,
-    color-mix(in srgb, var(--sidebar-bg) 92%, transparent)
-  );
-  border-color: color-mix(
-    in srgb,
-    var(--sidebar-input-ring, var(--border-color)) 62%,
-    transparent
-  );
-}
-
-.sidebar-action[data-variant="surface"]:where(:hover, :focus-visible) {
-  background: color-mix(
-    in srgb,
-    var(--sidebar-panel, var(--sidebar-bg)) 88%,
-    var(--accent-color) 10%
-  );
-  border-color: transparent;
-  color: var(--sidebar-color);
-  box-shadow: 0 10px 28px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
-}
-
-.sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
-  background: color-mix(in srgb, var(--accent-color) 26%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 58%, transparent);
+.sidebar-action:where(:hover, :focus-visible)::before {
+  opacity: 0.28;
 }
 
 .sidebar-action:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent-color) 50%, transparent);
-  outline-offset: 2px;
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 40%, transparent);
+  outline-offset: 3px;
 }
 
 .sidebar-action:active {
   transform: translateY(0);
+  --sidebar-action-shadow: 0 12px 28px
+    color-mix(in srgb, var(--shadow-color) 18%, transparent);
+}
+
+.sidebar-action[data-variant="surface"] {
+  --sidebar-action-background: linear-gradient(
+    140deg,
+    color-mix(in srgb, var(--accent-color) 20%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 96%, transparent) 100%
+  );
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--accent-color) 42%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 20px 52px
+    color-mix(in srgb, var(--accent-color) 26%, transparent);
+  --sidebar-action-color: color-mix(
+    in srgb,
+    var(--accent-color) 68%,
+    var(--sidebar-color)
+  );
+  --sidebar-icon-bg: color-mix(
+    in srgb,
+    var(--accent-color) 24%,
+    transparent
+  );
+  --sidebar-icon-color: color-mix(
+    in srgb,
+    var(--accent-color) 86%,
+    var(--sidebar-color)
+  );
+}
+
+.sidebar-action[data-variant="prominent"] {
+  --sidebar-action-background: linear-gradient(
+    150deg,
+    color-mix(in srgb, var(--accent-color) 32%, transparent) 0%,
+    color-mix(in srgb, var(--accent-color) 18%, transparent) 100%
+  );
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--accent-color) 58%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 24px 56px
+    color-mix(in srgb, var(--accent-color) 32%, transparent);
+  --sidebar-action-color: color-mix(
+    in srgb,
+    var(--accent-color) 88%,
+    var(--sidebar-color)
+  );
+  --sidebar-icon-bg: color-mix(
+    in srgb,
+    var(--accent-color) 40%,
+    transparent
+  );
+  --sidebar-icon-color: color-mix(
+    in srgb,
+    var(--accent-color) 96%,
+    var(--sidebar-color)
+  );
+}
+
+.sidebar-action[data-variant="surface"]:where(:hover, :focus-visible) {
+  --sidebar-action-background: linear-gradient(
+    140deg,
+    color-mix(in srgb, var(--accent-color) 28%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 92%, transparent) 100%
+  );
+  --sidebar-action-shadow: 0 26px 58px
+    color-mix(in srgb, var(--accent-color) 32%, transparent);
+}
+
+.sidebar-action[data-variant="prominent"]:where(:hover, :focus-visible) {
+  --sidebar-action-background: linear-gradient(
+    148deg,
+    color-mix(in srgb, var(--accent-color) 40%, transparent) 0%,
+    color-mix(in srgb, var(--accent-color) 24%, transparent) 100%
+  );
+  --sidebar-action-shadow: 0 28px 64px
+    color-mix(in srgb, var(--accent-color) 38%, transparent);
 }
 
 .sidebar-action-active {
-  background: var(
-    --sidebar-active-bg,
-    color-mix(in srgb, var(--sidebar-bg) 86%, transparent)
+  --sidebar-action-background: linear-gradient(
+    150deg,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 92%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-bg) 86%, transparent) 100%
   );
-  border-color: color-mix(
+  --sidebar-action-border-color: color-mix(
     in srgb,
-    var(--sidebar-input-ring, var(--border-color)) 70%,
+    var(--sidebar-border-color, var(--border-color)) 60%,
     transparent
   );
-  color: var(--sidebar-color);
+  --sidebar-action-color: color-mix(
+    in srgb,
+    var(--sidebar-color) 96%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 22px 52px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
 }
 
 .sidebar-action-active[data-variant="surface"] {
-  background: color-mix(
-    in srgb,
-    var(--sidebar-panel, var(--sidebar-bg)) 82%,
-    var(--accent-color) 16%
+  --sidebar-action-background: linear-gradient(
+    144deg,
+    color-mix(in srgb, var(--accent-color) 34%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 88%, transparent) 100%
   );
-  border-color: transparent;
-  color: var(--sidebar-color);
-  box-shadow: 0 12px 32px
-    color-mix(in srgb, var(--shadow-color) 26%, transparent);
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--accent-color) 56%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 28px 68px
+    color-mix(in srgb, var(--accent-color) 34%, transparent);
+  --sidebar-icon-bg: color-mix(
+    in srgb,
+    var(--accent-color) 30%,
+    transparent
+  );
+  --sidebar-icon-color: color-mix(
+    in srgb,
+    var(--accent-color) 94%,
+    var(--sidebar-color)
+  );
 }
 
 .sidebar-action-active[data-variant="prominent"] {
-  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
-  border-color: color-mix(in srgb, var(--accent-color) 62%, transparent);
+  --sidebar-action-background: linear-gradient(
+    148deg,
+    color-mix(in srgb, var(--accent-color) 46%, transparent) 0%,
+    color-mix(in srgb, var(--accent-color) 32%, transparent) 100%
+  );
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--accent-color) 68%,
+    transparent
+  );
+  --sidebar-action-shadow: 0 32px 72px
+    color-mix(in srgb, var(--accent-color) 42%, transparent);
+  --sidebar-icon-bg: color-mix(
+    in srgb,
+    var(--accent-color) 44%,
+    transparent
+  );
+  --sidebar-icon-color: color-mix(
+    in srgb,
+    var(--accent-color) 98%,
+    var(--sidebar-color)
+  );
 }
 
 .sidebar-action-icon {
@@ -196,9 +358,26 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  color: inherit;
+  width: clamp(36px, 3vw, 42px);
+  height: clamp(36px, 3vw, 42px);
+  border-radius: clamp(12px, 2vw, 16px);
+  background: var(
+    --sidebar-icon-bg,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 84%, transparent)
+  );
+  color: var(
+    --sidebar-icon-color,
+    color-mix(in srgb, var(--sidebar-color) 92%, transparent)
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 28%, transparent),
+    0 8px 18px color-mix(in srgb, var(--shadow-color) 14%, transparent);
+}
+
+.sidebar-action-icon-asset {
+  width: clamp(18px, 2vw, 22px);
+  height: clamp(18px, 2vw, 22px);
+  color: currentColor;
 }
 
 .sidebar-action-body {
@@ -212,9 +391,9 @@
 .sidebar-action-label {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: clamp(6px, 1.2vw, 10px);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.015em;
 }
 
 .history-entry :global(.sidebar-action-label) {
@@ -241,11 +420,7 @@
 .sidebar-action-description {
   font-size: 12px;
   line-height: 1.4;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--sidebar-color)) 82%,
-    transparent
-  );
+  color: var(--sidebar-action-muted);
   letter-spacing: 0.02em;
 }
 
@@ -253,40 +428,55 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--sidebar-color)) 78%,
-    transparent
-  );
+  color: var(--sidebar-action-muted);
 }
 
 .sidebar-user {
   --user-menu-width: 100%;
-
   margin-top: auto;
-  padding: 10px 12px;
+  padding: clamp(20px, 4vw, 26px);
   position: sticky;
-  bottom: 0;
-  background: var(--sidebar-bg);
-  border-top: 1px solid var(--sidebar-border-color, var(--border-color));
-  box-shadow: 0 -12px 24px
+  bottom: clamp(20px, 4vw, 28px);
+  border-radius: clamp(20px, 3vw, 26px);
+  border: 1px solid
+    color-mix(in srgb, var(--sidebar-border-color, var(--border-color)) 42%, transparent);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 96%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-bg) 88%, transparent) 100%
+  );
+  box-shadow: 0 -18px 44px
     color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  backdrop-filter: blur(16px);
 }
 
 .sidebar-user-trigger {
   width: 100%;
 
-  --sidebar-action-height: 64px;
-  --sidebar-action-padding-x: 12px;
-  --sidebar-action-radius: 12px;
-  --sidebar-action-gap: 12px;
+  --sidebar-action-height: clamp(60px, 8vh, 74px);
+  --sidebar-action-padding-x: clamp(16px, 3vw, 24px);
+  --sidebar-action-radius: clamp(16px, 3vw, 22px);
+  --sidebar-action-gap: clamp(12px, 2vw, 18px);
+  --sidebar-action-background: linear-gradient(
+    150deg,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 96%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-bg) 88%, transparent) 100%
+  );
+  --sidebar-action-border-color: color-mix(
+    in srgb,
+    var(--sidebar-border-color, var(--border-color)) 48%,
+    transparent
+  );
 }
 
 .sidebar-user-trigger .sidebar-action-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 999px;
+  width: clamp(44px, 4vw, 54px);
+  height: clamp(44px, 4vw, 54px);
+  border-radius: clamp(16px, 3vw, 22px);
   overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 24%, transparent),
+    0 12px 28px color-mix(in srgb, var(--shadow-color) 18%, transparent);
 }
 
 .sidebar-user-trigger .sidebar-action-description {
@@ -313,11 +503,11 @@
 
 @media (width <= 900px) {
   .sidebar-content {
-    padding: clamp(10px, 4vw, 18px) clamp(14px, 5vw, 24px)
-      clamp(24px, 10vw, 36px);
+    gap: clamp(16px, 6vw, 28px);
+    padding: clamp(18px, 6vw, 28px);
   }
 
   .history-list {
-    padding: clamp(8px, 4vw, 16px);
+    padding: clamp(12px, 5vw, 20px);
   }
 }

--- a/website/src/components/Sidebar/SidebarActionItem.jsx
+++ b/website/src/components/Sidebar/SidebarActionItem.jsx
@@ -7,20 +7,23 @@ const joinClassName = (...tokens) => tokens.filter(Boolean).join(" ");
 
 function renderIcon(icon, alt, label, tone) {
   if (!icon) return null;
+
   if (typeof icon !== "string") {
     return <span className={styles["sidebar-action-icon"]}>{icon}</span>;
   }
 
   return (
-    <ThemeIcon
-      name={icon}
-      alt={alt || label}
-      width={18}
-      height={18}
-      tone={tone}
-      aria-hidden={alt ? undefined : "true"}
-      className={styles["sidebar-action-icon"]}
-    />
+    <span className={styles["sidebar-action-icon"]}>
+      <ThemeIcon
+        name={icon}
+        alt={alt || label}
+        width={20}
+        height={20}
+        tone={tone}
+        aria-hidden={alt ? undefined : "true"}
+        className={styles["sidebar-action-icon-asset"]}
+      />
+    </span>
   );
 }
 

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -6,67 +6,84 @@
   min-width: var(--layout-sidebar-min, 240px);
   max-width: var(--layout-sidebar-max, 420px);
   height: var(--vh);
-  background: var(--sidebar-bg);
   color: var(--sidebar-color);
-  border-right: 1px solid var(--sidebar-border-color, var(--border-color));
+  background: linear-gradient(
+    155deg,
+    color-mix(in srgb, var(--sidebar-bg) 94%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 88%, transparent) 100%
+  );
+  border-right: 1px solid
+    color-mix(in srgb, var(--sidebar-border-color, var(--border-color)) 46%, transparent);
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   position: sticky;
   top: 0;
   align-self: start;
-  overflow: hidden;
-  box-shadow: var(--sidebar-shadow-elevated, 0 12px 30px var(--shadow-color));
+  padding: clamp(24px, 5vw, 32px) clamp(18px, 4vw, 28px);
+  row-gap: clamp(18px, 4vh, 30px);
+  box-sizing: border-box;
+  overflow: visible;
+  box-shadow: 0 28px 60px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
+  backdrop-filter: blur(12px);
   z-index: 1;
 }
 
 .sidebar-brand {
   position: sticky;
-  top: 0;
+  top: clamp(24px, 5vw, 32px);
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px 12px 8px;
-  background: var(--sidebar-bg);
-  border-bottom: 1px solid var(--sidebar-border-color, var(--border-color));
-  box-shadow: 0 18px 34px
-    color-mix(in srgb, var(--shadow-color) 18%, transparent);
+  gap: clamp(18px, 3vw, 24px);
+  padding: clamp(24px, 4vw, 30px);
+  border-radius: clamp(20px, 3vw, 26px);
+  border: 1px solid
+    color-mix(in srgb, var(--sidebar-border-color, var(--border-color)) 52%, transparent);
+  background: linear-gradient(
+    152deg,
+    color-mix(in srgb, var(--sidebar-panel, var(--sidebar-bg)) 96%, transparent) 0%,
+    color-mix(in srgb, var(--sidebar-bg) 88%, transparent) 100%
+  );
+  box-shadow: 0 26px 58px
+    color-mix(in srgb, var(--shadow-color) 20%, transparent);
+  backdrop-filter: blur(16px);
   z-index: 2;
 }
 
 .sidebar-brand-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: clamp(12px, 2vw, 18px);
 }
 
 .sidebar-primary-nav {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: clamp(10px, 2vw, 16px);
   flex: 1 1 auto;
 }
 
 .sidebar-nav-item {
-  --sidebar-action-height: 36px;
-  --sidebar-action-padding-x: 10px;
-  --sidebar-action-radius: 10px;
-  --sidebar-action-gap: 10px;
+  --sidebar-action-height: clamp(48px, 6vh, 64px);
+  --sidebar-action-padding-x: clamp(18px, 3vw, 26px);
+  --sidebar-action-radius: clamp(16px, 2.4vw, 22px);
+  --sidebar-action-gap: clamp(12px, 2vw, 18px);
 }
 
 .sidebar-nav-item-dictionary {
-  --sidebar-action-height: 38px;
+  --sidebar-action-height: clamp(50px, 6.2vh, 66px);
 }
 
 .sidebar-nav-item :global(.sidebar-action-body) {
   flex-direction: row;
   align-items: center;
-  gap: 0;
+  gap: clamp(4px, 1vw, 8px);
 }
 
 .sidebar-nav-item :global(.sidebar-action-label) {
-  font-size: 0.95rem;
-  letter-spacing: 0.01em;
+  font-size: clamp(0.95rem, 2vw, 1.02rem);
+  letter-spacing: 0.012em;
 }
 
 .sidebar-nav-item :global(.sidebar-action-description) {
@@ -74,11 +91,11 @@
 }
 
 .sidebar-section-indicator {
-  margin-top: 6px;
-  padding: 0 4px;
-  font-size: 0.75rem;
+  margin-top: clamp(10px, 2vh, 18px);
+  padding: 0 clamp(6px, 1vw, 10px);
+  font-size: clamp(0.72rem, 1.6vw, 0.78rem);
   font-weight: 600;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
   color: color-mix(
     in srgb,
@@ -163,8 +180,10 @@
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 999;
-    border-right: 1px solid var(--sidebar-border-color, var(--border-color));
-    box-shadow: var(--sidebar-shadow-elevated, 0 12px 30px var(--shadow-color));
+    border-right: 1px solid
+      color-mix(in srgb, var(--sidebar-border-color, var(--border-color)) 46%, transparent);
+    box-shadow: 0 26px 52px
+      color-mix(in srgb, var(--shadow-color) 24%, transparent);
   }
 
   .sidebar.mobile-open {
@@ -176,12 +195,12 @@
   }
 
   .sidebar-brand {
-    padding: clamp(18px, 6vw, 28px) clamp(18px, 6vw, 26px)
-      clamp(10px, 4vw, 20px);
+    top: clamp(18px, 8vw, 30px);
+    padding: clamp(22px, 8vw, 32px);
   }
 
   .sidebar-primary-nav {
-    gap: clamp(8px, 4vw, 16px);
+    gap: clamp(12px, 5vw, 20px);
   }
 
   .display {


### PR DESCRIPTION
## Summary
- restyle the sidebar shell with gradient padding, elevated cards, and responsive spacing to align with the reference aesthetic
- update sidebar action items to use tonal variables, icon capsules, and animated hover/active treatments for a luxe feel
- refresh the user card and navigation tokens so spacing, typography, and iconography remain cohesive across breakpoints

## Testing
- not run (Node tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d91a7fecbc833294c05bce7b60456d