### PR TITLE
Refine list item layout for compact entry rows

### DIFF
--- a/website/src/components/ui/ListItem/ListItem.jsx
+++ b/website/src/components/ui/ListItem/ListItem.jsx
@@ -1,24 +1,55 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styles from "./ListItem.module.css";
 
 function ListItem({
   text,
+  title,
+  icon,
   onClick,
   actions,
   className = "",
   textClassName = "",
+  isActive = false,
+  ...props
 }) {
+  const itemClassName = [styles.item, className].filter(Boolean).join(" ");
+  const textClass = [styles.text, textClassName].filter(Boolean).join(" ");
+  const label =
+    typeof title === "string"
+      ? title
+      : typeof text === "string"
+        ? text
+        : undefined;
+
   return (
     <li
-      className={[styles.item, className].filter(Boolean).join(" ")}
+      className={itemClassName}
+      data-active={isActive || undefined}
       onClick={onClick}
+      {...props}
     >
-      <span className={[styles.text, textClassName].filter(Boolean).join(" ")}>
+      <span className={styles.indicator} aria-hidden="true" />
+      <span className={styles.icon} aria-hidden={icon ? undefined : "true"}>
+        {icon || null}
+      </span>
+      <span className={textClass} title={label}>
         {text}
       </span>
       {actions ? <div className={styles.actions}>{actions}</div> : null}
     </li>
   );
 }
+
+ListItem.propTypes = {
+  text: PropTypes.node,
+  title: PropTypes.string,
+  icon: PropTypes.node,
+  onClick: PropTypes.func,
+  actions: PropTypes.node,
+  className: PropTypes.string,
+  textClassName: PropTypes.string,
+  isActive: PropTypes.bool,
+};
 
 export default ListItem;

--- a/website/src/components/ui/ListItem/ListItem.module.css
+++ b/website/src/components/ui/ListItem/ListItem.module.css
@@ -1,33 +1,79 @@
 @import url("@/theme/spacing.css");
 @import url("@/theme/variables.css");
+@import url("@/theme/colors.css");
+@import url("@/theme/typography.css");
 
 .item {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  padding: var(--space-1) var(--space-2);
-  border-radius: var(--radius-sm);
+  --list-item-height: 46px;
+  --list-item-gap: var(--space-2);
+  --list-item-padding-x: var(--space-2);
+  --list-item-radius: var(--radius-xl);
+  --list-item-text-color: var(--sidebar-text-color, var(--color-text));
+  --list-item-hover-bg: var(--sidebar-hover-bg, var(--color-overlay-weak));
+  --list-item-active-bg: var(--sidebar-active-bg, var(--color-overlay-strong));
+  --list-item-indicator-color: var(--accent-color);
+
   position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--list-item-gap);
+  min-height: var(--list-item-height);
+  height: var(--list-item-height);
+  padding: 0 var(--list-item-padding-x);
+  border-radius: var(--list-item-radius);
+  color: var(--list-item-text-color);
   cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .item:hover {
-  background-color: var(--color-overlay-weak);
+  background-color: var(--list-item-hover-bg);
 }
 
-:root[data-theme="dark"] .item:hover {
-  background-color: var(--color-overlay-inverse);
+.item[data-active="true"] {
+  background-color: var(--list-item-active-bg);
+}
+
+.indicator {
+  position: absolute;
+  inset-block: 8px;
+  inset-inline-start: 0;
+  width: 2px;
+  border-radius: var(--radius-sm);
+  background-color: var(--list-item-indicator-color);
+  display: none;
+}
+
+.item[data-active="true"] .indicator {
+  display: block;
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  color: inherit;
 }
 
 .text {
   flex: 1;
+  min-width: 0;
+  font-size: var(--text-sm);
+  line-height: var(--line-height-tight);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .actions {
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  position: relative;
   margin-left: auto;
   opacity: 0;
   pointer-events: none;
@@ -38,4 +84,14 @@
 .item:focus-within .actions {
   opacity: 1;
   pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .item {
+    transition: none;
+  }
+
+  .actions {
+    transition: none;
+  }
 }

--- a/website/src/components/ui/ListItem/__tests__/ListItem.test.jsx
+++ b/website/src/components/ui/ListItem/__tests__/ListItem.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import ListItem from "../ListItem.jsx";
+
+function SampleList({ items, activeId }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <ListItem
+          key={item.id}
+          text={item.label}
+          isActive={item.id === activeId}
+          icon={<svg role="presentation" />}
+        />
+      ))}
+    </ul>
+  );
+}
+
+test("renders mapped list items with active state indicator and preserved title", () => {
+  const items = [
+    { id: "alpha", label: "晨光" },
+    {
+      id: "beta",
+      label: "极光在北纬六十五度的绵长夜幕中缓缓蔓延",
+    },
+  ];
+
+  render(<SampleList items={items} activeId="beta" />);
+
+  const activeText = screen.getByText(items[1].label);
+
+  expect(activeText).toHaveAttribute("title", items[1].label);
+  expect(activeText.closest("li")).toHaveAttribute("data-active", "true");
+});


### PR DESCRIPTION
## Summary
- restyle the ListItem component for a 46px compact row with icon slot, active indicator, and hover/active surfaces
- enforce single-line truncation with title tooltips plus PropTypes for clearer contracts
- add a Jest example that maps entries, highlighting the active item and preserving the title attribute

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src
- npm run test -- ListItem

------
https://chatgpt.com/codex/tasks/task_e_68d98277790c83328cb5a93dd85424a3