### PR TITLE
fix: gracefully handle blocked local storage access

### DIFF
--- a/website/src/store/__tests__/createPersistentStore.test.ts
+++ b/website/src/store/__tests__/createPersistentStore.test.ts
@@ -1,0 +1,40 @@
+import { act } from "@testing-library/react";
+import { createPersistentStore } from "../createPersistentStore.js";
+
+describe("createPersistentStore", () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "localStorage",
+  );
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, "localStorage", originalDescriptor);
+    } else {
+      delete window.localStorage;
+    }
+  });
+
+  test("gracefully falls back when localStorage access is blocked", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("Denied");
+      },
+    });
+
+    const useTestStore = createPersistentStore({
+      key: "test-safe-storage",
+      initializer: (set) => ({
+        value: 0,
+        increment: () => set((state) => ({ value: state.value + 1 })),
+      }),
+    });
+
+    act(() => {
+      useTestStore.getState().increment();
+    });
+
+    expect(useTestStore.getState().value).toBe(1);
+  });
+});

--- a/website/src/store/createPersistentStore.ts
+++ b/website/src/store/createPersistentStore.ts
@@ -4,6 +4,7 @@ import {
   createJSONStorage,
   type PersistOptions,
 } from "zustand/middleware";
+import { resolveStateStorage } from "./persistUtils.js";
 import type { StateCreator, StoreApi, UseBoundStore } from "zustand";
 
 interface Options<T> {
@@ -20,7 +21,7 @@ export function createPersistentStore<T>({
   return create<T>()(
     persist(initializer, {
       name: key,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => resolveStateStorage(key)),
       ...(persistOptions ?? {}),
     }),
   );

--- a/website/src/store/persistUtils.ts
+++ b/website/src/store/persistUtils.ts
@@ -1,3 +1,5 @@
+import type { StateStorage } from "zustand/middleware";
+
 export function pickState<T extends object, K extends keyof T>(keys: K[]) {
   return (state: T) => {
     const result = {} as Pick<T, K>;
@@ -6,4 +8,48 @@ export function pickState<T extends object, K extends keyof T>(keys: K[]) {
     }
     return result;
   };
+}
+
+const inMemoryStorage: StateStorage = (() => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (name) => store.get(name) ?? null,
+    setItem: (name, value) => {
+      store.set(name, value);
+    },
+    removeItem: (name) => {
+      store.delete(name);
+    },
+  };
+})();
+
+function attemptLocalStorageAccess(key: string): StateStorage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const storage = window.localStorage;
+    const probeKey = `__glancy-storage-probe__${key}`;
+    storage.setItem(probeKey, probeKey);
+    storage.removeItem(probeKey);
+    return storage;
+  } catch (error) {
+    if (
+      typeof process !== "undefined" &&
+      process?.env?.NODE_ENV !== "production" &&
+      process?.env?.NODE_ENV !== "test"
+    ) {
+      console.warn("Falling back to in-memory storage due to access issue.", {
+        error,
+        key,
+      });
+    }
+    return null;
+  }
+}
+
+export function resolveStateStorage(key: string): StateStorage {
+  return attemptLocalStorageAccess(key) ?? inMemoryStorage;
 }


### PR DESCRIPTION
## Summary
- guard persistent stores against denied `localStorage` access by falling back to an in-memory adapter
- cover the storage fallback path with a focused regression test

## Testing
- npm run test -- createPersistentStore
- npx eslint --fix .
- npx stylelint "src/**/*.css" --fix
- npx prettier -w .

------
https://chatgpt.com/codex/tasks/task_e_68d99d817d708332b045343de97e85b3