### PR TITLE
Refine settings dialog layout and accessibility

### DIFF
--- a/website/src/__tests__/Preferences.test.jsx
+++ b/website/src/__tests__/Preferences.test.jsx
@@ -16,12 +16,13 @@ const mockTtsVoices = jest.fn().mockResolvedValue([]);
 const mockT = {
   prefTitle: "Preferences",
   prefDescription: "Description",
-  prefLanguage: "Language",
-  prefSearchLanguage: "Search Language",
+  prefLanguage: "Source Language",
+  prefSearchLanguage: "Target Language",
   prefVoiceEn: "English Voice",
   prefVoiceZh: "Chinese Voice",
   prefTheme: "Theme",
-  saveButton: "Save",
+  saveButton: "Save changes",
+  saving: "Saving...",
   saveSuccess: "Saved",
   fail: "Fail",
   autoDetect: "Auto",
@@ -58,13 +59,6 @@ jest.unstable_mockModule("@/hooks/useApi.js", () => ({
 jest.unstable_mockModule("@/components", () => ({
   __esModule: true,
   VoiceSelector: ({ lang }) => <div data-testid={`voice-selector-${lang}`} />,
-  SettingsSurface: ({ children, actions, onSubmit }) => (
-    <form data-testid="settings-surface" onSubmit={onSubmit}>
-      <div>{children}</div>
-      {actions}
-    </form>
-  ),
-  SETTINGS_SURFACE_VARIANTS: { PAGE: "page", MODAL: "modal" },
 }));
 jest.unstable_mockModule("@/store", () => ({
   useUserStore: (fn) => fn({ user: { plan: "free" } }),
@@ -185,10 +179,10 @@ test("saves preferences via api", async () => {
     render(<Preferences />);
   });
   await act(async () => {});
-  fireEvent.change(screen.getByLabelText("Language"), {
+  fireEvent.change(screen.getByLabelText("Source Language"), {
     target: { value: "CHINESE" },
   });
-  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
   await waitFor(() => expect(mockRequest).toHaveBeenCalled());
   expect(mockRequest.mock.calls[0][0]).toBe(`${API_PATHS.preferences}/user`);
 });
@@ -228,10 +222,10 @@ test("updates dictionary language preferences in settings store", async () => {
     render(<Preferences />);
   });
   await act(async () => {});
-  fireEvent.change(screen.getByLabelText("Language"), {
+  fireEvent.change(screen.getByLabelText("Source Language"), {
     target: { value: "CHINESE" },
   });
-  fireEvent.change(screen.getByLabelText("Search Language"), {
+  fireEvent.change(screen.getByLabelText("Target Language"), {
     target: { value: "ENGLISH" },
   });
   await waitFor(() => {

--- a/website/src/components/modals/Modal.jsx
+++ b/website/src/components/modals/Modal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import styles from "./Modal.module.css";
 import { useEscapeKey } from "@/hooks";
@@ -56,8 +56,34 @@ function unlockBodyScroll() {
   }
 }
 
+const FOCUSABLE_SELECTOR =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), iframe, object, embed, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]';
+
+const toFocusableElements = (root) => {
+  if (!root) {
+    return [];
+  }
+  const nodes = root.querySelectorAll(FOCUSABLE_SELECTOR);
+  return Array.from(nodes).filter((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+    if (element.hasAttribute("disabled")) {
+      return false;
+    }
+    if (element.tabIndex === -1) {
+      return false;
+    }
+    const hasLayout =
+      element.offsetParent !== null || element.getClientRects().length > 0;
+    return hasLayout;
+  });
+};
+
 function Modal({ onClose, className = "", children, closeLabel = "Close" }) {
   useEscapeKey(onClose);
+  const contentRef = useRef(null);
+  const previousFocusRef = useRef(null);
 
   useEffect(() => {
     const root = ensureModalRoot();
@@ -67,6 +93,65 @@ function Modal({ onClose, className = "", children, closeLabel = "Close" }) {
 
     return () => {
       unlockBodyScroll();
+    };
+  }, []);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) {
+      return undefined;
+    }
+
+    if (typeof document !== "undefined") {
+      const activeElement = document.activeElement;
+      if (activeElement instanceof HTMLElement) {
+        previousFocusRef.current = activeElement;
+      }
+    }
+
+    const focusables = toFocusableElements(content);
+    const focusTarget = focusables[0] ?? content;
+    requestAnimationFrame(() => {
+      focusTarget.focus({ preventScroll: true });
+    });
+
+    const handleKeyDown = (event) => {
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const elements = toFocusableElements(content);
+      if (elements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !content.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    content.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      content.removeEventListener("keydown", handleKeyDown);
+      const previous = previousFocusRef.current;
+      if (previous && typeof previous.focus === "function") {
+        previous.focus({ preventScroll: true });
+      }
     };
   }, []);
 
@@ -89,6 +174,8 @@ function Modal({ onClose, className = "", children, closeLabel = "Close" }) {
         className={contentClassName}
         role="dialog"
         aria-modal="true"
+        tabIndex={-1}
+        ref={contentRef}
         onClick={withStopPropagation()}
       >
         <button

--- a/website/src/components/modals/Modal.module.css
+++ b/website/src/components/modals/Modal.module.css
@@ -1,52 +1,86 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background: var(--color-overlay);
-  display: flex;
-  justify-content: center;
-  align-items: center;
   z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: var(--settings-dialog-gap-md);
+  background: rgb(11 18 32 / 48%);
+  overflow: auto;
+  animation: modal-overlay-fade 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .content {
   position: relative;
   display: flex;
   flex-direction: column;
-  max-height: 90vh;
-  overflow: auto;
-  box-shadow: 0 26px 68px -32px var(--shadow-color);
+  width: min(100%, var(--modal-max-width, var(--settings-dialog-width-lg)));
+  max-height: var(--modal-max-height, var(--settings-dialog-max-height));
+  border-radius: var(--modal-radius, var(--settings-dialog-radius));
+  background: var(--modal-surface, var(--settings-dialog-surface));
+  color: var(--modal-color, var(--settings-dialog-text));
+  box-shadow: var(--modal-shadow, var(--settings-dialog-shadow));
+  overflow: hidden;
 }
 
 .close-button {
   position: absolute;
-  top: 18px;
-  left: 18px;
-  width: 36px;
-  height: 36px;
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--app-color) 20%, transparent);
-  background: color-mix(in srgb, var(--app-bg) 80%, transparent);
-  color: var(--app-color);
+  top: var(--settings-dialog-gap-md);
+  left: var(--settings-dialog-gap-md);
   display: grid;
   place-items: center;
-  font-size: 20px;
-  line-height: 1;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid var(--settings-dialog-border);
+  background: transparent;
+  color: inherit;
   cursor: pointer;
+  font-size: 24px;
+  line-height: 1;
   transition:
-    background 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
+    background 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .close-button:hover,
 .close-button:focus-visible {
-  background: color-mix(in srgb, var(--app-bg) 60%, transparent);
-  border-color: color-mix(in srgb, var(--app-color) 30%, transparent);
-  box-shadow: 0 12px 24px -18px var(--shadow-color);
+  background: var(--settings-dialog-surface-muted);
+  border-color: var(--settings-dialog-border);
+  box-shadow: 0 8px 20px rgb(11 18 32 / 12%);
 }
 
 .close-button:focus-visible {
   outline: none;
   transform: translateY(-1px);
+}
+
+@keyframes modal-overlay-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (width <= 767px) {
+  .overlay {
+    padding: 0;
+  }
+
+  .content {
+    width: 100vw;
+    height: 100vh;
+    max-height: none;
+    border-radius: 0;
+  }
+
+  .close-button {
+    top: 12px;
+    left: 12px;
+  }
 }

--- a/website/src/components/modals/SettingsModal.module.css
+++ b/website/src/components/modals/SettingsModal.module.css
@@ -1,26 +1,18 @@
-@import url("./ModalContent.module.css");
-
 .dialog {
-  width: min(96vw, 920px);
-  max-height: 90vh;
-  padding: clamp(var(--space-2), 2vw, var(--space-3));
-  border-radius: var(--radius-xxl);
-  background: transparent;
-  border: none;
-  box-shadow: none;
+  --modal-max-width: var(--settings-dialog-width-lg);
+  --modal-max-height: var(--settings-dialog-max-height);
+  --modal-radius: var(--settings-dialog-radius);
+  --modal-surface: var(--settings-dialog-surface);
+  --modal-color: var(--settings-dialog-text);
+  --modal-shadow: var(--settings-dialog-shadow);
+
   display: flex;
-  align-items: stretch;
-  justify-content: center;
-  overflow: visible;
+  flex-direction: column;
+  background: var(--settings-dialog-surface);
 }
 
-.dialog > :global(*) {
-  flex: 1;
-}
-
-@media (width <= 599px) {
+@media (width <= 1023px) {
   .dialog {
-    padding: clamp(var(--space-2), 6vw, var(--space-3));
-    border-radius: var(--radius-xl);
+    --modal-max-width: var(--settings-dialog-width-md);
   }
 }

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -1,671 +1,352 @@
-.surface-page {
-  padding: clamp(var(--space-5), 4vw, var(--space-7));
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--settings-dialog-surface);
+  color: var(--settings-dialog-text);
 }
 
-.surface-dialog {
-  padding: clamp(var(--space-4), 3vw, var(--space-5));
+.page {
+  max-width: min(960px, 100%);
+  margin: 32px auto;
+  border-radius: var(--settings-dialog-radius);
+  box-shadow: var(--settings-dialog-shadow);
 }
 
-.layout {
-  display: grid;
-  gap: clamp(var(--space-5), 4vw, var(--space-7));
-  grid-template-columns: minmax(0, 1fr);
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: var(--settings-dialog-gap-md);
+  border-bottom: 1px solid var(--settings-dialog-border);
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--settings-dialog-muted);
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  gap: var(--settings-dialog-gap-md);
+  padding: var(--settings-dialog-gap-md);
+  min-height: 0;
 }
 
 .sidebar {
+  width: var(--settings-dialog-navigation-width);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--settings-dialog-gap-sm);
+  padding-right: 4px;
+  overflow-y: auto;
+}
+
+.nav-list {
   display: grid;
-  gap: clamp(var(--space-4), 3vw, var(--space-5));
-  align-content: start;
-}
-
-.sidebar-card {
-  position: relative;
-  display: grid;
-  gap: var(--space-3);
-  padding: clamp(var(--space-4), 3vw, var(--space-5));
-  border-radius: 26px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 42%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      140deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 36%)) 48%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
-  box-shadow: 0 36px 96px
-    color-mix(in srgb, var(--shadow-color) 26%, transparent);
-  overflow: hidden;
-}
-
-.sidebar-card::after {
-  content: "";
-  position: absolute;
-  inset: 1px;
-  border-radius: inherit;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 18%,
-      transparent
-    );
-  pointer-events: none;
-}
-
-.sidebar-eyebrow {
-  font-size: var(--text-xs);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 68%,
-    transparent
-  );
-}
-
-.sidebar-active-title {
+  gap: var(--settings-dialog-gap-sm);
   margin: 0;
-  font-size: clamp(var(--text-lg), 2.6vw, var(--text-2xl));
-  font-weight: var(--font-semibold);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--sidebar-color, var(--app-color));
+  padding: 0;
+  list-style: none;
 }
 
-.sidebar-description {
-  margin: 0;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 72%,
-    transparent
-  );
-  line-height: 1.7;
-  font-size: var(--text-sm);
-}
-
-.tab-list {
-  display: grid;
-  gap: clamp(var(--space-3), 3vw, var(--space-4));
-  align-content: start;
-}
-
-.tab-button {
-  position: relative;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: var(--space-3);
+.nav-button {
+  display: flex;
   align-items: center;
+  gap: var(--settings-dialog-gap-sm);
   width: 100%;
-  padding: clamp(14px, 2.6vw, 18px) clamp(18px, 4vw, 22px);
-  border-radius: 20px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 38%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 28%)) 42%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
-  color: color-mix(
-    in srgb,
-    var(--sidebar-color, var(--app-color)) 88%,
-    transparent
-  );
+  height: 44px;
+  padding-inline: 12px;
+  border-radius: var(--settings-dialog-control-radius);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--settings-dialog-text);
+  font-size: 14px;
+  font-weight: 500;
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 160ms ease,
-    border-color 160ms ease,
-    transform 160ms ease,
-    color 160ms ease,
-    box-shadow 160ms ease;
+    background 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.tab-button::after {
-  content: "\203A";
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-end: clamp(14px, 3vw, 20px);
-  transform: translate(0, -50%);
-  font-size: 1.2rem;
-  color: currentcolor;
-  opacity: 0.48;
-  transition:
-    transform 160ms ease,
-    opacity 160ms ease;
+.nav-button:hover {
+  background: var(--settings-dialog-surface-muted);
 }
 
-.tab-button:hover,
-.tab-button:focus-visible {
-  background:
-    linear-gradient(
-      140deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 42%)) 52%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
-  border-color: color-mix(
-    in srgb,
-    var(--sidebar-border-color, var(--border-color)) 58%,
-    transparent
-  );
-  color: var(--sidebar-color, var(--app-color));
-  transform: translateX(4px);
-  box-shadow: 0 24px 68px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
-}
-
-.tab-button:hover::after,
-.tab-button:focus-visible::after {
-  opacity: 0.84;
-  transform: translate(4px, -50%);
-}
-
-.tab-button:focus-visible {
+.nav-button:focus-visible {
   outline: none;
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--primary-color) 32%, transparent),
-    0 24px 68px color-mix(in srgb, var(--shadow-color) 24%, transparent);
+  border-color: var(--settings-dialog-accent);
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 20%);
 }
 
