### PR TITLE
refactor: modularize dictionary experience state

### DIFF
--- a/website/src/features/dictionary-experience/hooks/useDictionaryLanguageConfig.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryLanguageConfig.js
@@ -1,0 +1,117 @@
+import { useCallback, useMemo } from "react";
+import {
+  WORD_LANGUAGE_AUTO,
+  normalizeWordSourceLanguage,
+  normalizeWordTargetLanguage,
+  resolveDictionaryFlavor,
+} from "@/utils";
+import { useSettingsStore } from "@/store";
+
+export function useDictionaryLanguageConfig({ t }) {
+  const dictionarySourceLanguage = useSettingsStore(
+    (state) => state.dictionarySourceLanguage,
+  );
+  const setDictionarySourceLanguage = useSettingsStore(
+    (state) => state.setDictionarySourceLanguage,
+  );
+  const dictionaryTargetLanguage = useSettingsStore(
+    (state) => state.dictionaryTargetLanguage,
+  );
+  const setDictionaryTargetLanguage = useSettingsStore(
+    (state) => state.setDictionaryTargetLanguage,
+  );
+
+  const sourceLanguageOptions = useMemo(
+    () => [
+      {
+        value: WORD_LANGUAGE_AUTO,
+        label: t.dictionarySourceLanguageAuto,
+        description: t.dictionarySourceLanguageAutoDescription,
+      },
+      {
+        value: "ENGLISH",
+        label: t.dictionarySourceLanguageEnglish,
+        description: t.dictionarySourceLanguageEnglishDescription,
+      },
+      {
+        value: "CHINESE",
+        label: t.dictionarySourceLanguageChinese,
+        description: t.dictionarySourceLanguageChineseDescription,
+      },
+    ],
+    [
+      t.dictionarySourceLanguageAuto,
+      t.dictionarySourceLanguageAutoDescription,
+      t.dictionarySourceLanguageEnglish,
+      t.dictionarySourceLanguageEnglishDescription,
+      t.dictionarySourceLanguageChinese,
+      t.dictionarySourceLanguageChineseDescription,
+    ],
+  );
+
+  const targetLanguageOptions = useMemo(
+    () => [
+      {
+        value: "CHINESE",
+        label: t.dictionaryTargetLanguageChinese,
+        description: t.dictionaryTargetLanguageChineseDescription,
+      },
+      {
+        value: "ENGLISH",
+        label: t.dictionaryTargetLanguageEnglish,
+        description: t.dictionaryTargetLanguageEnglishDescription,
+      },
+    ],
+    [
+      t.dictionaryTargetLanguageChinese,
+      t.dictionaryTargetLanguageChineseDescription,
+      t.dictionaryTargetLanguageEnglish,
+      t.dictionaryTargetLanguageEnglishDescription,
+    ],
+  );
+
+  const dictionaryFlavor = useMemo(
+    () =>
+      resolveDictionaryFlavor({
+        sourceLanguage: dictionarySourceLanguage,
+        targetLanguage: dictionaryTargetLanguage,
+      }),
+    [dictionarySourceLanguage, dictionaryTargetLanguage],
+  );
+
+  const handleSwapLanguages = useCallback(() => {
+    const normalizedSource = normalizeWordSourceLanguage(
+      dictionarySourceLanguage,
+    );
+    const normalizedTarget = normalizeWordTargetLanguage(
+      dictionaryTargetLanguage,
+    );
+
+    const nextSource = normalizedTarget;
+    const nextTarget =
+      normalizedSource === WORD_LANGUAGE_AUTO
+        ? normalizedTarget === "CHINESE"
+          ? "ENGLISH"
+          : "CHINESE"
+        : normalizeWordTargetLanguage(normalizedSource);
+
+    setDictionarySourceLanguage(nextSource);
+    setDictionaryTargetLanguage(nextTarget);
+  }, [
+    dictionarySourceLanguage,
+    dictionaryTargetLanguage,
+    setDictionarySourceLanguage,
+    setDictionaryTargetLanguage,
+  ]);
+
+  return {
+    dictionarySourceLanguage,
+    dictionaryTargetLanguage,
+    setDictionarySourceLanguage,
+    setDictionaryTargetLanguage,
+    sourceLanguageOptions,
+    targetLanguageOptions,
+    dictionaryFlavor,
+    handleSwapLanguages,
+  };
+}

