### PR TITLE
Refine dictionary input shell and language menu

### DIFF
--- a/website/src/components/ui/ChatInput/ActionInput.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput.jsx
@@ -115,22 +115,25 @@ function ActionInput({
     >
       <SearchBox className={styles["input-surface"]}>
         {showLanguageControls ? (
-          <div className={styles["lang-rail"]}>
-            <LanguageControls
-              sourceLanguage={sourceLanguage}
-              sourceLanguageOptions={sourceLanguageOptions}
-              sourceLanguageLabel={sourceLanguageLabel}
-              onSourceLanguageChange={onSourceLanguageChange}
-              targetLanguage={targetLanguage}
-              targetLanguageOptions={targetLanguageOptions}
-              targetLanguageLabel={targetLanguageLabel}
-              onTargetLanguageChange={onTargetLanguageChange}
-              onSwapLanguages={onSwapLanguages}
-              swapLabel={swapLabel}
-              normalizeSourceLanguage={normalizeSourceLanguageFn}
-              normalizeTargetLanguage={normalizeTargetLanguageFn}
-            />
-          </div>
+          <>
+            <div className={styles["lang-rail"]}>
+              <LanguageControls
+                sourceLanguage={sourceLanguage}
+                sourceLanguageOptions={sourceLanguageOptions}
+                sourceLanguageLabel={sourceLanguageLabel}
+                onSourceLanguageChange={onSourceLanguageChange}
+                targetLanguage={targetLanguage}
+                targetLanguageOptions={targetLanguageOptions}
+                targetLanguageLabel={targetLanguageLabel}
+                onTargetLanguageChange={onTargetLanguageChange}
+                onSwapLanguages={onSwapLanguages}
+                swapLabel={swapLabel}
+                normalizeSourceLanguage={normalizeSourceLanguageFn}
+                normalizeTargetLanguage={normalizeTargetLanguageFn}
+              />
+            </div>
+            <div className={styles["language-divider"]} aria-hidden="true" />
+          </>
         ) : null}
         <div className={styles["core-input"]}>
           <textarea

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -17,12 +17,9 @@
 .lang-rail {
   display: flex;
   align-items: center;
-  gap: var(--sb-gap);
-  padding-block: 0;
-  padding-inline: 0 var(--sb-gap-lg);
-  margin-inline-end: var(--sb-gap);
-  border-inline-end: 1px solid var(--sb-border);
-  color: var(--sb-muted);
+  padding: 0;
+  margin: 0;
+  height: 100%;
 }
 
 .lang-rail:empty {
@@ -32,100 +29,140 @@
 .language-controls {
   display: inline-flex;
   align-items: center;
-  gap: var(--sb-gap);
-  color: inherit;
+  justify-content: center;
+  gap: var(--sb-direction-gap);
+  height: 100%;
+  padding-inline: var(--sb-direction-padding-inline);
+  border-radius: calc(var(--sb-radius) - 6px);
+  border: 1px solid var(--sb-direction-border);
+  background: var(--sb-direction-bg);
+  color: var(--sb-text);
+  letter-spacing: var(--sb-code-letter-spacing);
 }
 
 .language-select-wrapper {
   position: relative;
   display: inline-flex;
   align-items: center;
+  height: 100%;
 }
 
 .language-trigger {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: calc(var(--sb-gap) / 2);
-  height: var(--sb-chip-height);
-  padding-inline: var(--sb-chip-padding-inline);
-  border-radius: var(--sb-chip-height);
-  border: 1px solid transparent;
-  background: var(--sb-chip-bg);
+  min-width: var(--sb-code-min-width);
+  height: 100%;
+  padding-inline: 8px;
+  border: none;
+  border-radius: calc(var(--sb-radius) - 12px);
+  background: transparent;
   color: var(--sb-muted);
   font-size: var(--sb-font-sm);
   font-weight: var(--sb-font-strong);
-  letter-spacing: var(--sb-chip-letter-spacing);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  letter-spacing: var(--sb-code-letter-spacing);
   text-transform: uppercase;
   cursor: pointer;
   transition:
-    background 0.2s ease,
     color 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.2s ease;
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .language-trigger:hover,
 .language-trigger:focus-visible,
 .language-trigger[data-open="true"] {
-  background: var(--sb-hover);
   color: var(--sb-text);
   outline: none;
-  border-color: color-mix(in srgb, var(--sb-ring) 60%, transparent);
   transform: translateY(-1px);
 }
 
 .language-trigger:focus-visible {
   box-shadow: 0 0 0 var(--sb-ring-width)
-    color-mix(in srgb, var(--sb-ring) 60%, transparent);
+    color-mix(in srgb, var(--sb-ring) 55%, transparent);
 }
 
 .language-trigger-content {
   display: inline-flex;
   align-items: center;
-  gap: calc(var(--sb-gap) / 2);
+  gap: 8px;
 }
 
 .language-trigger-code {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
   letter-spacing: var(--sb-code-letter-spacing);
 }
 
 .language-trigger-label {
   font-weight: var(--sb-font-weight);
   font-size: var(--sb-font-sm);
+  letter-spacing: var(--sb-body-letter-spacing);
   text-transform: none;
   color: var(--sb-muted);
+}
+
+.language-trigger-label[data-visible="false"] {
+  display: none;
 }
 
 .language-menu {
   list-style: none;
   margin: 0;
-  padding: var(--sb-gap-lg);
-  min-width: var(--sb-menu-min-width);
+  padding: var(--sb-menu-padding);
+  width: min(var(--sb-menu-width), calc(100vw - 32px));
+  max-height: calc(var(--sb-row-height) * 8 + var(--sb-menu-padding) * 2);
   display: flex;
   flex-direction: column;
-  gap: var(--sb-gap);
-  border-radius: var(--sb-radius);
-  background: color-mix(in srgb, var(--sb-panel) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--sb-border) 70%, transparent);
-  box-shadow: var(--sb-shadow);
+  gap: 4px;
+  border-radius: var(--sb-menu-radius);
+  background: var(--sb-panel);
+  border: 1px solid color-mix(in srgb, var(--sb-border) 80%, transparent);
+  box-shadow: var(--sb-menu-shadow);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--sb-scroll-thumb) var(--sb-scroll-track);
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    opacity 0.12s ease,
+    transform 0.12s ease;
+}
+
+.language-menu[data-open="true"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.language-menu::-webkit-scrollbar {
+  width: 6px;
+}
+
+.language-menu::-webkit-scrollbar-track {
+  background: var(--sb-scroll-track);
+  border-radius: 999px;
+}
+
+.language-menu::-webkit-scrollbar-thumb {
+  background: var(--sb-scroll-thumb);
+  border-radius: 999px;
 }
 
 .language-menu-item {
   margin: 0;
 }
 
-.language-menu-item button {
+.language-menu-button {
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--sb-code-min-width) 1fr auto;
   align-items: center;
   gap: var(--sb-gap);
-  padding: calc(var(--sb-gap) - var(--sb-compact-offset)) var(--sb-gap);
+  padding-inline: 16px;
+  height: var(--sb-row-height);
   border: none;
-  border-radius: calc(var(--sb-radius) - 4px);
+  border-radius: 12px;
   background: transparent;
   color: var(--sb-text);
   font-size: var(--sb-font);
@@ -133,26 +170,27 @@
   text-align: left;
   cursor: pointer;
   transition:
-    background 0.2s ease,
-    transform 0.2s ease;
+    background 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
 }
 
-.language-menu-item button[data-active="true"],
-.language-menu-item button:hover,
-.language-menu-item button:focus-visible {
-  background: var(--sb-hover);
-  transform: translateY(-1px);
+.language-menu-button[data-active="true"],
+.language-menu-button:hover,
+.language-menu-button:focus-visible {
+  background: rgb(255 255 255 / 6%);
   outline: none;
+  box-shadow: 0 0 0 var(--sb-ring-width)
+    color-mix(in srgb, var(--sb-ring) 45%, transparent);
 }
 
 .language-option-code {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: var(--sb-code-min-width);
-  padding-inline: calc(var(--sb-gap) / 2);
-  border-radius: var(--sb-chip-height);
-  background: var(--sb-chip-bg);
+  min-width: 0;
+  padding-inline: 0;
+  border-radius: 999px;
   color: var(--sb-muted);
   font-family:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
@@ -167,7 +205,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .language-option-label {
@@ -183,29 +221,69 @@
   text-transform: uppercase;
 }
 
-.language-swap-button {
-  width: var(--sb-swap-size);
-  height: var(--sb-swap-size);
+.language-option-state {
+  justify-self: end;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: transparent;
+  transition: background 0.2s ease;
+}
+
+.language-option-state[data-active="true"] {
+  background: color-mix(in srgb, var(--sb-ring) 65%, transparent);
+}
+
+.language-divider {
+  width: 1px;
+  align-self: stretch;
+  background: color-mix(in srgb, var(--sb-divider) 85%, transparent);
+  border-radius: 1px;
+}
+
+.language-arrow,
+.language-swap {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--sb-text);
+  letter-spacing: 0.12em;
+}
+
+.language-arrow {
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+.language-swap {
+  border: none;
   border-radius: 999px;
-  border: 1px solid transparent;
   background: transparent;
   color: var(--sb-muted);
   cursor: pointer;
   transition:
     background 0.2s ease,
     color 0.2s ease,
-    transform 0.2s ease;
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
-.language-swap-button:hover,
-.language-swap-button:focus-visible {
-  background: var(--sb-hover);
+.language-swap:hover,
+.language-swap:focus-visible {
   color: var(--sb-text);
+  background: rgb(255 255 255 / 8%);
   outline: none;
+  box-shadow: 0 0 0 var(--sb-ring-width)
+    color-mix(in srgb, var(--sb-ring) 45%, transparent);
   transform: translateY(-1px);
+}
+
+.language-swap:active {
+  transform: translateY(1px);
 }
 
 .core-input {
@@ -213,6 +291,7 @@
   min-width: 0;
   display: flex;
   align-items: center;
+  padding-block: 0;
 }
 
 .textarea {
@@ -225,12 +304,14 @@
   font-size: var(--sb-font);
   font-weight: var(--sb-font-weight);
   line-height: 1.6;
+  letter-spacing: var(--sb-body-letter-spacing);
   resize: none;
   outline: none;
+  caret-color: var(--sb-text);
 }
 
 .textarea::placeholder {
-  color: var(--sb-muted);
+  color: var(--sb-placeholder);
   letter-spacing: var(--sb-body-letter-spacing);
 }
 
@@ -246,7 +327,7 @@
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  border: 1px solid transparent;
+  border: none;
   cursor: pointer;
   transition:
     background 0.2s ease,
@@ -257,17 +338,19 @@
 }
 
 .voice-button {
-  width: var(--sb-swap-size);
-  height: var(--sb-swap-size);
+  width: var(--sb-action-size);
+  height: var(--sb-action-size);
   background: transparent;
   color: var(--sb-muted);
 }
 
 .voice-button:hover,
 .voice-button:focus-visible {
-  background: var(--sb-hover);
+  background: rgb(255 255 255 / 8%);
   color: var(--sb-text);
   outline: none;
+  box-shadow: 0 0 0 var(--sb-ring-width)
+    color-mix(in srgb, var(--sb-ring) 35%, transparent);
 }
 
 .send-button {
@@ -277,6 +360,7 @@
   color: var(--sb-send-color);
   font-weight: var(--sb-font-strong);
   box-shadow: var(--sb-shadow);
+  border: none;
 }
 
 .send-button:hover,
@@ -291,8 +375,8 @@
 .voice-button:active,
 .send-button:active,
 .language-trigger:active,
-.language-swap-button:active,
-.language-menu-item button:active {
+.language-menu-button:active,
+.language-swap:active {
   transform: translateY(1px);
   opacity: 0.9;
 }
@@ -313,8 +397,8 @@ button[disabled] {
 
 .send-button[data-loading="true"]::after {
   content: "";
-  width: calc(var(--sb-icon-size) + var(--sb-compact-offset));
-  height: calc(var(--sb-icon-size) + var(--sb-compact-offset));
+  width: var(--sb-icon-size);
+  height: var(--sb-icon-size);
   border-radius: 999px;
   border: var(--sb-ring-width) solid currentcolor;
   border-inline-start-color: transparent;
@@ -328,20 +412,12 @@ button[disabled] {
 }
 
 @media (width <= 480px) {
-  .lang-rail {
-    padding-inline-end: calc(var(--sb-gap) - var(--sb-compact-offset));
-    margin-inline-end: calc(var(--sb-gap) - var(--sb-compact-offset));
-  }
-
-  .language-trigger {
-    height: calc(var(--sb-chip-height) - var(--sb-compact-offset));
-    padding-inline: calc(
-      var(--sb-chip-padding-inline) - var(--sb-compact-offset)
-    );
-    letter-spacing: var(--sb-chip-letter-spacing-tight);
+  .language-controls {
+    padding-inline: 14px;
+    gap: 8px;
   }
 
   .actions {
-    gap: calc(var(--sb-gap) - var(--sb-compact-offset));
+    gap: 10px;
   }
 }

--- a/website/src/components/ui/ChatInput/LanguageControls.jsx
+++ b/website/src/components/ui/ChatInput/LanguageControls.jsx
@@ -1,9 +1,6 @@
 import PropTypes from "prop-types";
-import ThemeIcon from "@/components/ui/Icon";
 import LanguageMenu from "./parts/LanguageMenu.jsx";
 import styles from "./ChatInput.module.css";
-
-const ICON_SIZE = 20;
 
 export default function LanguageControls({
   sourceLanguage,
@@ -49,29 +46,32 @@ export default function LanguageControls({
         onChange={onSourceLanguageChange}
         ariaLabel={sourceLanguageLabel}
         normalizeValue={normalizeSource}
+        showLabel={false}
+        variant="source"
       />
       {canSwap ? (
         <button
           type="button"
-          className={styles["language-swap-button"]}
+          className={styles["language-swap"]}
           onClick={onSwapLanguages}
           aria-label={swapLabel}
           title={swapLabel}
         >
-          <ThemeIcon
-            name="arrow-right"
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-            aria-hidden="true"
-          />
+          →
         </button>
-      ) : null}
+      ) : (
+        <span className={styles["language-arrow"]} aria-hidden="true">
+          →
+        </span>
+      )}
       <LanguageMenu
         options={targetLanguageOptions}
         value={targetLanguage}
         onChange={onTargetLanguageChange}
         ariaLabel={targetLanguageLabel}
         normalizeValue={normalizeTarget}
+        showLabel={false}
+        variant="target"
       />
     </div>
   );

--- a/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
@@ -82,12 +82,16 @@ test("handles language selection and swapping", async () => {
 
   const sourceButton = screen.getByRole("button", { name: "源语言" });
   fireEvent.click(sourceButton);
-  fireEvent.click(await screen.findByRole("menuitem", { name: "英文词条" }));
+  fireEvent.click(
+    await screen.findByRole("menuitemradio", { name: "英文词条" }),
+  );
   expect(handleSourceChange).toHaveBeenCalledWith("ENGLISH");
 
   const targetButton = screen.getByRole("button", { name: "目标语言" });
   fireEvent.click(targetButton);
-  fireEvent.click(await screen.findByRole("menuitem", { name: "中文释义" }));
+  fireEvent.click(
+    await screen.findByRole("menuitemradio", { name: "中文释义" }),
+  );
   expect(handleTargetChange).toHaveBeenCalledWith("CHINESE");
 
   const swapButton = screen.getByRole("button", { name: "交换语向" });

--- a/website/src/components/ui/ChatInput/parts/LanguageMenu.jsx
+++ b/website/src/components/ui/ChatInput/parts/LanguageMenu.jsx
@@ -59,6 +59,8 @@ export default function LanguageMenu({
   onChange,
   ariaLabel,
   normalizeValue,
+  showLabel,
+  variant,
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
@@ -123,6 +125,10 @@ export default function LanguageMenu({
     return null;
   }
 
+  const triggerAriaLabel = ariaLabel || currentOption.label;
+  const triggerTitle = currentOption.label;
+  const showTriggerLabel = Boolean(showLabel);
+
   return (
     <div className={styles["language-select-wrapper"]}>
       <button
@@ -132,15 +138,20 @@ export default function LanguageMenu({
         aria-expanded={open}
         onClick={handleToggle}
         onKeyDown={handleTriggerKeyDown}
-        aria-label={ariaLabel}
+        aria-label={triggerAriaLabel}
+        title={triggerTitle}
         ref={triggerRef}
         data-open={open}
+        data-variant={variant}
       >
         <span className={styles["language-trigger-content"]}>
           <span className={styles["language-trigger-code"]}>
             {currentOption.badge}
           </span>
-          <span className={styles["language-trigger-label"]}>
+          <span
+            className={styles["language-trigger-label"]}
+            data-visible={showTriggerLabel}
+          >
             {currentOption.label}
           </span>
         </span>
@@ -154,14 +165,25 @@ export default function LanguageMenu({
         offset={12}
       >
         {open ? (
-          <ul className={styles["language-menu"]} role="menu" ref={menuRef}>
+          <ul
+            className={styles["language-menu"]}
+            role="menu"
+            ref={menuRef}
+            data-open={open}
+          >
             {normalizedOptions.map((option) => {
               const isActive = option.value === currentOption.value;
               return (
-                <li key={option.value} role="menuitem">
+                <li
+                  key={option.value}
+                  role="none"
+                  className={styles["language-menu-item"]}
+                >
                   <button
                     type="button"
-                    className={styles["language-menu-item"]}
+                    role="menuitemradio"
+                    aria-checked={isActive}
+                    className={styles["language-menu-button"]}
                     data-active={isActive}
                     onClick={() => handleSelect(option.value)}
                   >
@@ -178,6 +200,11 @@ export default function LanguageMenu({
                         </span>
                       ) : null}
                     </span>
+                    <span
+                      className={styles["language-option-state"]}
+                      data-active={isActive}
+                      aria-hidden="true"
+                    />
                   </button>
                 </li>
               );
@@ -201,6 +228,8 @@ LanguageMenu.propTypes = {
   onChange: PropTypes.func,
   ariaLabel: PropTypes.string,
   normalizeValue: PropTypes.func,
+  showLabel: PropTypes.bool,
+  variant: PropTypes.oneOf(["source", "target"]),
 };
 
 LanguageMenu.defaultProps = {
@@ -209,4 +238,6 @@ LanguageMenu.defaultProps = {
   onChange: undefined,
   ariaLabel: undefined,
   normalizeValue: undefined,
+  showLabel: false,
+  variant: "source",
 };

--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -2,29 +2,31 @@
 .search-box {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   width: 100%;
-  min-height: var(--sb-h, 48px);
-  padding: var(--padding-y, 0) var(--padding-x, var(--sb-gap-lg, 14px));
-  gap: var(--slot-gap, var(--sb-gap, 10px));
-  border-radius: var(--sb-radius, 14px);
-  border: 1px solid var(--sb-border, #2a2e37);
-  background: var(--sb-panel, var(--sb-bg, #111318));
-  box-shadow: var(--sb-shadow, 0 4px 18px rgb(0 0 0 / 35%));
-  color: var(--sb-text, #eef0f3);
-  font-size: var(--sb-font, 14px);
+  min-height: var(--sb-h, 56px);
+  padding: var(--padding-y, 0) var(--padding-x, var(--sb-gap-lg, 16px));
+  gap: var(--slot-gap, var(--sb-gap, 12px));
+  border-radius: var(--sb-radius, 28px);
+  border: 1px solid var(--sb-border, #2a2f3a);
+  background: var(--sb-bg, #15181e);
+  box-shadow: var(--sb-shadow, 0 16px 40px rgb(0 0 0 / 45%));
+  color: var(--sb-text, #e8ecf2);
+  font-size: var(--sb-font, 15px);
   line-height: 1.4;
   box-sizing: border-box;
   transition:
     box-shadow 0.25s ease,
     border-color 0.25s ease,
-    color 0.25s ease;
+    color 0.25s ease,
+    background 0.25s ease;
 }
 
 .search-box:focus-within {
+  border-color: color-mix(in srgb, var(--sb-ring, #7aa2ff) 35%, transparent);
   box-shadow:
-    var(--sb-shadow, 0 4px 18px rgb(0 0 0 / 35%)),
-    0 0 0 1px var(--sb-ring, #3a3f46) inset;
+    var(--sb-shadow, 0 16px 40px rgb(0 0 0 / 45%)),
+    0 0 0 1px color-mix(in srgb, var(--sb-ring, #7aa2ff) 35%, transparent) inset;
 }
 
 .search-box :global(button) {
@@ -35,7 +37,7 @@
 .search-box :global(svg) {
   width: var(--sb-icon-size, 20px);
   height: var(--sb-icon-size, 20px);
-  color: var(--sb-muted, #a7afbd);
+  color: var(--sb-muted, #9aa3af);
   transition: color 0.2s ease;
 }
 

--- a/website/src/hooks/useMenuNavigation.js
+++ b/website/src/hooks/useMenuNavigation.js
@@ -15,16 +15,29 @@ export default function useMenuNavigation(open, menuRef, triggerRef, setOpen) {
     const menuEl = menuRef.current;
     if (!menuEl) return undefined;
 
-    const items = Array.from(menuEl.querySelectorAll('[role="menuitem"]'));
+    const items = Array.from(
+      menuEl.querySelectorAll(
+        '[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"]',
+      ),
+    );
     if (!items.length) return undefined;
 
-    const getFocusable = (item) =>
-      item.querySelector("button, [href], [tabindex]");
+    const getFocusable = (item) => {
+      if (!item) return undefined;
+      if (typeof item.matches === "function") {
+        if (item.matches("button, [href], [tabindex]")) {
+          return item;
+        }
+      }
+      return item.querySelector?.("button, [href], [tabindex]");
+    };
 
     getFocusable(items[0])?.focus();
 
     const handleKeyDown = (e) => {
-      const currentItem = e.target.closest('[role="menuitem"]');
+      const currentItem = e.target.closest(
+        '[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"]',
+      );
       const index = items.indexOf(currentItem);
       switch (e.key) {
         case "Escape":

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -200,7 +200,7 @@ export default {
   favoriteAction: "Favorite",
   deleteAction: "Delete",
   searchPlaceholder: "What are we querying next?",
-  inputPlaceholder: "Term, phrase, or sentence",
+  inputPlaceholder: "“Words, phrases, sentences”",
   cookieConsentTitle: "Your privacy, elevated",
   cookieConsentDescription:
     "We use cookies to remember trusted devices and tailor your sign-in journey.",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -189,7 +189,7 @@ export default {
   favoriteAction: "收藏",
   deleteAction: "删除",
   searchPlaceholder: "接下来查询什么？",
-  inputPlaceholder: "词条、短语或句子",
+  inputPlaceholder: "“词条、短语、句子”",
   cookieConsentTitle: "尊重隐私的尊奢体验",
   cookieConsentDescription:
     "我们会使用 Cookie 记录已信任的设备，为您定制更顺滑的登录旅程。",

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -5,6 +5,17 @@
   --radius-lg: 12px;
   --radius-xl: 20px;
   --radius-avatar: 12px;
+  --color-bg: #0f1115;
+  --color-surface: #15181e;
+  --color-panel: #1c2027;
+  --color-panel-subtle: #111417;
+  --color-border-strong: #2a2f3a;
+  --color-text-primary: #e8ecf2;
+  --color-text-muted: #9aa3af;
+  --color-text-placeholder: #98a2b3;
+  --color-accent: #7aa2ff;
+  --shadow-elevated-md: 0 16px 40px rgb(0 0 0 / 45%);
+  --shadow-elevated-lg: 0 20px 56px rgb(0 0 0 / 45%);
 
   /* search box vertical padding */
   --search-box-padding-y: 12px;
@@ -14,37 +25,55 @@
   --z-index-popover: 1100;
 
   /* search bar tokens */
-  --sb-h: 48px;
-  --sb-radius: 14px;
-  --sb-border: #2a2e37;
-  --sb-bg: #111318;
-  --sb-panel: #1b1f27;
-  --sb-text: #eef0f3;
-  --sb-muted: #a7afbd;
-  --sb-hover: #20242d;
-  --sb-ring: #3a3f46;
-  --sb-shadow: 0 4px 18px rgb(0 0 0 / 35%);
-  --sb-gap: 10px;
-  --sb-gap-lg: 14px;
-  --sb-font: 14px;
-  --sb-font-sm: 12px;
+  --sb-h: 56px;
+  --sb-radius: 28px;
+  --sb-border: var(--color-border-strong);
+  --sb-bg: var(--color-surface);
+  --sb-panel: var(--color-panel);
+  --sb-panel-strong: var(--color-panel-subtle);
+  --sb-text: var(--color-text-primary);
+  --sb-muted: var(--color-text-muted);
+  --sb-placeholder: var(--color-text-placeholder);
+  --sb-hover: rgb(255 255 255 / 6%);
+  --sb-ring: var(--color-accent);
+  --sb-shadow: var(--shadow-elevated-md);
+  --sb-menu-shadow: var(--shadow-elevated-lg);
+  --sb-gap: 12px;
+  --sb-gap-lg: 16px;
+  --sb-font: 15px;
+  --sb-font-sm: 13px;
   --sb-font-strong: 600;
   --sb-font-weight: 500;
   --sb-body-letter-spacing: 0.02em;
   --sb-description-letter-spacing: 0.04em;
-  --sb-chip-bg: #0f1115;
-  --sb-chip-height: 28px;
-  --sb-chip-padding-inline: 12px;
-  --sb-chip-letter-spacing: 0.08em;
-  --sb-chip-letter-spacing-tight: 0.06em;
+  --sb-direction-gap: 12px;
+  --sb-direction-padding-inline: 18px;
+  --sb-divider: var(--color-border-strong);
+  --sb-direction-bg: var(--color-panel-subtle);
+  --sb-direction-border: color-mix(
+    in srgb,
+    var(--color-border-strong) 60%,
+    transparent
+  );
   --sb-code-letter-spacing: 0.16em;
-  --sb-code-min-width: 42px;
-  --sb-menu-min-width: 220px;
-  --sb-swap-size: 32px;
+  --sb-code-min-width: 88px;
+  --sb-menu-width: 368px;
+  --sb-row-height: 48px;
+  --sb-menu-radius: 16px;
+  --sb-menu-padding: 8px;
+  --sb-scroll-track: color-mix(
+    in srgb,
+    var(--color-border-strong) 35%,
+    transparent
+  );
+  --sb-scroll-thumb: color-mix(
+    in srgb,
+    var(--color-border-strong) 65%,
+    transparent
+  );
   --sb-icon-size: 20px;
-  --sb-action-size: 40px;
+  --sb-action-size: 44px;
   --sb-send-bg: rgb(255 255 255 / 92%);
   --sb-send-color: #0b0d11;
-  --sb-compact-offset: 2px;
   --sb-ring-width: 2px;
 }


### PR DESCRIPTION
## Summary
- refresh search bar variables to align with the new high-contrast capsule direction and placeholder tone
- restyle the chat input shell, language picker, and action controls for the thicker capsule, arrow swap, and richer hover/focus cues
- harden menu accessibility and localisation by updating keyboard navigation roles, menu layout, and placeholder copy

## Testing
- npm run lint
- npm run lint:css
- npx eslint --fix .
- npx stylelint --fix "src/**/*.css"
- npx prettier -w .

------
https://chatgpt.com/codex/tasks/task_e_68d98ca4b7188332b61d61a628f09e80