-.tab-button-active {
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 52%)) 66%,
-          transparent
-        )
-        0%,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
-  border-color: color-mix(
-    in srgb,
-    var(--sidebar-border-color, var(--border-color)) 62%,
-    transparent
-  );
-  color: var(--sidebar-color, var(--app-color));
-  transform: translateX(6px);
-  box-shadow: 0 30px 82px
-    color-mix(in srgb, var(--shadow-color) 32%, transparent);
+.nav-button-active {
+  background: var(--settings-dialog-surface-muted);
+  font-weight: 600;
 }
 
-.tab-button-active::after {
-  opacity: 1;
-  transform: translate(6px, -50%);
-}
-
-.tab-icon-wrapper {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 38px;
-  height: 38px;
-  border-radius: 14px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 36%,
-      transparent
-    );
-  background: color-mix(
-    in srgb,
-    var(--sidebar-panel, var(--app-bg)) 90%,
-    transparent
-  );
-  box-shadow: inset 0 1px 0
-    color-mix(in srgb, var(--neutral-0) 20%, transparent);
-  transition:
-    background-color 160ms ease,
-    border-color 160ms ease,
-    box-shadow 160ms ease;
-}
-
-.tab-button-active .tab-icon-wrapper {
-  border-color: color-mix(in srgb, var(--primary-color) 38%, transparent);
-  background: color-mix(
-    in srgb,
-    var(--primary-bg, var(--sidebar-panel, var(--app-bg))) 72%,
-    transparent
-  );
-  box-shadow: 0 12px 28px
-    color-mix(in srgb, var(--shadow-color) 26%, transparent);
-}
-
-.tab-icon {
+.nav-icon {
   width: 18px;
   height: 18px;
-  color: inherit;
+  color: var(--settings-dialog-muted);
 }
 
-.tab-copy {
-  display: grid;
-  gap: 6px;
+.nav-button-active .nav-icon {
+  color: var(--settings-dialog-text);
 }
 
-.tab-label {
-  font-size: var(--text-sm);
-  font-weight: var(--font-semibold);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.tab-support {
-  font-size: var(--text-xs);
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 70%,
-    transparent
-  );
-  line-height: 1.6;
-}
-
-.panel-area {
-  display: grid;
-  min-height: 100%;
-}
-
-.panel-card {
-  position: relative;
-  display: grid;
-  gap: clamp(var(--space-4), 3vw, var(--space-5));
-  padding: clamp(var(--space-4), 3vw, var(--space-5));
-  border-radius: 28px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 42%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      150deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
-        0%,
-      color-mix(in srgb, var(--color-surface-alt) 72%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
-  box-shadow: 0 44px 120px
-    color-mix(in srgb, var(--shadow-color) 28%, transparent);
+.nav-label {
+  flex: 1;
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.panel-card::after {
-  content: "";
-  position: absolute;
-  inset: 1px;
-  border-radius: inherit;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 18%,
-      transparent
-    );
-  pointer-events: none;
-}
-
-.panel-header {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  gap: var(--space-2);
-}
-
-.panel-title-group {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.panel-icon {
-  width: 18px;
-  height: 18px;
-  color: inherit;
-}
-
-.panel-title {
-  margin: 0;
-  font-size: var(--text-base);
-  font-weight: var(--font-semibold);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.panel-description {
-  margin: 0;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 70%,
-    transparent
-  );
-  line-height: 1.7;
-  font-size: var(--text-sm);
-}
-
-.panel-body {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  gap: clamp(var(--space-4), 3vw, var(--space-5));
-}
-
-.panel-callout {
-  display: grid;
-  gap: 8px;
-  padding: clamp(var(--space-3), 2.4vw, var(--space-4));
-  border-radius: 22px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 34%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      150deg,
-      color-mix(in srgb, var(--primary-bg, var(--app-bg)) 82%, transparent) 0%,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
-  box-shadow: 0 26px 70px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
-}
-
-.callout-eyebrow {
-  font-size: var(--text-xs);
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--primary-color) 86%, transparent);
-}
-
-.callout-description {
-  margin: 0;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 72%,
-    transparent
-  );
-  line-height: 1.7;
-  font-size: var(--text-sm);
-}
-
-.setting-grid {
-  display: grid;
-  gap: clamp(var(--space-3), 2.6vw, var(--space-4));
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.setting-row {
-  display: grid;
-  gap: var(--space-3);
-  align-content: start;
-  padding: clamp(16px, 2.6vw, 22px);
-  border-radius: 20px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 36%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      150deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 32%)) 42%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
-  box-shadow: 0 26px 70px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
-}
-
-.setting-label {
-  font-size: var(--text-xs);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 70%,
-    transparent
-  );
-}
-
-.setting-toggle-row {
+.content {
+  flex: 1;
+  min-width: 0;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: var(--settings-dialog-gap-md);
+  padding-block: var(--settings-dialog-gap-md);
+  overflow-y: auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--settings-dialog-gap-sm);
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.section-title {
+  margin: 0;
+  font-size: 15px;
+  line-height: 22px;
+  font-weight: 600;
+}
+
+.section-description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--settings-dialog-muted);
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--settings-dialog-gap-sm);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-inline {
+  display: flex;
   align-items: center;
-  gap: var(--space-3);
-  padding: clamp(18px, 3vw, 24px);
-  border-radius: 22px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 36%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      140deg,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 32%)) 48%,
-          transparent
-        )
-        0%,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
-  box-shadow: 0 24px 64px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
+  justify-content: space-between;
+  gap: var(--settings-dialog-gap-sm);
+}
+
+.field-label {
+  font-size: 14px;
+  line-height: 22px;
+  font-weight: 500;
+}
+
+.field-description {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--settings-dialog-muted);
+}
+
+.select,
+.input,
+.textarea {
+  width: 100%;
+  border: 1px solid var(--settings-dialog-border);
+  border-radius: var(--settings-dialog-control-radius);
+  background: var(--settings-dialog-surface);
+  color: var(--settings-dialog-text);
+  font-size: 14px;
+  transition:
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.select,
+.input {
+  height: var(--settings-dialog-control-height);
+  padding: 0 36px 0 14px;
+}
+
+.select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='%23667085'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px 16px;
+}
+
+.textarea {
+  min-height: 120px;
+  padding: 12px 14px;
+  resize: vertical;
+}
+
+.select:hover,
+.input:hover,
+.textarea:hover {
+  border-color: #d1d5db;
+}
+
+.select:focus-visible,
+.input:focus-visible,
+.textarea:focus-visible {
+  outline: none;
+  border-color: var(--settings-dialog-accent);
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 18%);
+}
+
+.select:disabled,
+.input:disabled,
+.textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .switch {
   position: relative;
+  width: 44px;
+  height: 24px;
   display: inline-flex;
-  width: 58px;
-  height: 30px;
-  border-radius: 999px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 44%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      130deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 28%)) 48%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 88%, transparent);
-  box-shadow: inset 0 1px 0
-    color-mix(in srgb, var(--neutral-0) 24%, transparent);
-  transition:
-    background-color 160ms ease,
-    border-color 160ms ease,
-    box-shadow 160ms ease;
+  align-items: center;
 }
 
 .switch input {
   position: absolute;
   inset: 0;
   opacity: 0;
-  cursor: pointer;
 }
 
 .switch span {
+  position: relative;
+  display: block;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  transition: background 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.switch span::after {
+  content: "";
   position: absolute;
   top: 4px;
   left: 4px;
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  background:
-    linear-gradient(
-      140deg,
-      color-mix(in srgb, var(--app-bg) 96%, transparent) 0%,
-      color-mix(in srgb, var(--color-surface-muted) 68%, transparent) 100%
-    ),
-    var(--app-bg);
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 36%,
-      transparent
-    );
-  box-shadow: 0 8px 20px
-    color-mix(in srgb, var(--shadow-color) 30%, transparent);
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgb(15 23 42 / 12%);
   transition:
-    transform 160ms ease,
-    box-shadow 160ms ease,
-    background 160ms ease,
-    border-color 160ms ease;
+    transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .switch input:checked + span {
-  transform: translateX(26px);
-  box-shadow: 0 12px 26px
-    color-mix(in srgb, var(--primary-color) 36%, transparent);
-  border: 1px solid color-mix(in srgb, var(--primary-color) 46%, transparent);
-  background:
-    linear-gradient(
-      140deg,
-      color-mix(in srgb, var(--primary-color) 80%, transparent) 0%,
-      color-mix(in srgb, var(--primary-color) 60%, transparent) 100%
-    ),
-    var(--primary-color);
+  background: var(--settings-dialog-accent);
 }
 
-.field-grid {
-  display: grid;
-  gap: clamp(var(--space-3), 2.6vw, var(--space-4));
+.switch input:checked + span::after {
+  transform: translateX(20px);
 }
 
-.field-item {
-  display: grid;
-  gap: var(--space-3);
-  padding: clamp(16px, 2.6vw, 22px);
-  border-radius: 22px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 36%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 30%)) 40%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
-  box-shadow: 0 26px 70px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
-  color: inherit;
+.switch input:focus-visible + span {
+  outline: 2px solid rgb(59 130 246 / 32%);
+  outline-offset: 2px;
 }
 
-.field-label {
-  font-size: var(--text-xs);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 68%,
-    transparent
-  );
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--settings-dialog-gap-sm);
+  padding: var(--settings-dialog-gap-md);
+  border-top: 1px solid var(--settings-dialog-border);
 }
 