--- a/website/src/features/dictionary-experience/hooks/useDictionaryLanguageConfig.test.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryLanguageConfig.test.js
@@ -1,0 +1,80 @@
+import { renderHook, act } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+const translationFixture = {
+  dictionarySourceLanguageAuto: "自动检测",
+  dictionarySourceLanguageAutoDescription: "自动识别语言",
+  dictionarySourceLanguageEnglish: "英文",
+  dictionarySourceLanguageEnglishDescription: "使用英文解释",
+  dictionarySourceLanguageChinese: "中文",
+  dictionarySourceLanguageChineseDescription: "使用中文解释",
+  dictionaryTargetLanguageChinese: "中文",
+  dictionaryTargetLanguageChineseDescription: "输出中文",
+  dictionaryTargetLanguageEnglish: "英文",
+  dictionaryTargetLanguageEnglishDescription: "输出英文",
+};
+
+const mockSettingsState = {
+  dictionarySourceLanguage: "AUTO",
+  dictionaryTargetLanguage: "CHINESE",
+  setDictionarySourceLanguage: jest.fn(),
+  setDictionaryTargetLanguage: jest.fn(),
+};
+
+jest.unstable_mockModule("@/utils", () => ({
+  WORD_LANGUAGE_AUTO: "AUTO",
+  normalizeWordSourceLanguage: jest.fn((value) => value ?? "AUTO"),
+  normalizeWordTargetLanguage: jest.fn((value) => value ?? "CHINESE"),
+  resolveDictionaryFlavor: jest.fn(() => "default"),
+}));
+
+const useSettingsStore = (selector) => selector(mockSettingsState);
+
+jest.unstable_mockModule("@/store", () => ({
+  useSettingsStore,
+}));
+
+const { useDictionaryLanguageConfig } = await import(
+  "./useDictionaryLanguageConfig.js"
+);
+
+describe("useDictionaryLanguageConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSettingsState.dictionarySourceLanguage = "AUTO";
+    mockSettingsState.dictionaryTargetLanguage = "CHINESE";
+  });
+
+  /**
+   * 测试路径：读取语言配置，期望暴露正确的选项与风味。
+   * 步骤：执行 Hook 并读取返回值。
+   * 断言：选项数量与 flavor 与预期一致。
+   */
+  it("returns language options and flavor metadata", () => {
+    const { result } = renderHook(() =>
+      useDictionaryLanguageConfig({ t: translationFixture }),
+    );
+
+    expect(result.current.sourceLanguageOptions).toHaveLength(3);
+    expect(result.current.targetLanguageOptions).toHaveLength(2);
+    expect(result.current.dictionaryFlavor).toBe("default");
+  });
+
+  /**
+   * 测试路径：触发语言交换逻辑。
+   * 步骤：调用 handleSwapLanguages。
+   * 断言：应写入新的源、目标语言。
+   */
+  it("swaps source and target language settings", () => {
+    const { result } = renderHook(() =>
+      useDictionaryLanguageConfig({ t: translationFixture }),
+    );
+
+    act(() => {
+      result.current.handleSwapLanguages();
+    });
+
+    expect(mockSettingsState.setDictionarySourceLanguage).toHaveBeenCalled();
+    expect(mockSettingsState.setDictionaryTargetLanguage).toHaveBeenCalled();
+  });
+});

--- a/website/src/features/dictionary-experience/hooks/useDictionaryPopup.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryPopup.js
@@ -1,0 +1,25 @@
+import { useCallback, useState } from "react";
+
+export function useDictionaryPopup() {
+  const [popupOpen, setPopupOpen] = useState(false);
+  const [popupMsg, setPopupMsg] = useState("");
+
+  const showPopup = useCallback((message) => {
+    if (!message) {
+      return;
+    }
+    setPopupMsg(message);
+    setPopupOpen(true);
+  }, []);
+
+  const closePopup = useCallback(() => {
+    setPopupOpen(false);
+  }, []);
+
+  return {
+    popupOpen,
+    popupMsg,
+    showPopup,
+    closePopup,
+  };
+}

--- a/website/src/features/dictionary-experience/hooks/useDictionaryPopup.test.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryPopup.test.js
@@ -1,0 +1,40 @@
+import { renderHook, act } from "@testing-library/react";
+
+const { useDictionaryPopup } = await import("./useDictionaryPopup.js");
+
+describe("useDictionaryPopup", () => {
+  /**
+   * 测试路径：展示弹窗。
+   * 步骤：调用 showPopup。
+   * 断言：应写入消息并标记弹窗为开启。
+   */
+  it("opens popup with provided message", () => {
+    const { result } = renderHook(() => useDictionaryPopup());
+
+    act(() => {
+      result.current.showPopup("Hello");
+    });
+
+    expect(result.current.popupOpen).toBe(true);
+    expect(result.current.popupMsg).toBe("Hello");
+  });
+
+  /**
+   * 测试路径：关闭弹窗。
+   * 步骤：先调用 showPopup 再执行 closePopup。
+   * 断言：弹窗标记应变为关闭。
+   */
+  it("closes popup when closePopup is called", () => {
+    const { result } = renderHook(() => useDictionaryPopup());
+
+    act(() => {
+      result.current.showPopup("Hello");
+    });
+
+    act(() => {
+      result.current.closePopup();
+    });
+
+    expect(result.current.popupOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extract dictionary language configuration logic into a dedicated hook to centralize swap handling and memoized options
- isolate popup state management into a reusable hook and wire `useDictionaryExperience` to the new abstractions
- add focused hook tests that document the expected behaviors for language configuration and popup workflows

## Testing
- npm run test *(fails: email binding suite requires missing request state and exceeds available heap; existing issue outside touched scope)*
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/features/dictionary-experience/hooks
- NODE_OPTIONS='--experimental-vm-modules' npx jest src/features/dictionary-experience/hooks --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d936ddc3c8833289382c8e8f46bdd0