-.field-input,
-.field-area {
-  width: 100%;
-  padding: 12px 16px;
-  border-radius: 16px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 40%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--app-bg) 96%, transparent) 0%,
-      color-mix(in srgb, var(--color-surface-muted) 60%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--app-bg) 94%, transparent);
-  color: inherit;
-  font: inherit;
-  resize: vertical;
+.primary-button,
+.secondary-button {
+  min-width: 120px;
+  height: var(--settings-dialog-control-height);
+  padding: 0 20px;
+  border-radius: var(--settings-dialog-control-radius);
+  font-size: 14px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition:
-    border-color 160ms ease,
-    box-shadow 160ms ease;
+    background 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.field-input:focus,
-.field-area:focus {
-  outline: none;
-  border-color: color-mix(in srgb, var(--primary-color) 46%, transparent);
-  box-shadow: 0 0 0 2px
-    color-mix(in srgb, var(--primary-color) 32%, transparent);
+.primary-button {
+  border: 1px solid var(--settings-dialog-accent);
+  background: var(--settings-dialog-accent);
+  color: #fff;
+  box-shadow: 0 8px 16px rgb(59 130 246 / 24%);
 }
 
-.field-input:disabled,
-.field-area:disabled {
+.primary-button:disabled {
   opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary-button:hover:not(:disabled) {
+  box-shadow: 0 12px 22px rgb(59 130 246 / 28%);
+}
+
+.secondary-button {
+  border: 1px solid var(--settings-dialog-border);
+  background: transparent;
+  color: var(--settings-dialog-text);
+}
+
+.secondary-button:hover:not(:disabled) {
+  background: var(--settings-dialog-surface-muted);
 }
 
 .shortcut-list {
-  display: grid;
-  gap: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -673,288 +354,152 @@
 
 .shortcut-item {
   display: flex;
-  gap: 16px;
   align-items: center;
-  padding: clamp(14px, 2.4vw, 20px) clamp(16px, 3vw, 22px);
-  border-radius: 18px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 34%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 32%)) 44%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
-  box-shadow: 0 22px 64px
-    color-mix(in srgb, var(--shadow-color) 22%, transparent);
+  gap: var(--settings-dialog-gap-sm);
 }
 
 .shortcut-key {
-  min-width: 140px;
-  font-family: var(--font-mono, "SFMono-Regular", monospace);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-family: Inter, SFMono-Regular, "SF Mono", ui-monospace, monospace;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--settings-dialog-border);
+  background: var(--settings-dialog-surface-muted);
 }
 
 .shortcut-label {
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 72%,
-    transparent
-  );
-  font-size: var(--text-sm);
+  font-size: 13px;
+  color: var(--settings-dialog-muted);
 }
 
 .data-card {
-  display: grid;
-  gap: var(--space-3);
-  padding: clamp(18px, 3vw, 24px);
-  border-radius: 20px;
-  border: 1px dashed
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 42%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 94%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 24%)) 32%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
-  box-shadow: 0 20px 56px
-    color-mix(in srgb, var(--shadow-color) 20%, transparent);
-}
-
-.data-text {
-  margin: 0;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 74%,
-    transparent
-  );
-  line-height: 1.8;
+  display: flex;
+  flex-direction: column;
+  gap: var(--settings-dialog-gap-sm);
+  padding: 16px;
+  border-radius: var(--settings-dialog-control-radius);
+  border: 1px solid var(--settings-dialog-border);
+  background: var(--settings-dialog-surface-muted);
 }
 
 .data-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
-}
-
-.secondary-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.7rem 1.5rem;
-  border-radius: 18px;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 44%,
-      transparent
-    );
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 92%, transparent)
-        0%,
-      color-mix(
-          in srgb,
-          var(--sidebar-hover-bg, rgb(24 27 33 / 28%)) 48%,
-          transparent
-        )
-        100%
-    ),
-    color-mix(in srgb, var(--sidebar-panel, var(--app-bg)) 90%, transparent);
-  color: color-mix(
-    in srgb,
-    var(--sidebar-color, var(--app-color)) 88%,
-    transparent
-  );
-  font-size: var(--text-sm);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    background-color 160ms ease,
-    transform 160ms ease,
-    border-color 160ms ease,
-    box-shadow 160ms ease;
-  box-shadow: 0 18px 48px
-    color-mix(in srgb, var(--shadow-color) 20%, transparent);
-}
-
-.secondary-button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.secondary-button:focus-visible {
-  outline: none;
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--primary-color) 32%, transparent),
-    0 22px 60px color-mix(in srgb, var(--shadow-color) 24%, transparent);
-  border-color: color-mix(in srgb, var(--primary-color) 38%, transparent);
-  transform: translateY(-1px);
-}
-
-.secondary-button:not(:disabled):hover {
-  border-color: color-mix(in srgb, var(--primary-color) 38%, transparent);
-  transform: translateY(-1px);
-  box-shadow: 0 22px 60px
-    color-mix(in srgb, var(--shadow-color) 24%, transparent);
-}
-
-.primary-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 176px;
-  padding: 0.85rem 1.6rem;
-  border-radius: 18px;
-  border: none;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--primary-bg) 94%, transparent) 0%,
-    color-mix(in srgb, var(--primary-bg) 78%, transparent) 100%
-  );
-  color: var(--primary-color);
-  font-size: var(--text-sm);
-  font-weight: var(--font-bold);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  cursor: pointer;
-  box-shadow: 0 28px 80px
-    color-mix(in srgb, var(--shadow-color) 32%, transparent);
-  transition:
-    transform 160ms ease,
-    box-shadow 160ms ease;
-}
-
-.primary-button:disabled {
-  opacity: 0.6;
-  cursor: progress;
-}
-
-.primary-button:focus-visible {
-  outline: none;
-  transform: translateY(-1px);
-  box-shadow:
-    0 32px 92px color-mix(in srgb, var(--shadow-color) 36%, transparent),
-    0 0 0 3px color-mix(in srgb, var(--highlight-color) 38%, transparent);
-}
-
-.primary-button:not(:disabled):hover {
-  transform: translateY(-2px);
-  box-shadow: 0 36px 96px
-    color-mix(in srgb, var(--shadow-color) 40%, transparent);
+  gap: var(--settings-dialog-gap-sm);
 }
 
 .account-header {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--settings-dialog-gap-sm);
 }
 
 .account-meta {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 4px;
-  min-width: 160px;
+  flex: 1;
 }
 
 .account-name {
-  font-size: var(--text-base);
-  font-weight: var(--font-semibold);
+  font-size: 15px;
+  font-weight: 600;
 }
 
 .account-plan {
-  font-size: var(--text-sm);
+  font-size: 12px;
+  color: var(--settings-dialog-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 70%,
-    transparent
-  );
 }
 
 .account-list {
-  display: grid;
-  gap: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--settings-dialog-gap-sm);
   margin: 0;
+  padding: 0;
 }
 
 .account-row {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  gap: var(--space-3);
-  padding-bottom: 12px;
-  border-bottom: 1px solid
-    color-mix(
-      in srgb,
-      var(--sidebar-border-color, var(--border-color)) 36%,
-      transparent
-    );
-}
-
-.account-row:last-of-type {
-  border-bottom: none;
-  padding-bottom: 0;
+  gap: var(--settings-dialog-gap-sm);
+  font-size: 13px;
 }
 
 .account-row dt {
-  font-size: var(--text-sm);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 70%,
-    transparent
-  );
+  font-weight: 500;
+  color: var(--settings-dialog-muted);
 }
 
 .account-row dd {
   margin: 0;
-  font-size: var(--text-sm);
-  color: var(--sidebar-color, var(--app-color));
+  font-weight: 500;
 }
 
-@media (width >= 960px) {
-  .layout {
-    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+@media (width <= 1023px) {
+  .body {
+    flex-direction: column;
   }
 
-  .panel-area {
-    min-height: 560px;
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    overflow: visible;
+    padding-right: 0;
   }
 
-  .field-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .nav-list {
+    display: flex;
+    flex-wrap: wrap;
   }
 
-  .field-grid label:last-child {
-    grid-column: 1 / -1;
+  .nav-button {
+    flex: 1 1 calc(50% - var(--settings-dialog-gap-sm));
+  }
+}
+
+@media (width <= 767px) {
+  .container {
+    height: 100%;
+  }
+
+  .header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--settings-dialog-surface);
+  }
+
+  .body {
+    padding: var(--settings-dialog-gap-md);
+    gap: var(--settings-dialog-gap-md);
+  }
+
+  .sidebar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .nav-list {
+    gap: 8px;
+  }
+
+  .nav-button {
+    flex: 1 0 auto;
+    min-width: 140px;
+  }
+
+  .content {
+    padding-block: var(--settings-dialog-gap-sm);
+  }
+
+  .actions {
+    position: sticky;
+    bottom: 0;
+    background: var(--settings-dialog-surface);
   }
 }

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -47,4 +47,24 @@
   --sb-send-color: #0b0d11;
   --sb-compact-offset: 2px;
   --sb-ring-width: 2px;
+
+  /* settings dialog */
+  --settings-dialog-width-md: 640px;
+  --settings-dialog-width-lg: 720px;
+  --settings-dialog-max-height: 72vh;
+  --settings-dialog-surface: #fff;
+  --settings-dialog-surface-muted: #f2f4f7;
+  --settings-dialog-background: #f7f7f8;
+  --settings-dialog-border: #e5e7eb;
+  --settings-dialog-text: #0b1220;
+  --settings-dialog-muted: #667085;
+  --settings-dialog-accent: #3b82f6;
+  --settings-dialog-shadow:
+    0 12px 30px rgb(11 18 32 / 12%), 0 2px 8px rgb(11 18 32 / 6%);
+  --settings-dialog-radius: 16px;
+  --settings-dialog-control-radius: 12px;
+  --settings-dialog-control-height: 40px;
+  --settings-dialog-navigation-width: 240px;
+  --settings-dialog-gap-sm: 16px;
+  --settings-dialog-gap-md: 24px;
 }


### PR DESCRIPTION
## Summary
- transform the settings modal into a centered dialog with refreshed tokens, dedicated navigation, and scrollable content
- add focus trapping and updated styling to the shared modal infrastructure used by settings
- align settings tests with the new layout and labels

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/pages/preferences/index.jsx src/pages/preferences/Preferences.module.css
- npm test -- Preferences

------
https://chatgpt.com/codex/tasks/task_e_68d98f15db3c83329b9008de9f56a659