### PR TITLE
feat: redesign dictionary search bar

### DIFF
--- a/website/src/components/__tests__/SearchBox.test.jsx
+++ b/website/src/components/__tests__/SearchBox.test.jsx
@@ -43,8 +43,10 @@ test("applies design token defaults", () => {
   );
   const box = container.firstChild;
   const styles = getComputedStyle(box);
-  expect(styles.borderRadius).toBe("var(--sb-radius, 14px)");
-  expect(styles.minHeight).toBe("var(--sb-h, 48px)");
+  expect(styles.borderRadius).toBe("var(--sb-r, 28px)");
+  expect(styles.minHeight).toBe("var(--sb-h, 56px)");
+  expect(box.getAttribute("data-testid")).toBe("searchbar");
+  expect(box.getAttribute("role")).toBe("search");
 });
 
 /**

--- a/website/src/components/ui/ChatInput/ActionInput.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput.jsx
@@ -4,56 +4,55 @@ import SearchBox from "@/components/ui/SearchBox";
 import LanguageControls from "./LanguageControls.jsx";
 import styles from "./ChatInput.module.css";
 
-const MIC_ICON_SIZE = 18;
+const EQUALIZER_ICON_SIZE = 18;
 
-function MicIcon({ className }) {
+function EqualizerIcon({ className }) {
   return (
     <svg
       className={className}
-      width={MIC_ICON_SIZE}
-      height={MIC_ICON_SIZE}
+      width={EQUALIZER_ICON_SIZE}
+      height={EQUALIZER_ICON_SIZE}
       viewBox="0 0 18 18"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
     >
-      <path
-        d="M9 11.75a2.75 2.75 0 0 0 2.75-2.75V5a2.75 2.75 0 0 0-5.5 0v4c0 1.52 1.23 2.75 2.75 2.75Z"
+      <rect
+        x="2.75"
+        y="6"
+        width="2.5"
+        height="9.25"
+        rx="1.25"
         stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
+        strokeWidth="1.5"
       />
-      <path
-        d="M4.5 8.5V9a4.5 4.5 0 0 0 9 0v-.5"
+      <rect
+        x="7.75"
+        y="3"
+        width="2.5"
+        height="12.25"
+        rx="1.25"
         stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
+        strokeWidth="1.5"
       />
-      <path
-        d="M9 13.5V16"
+      <rect
+        x="12.75"
+        y="8"
+        width="2.5"
+        height="7.25"
+        rx="1.25"
         stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M6.5 16h5"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
+        strokeWidth="1.5"
       />
     </svg>
   );
 }
 
-MicIcon.propTypes = {
+EqualizerIcon.propTypes = {
   className: PropTypes.string,
 };
 
-MicIcon.defaultProps = {
+EqualizerIcon.defaultProps = {
   className: undefined,
 };
 
@@ -66,11 +65,14 @@ function ActionInput({
   onChange,
   onSubmit,
   onVoice,
+  onEqualizer,
   inputRef,
   placeholder,
   voiceLabel = "Voice",
+  equalizerLabel = "Voice settings",
   rows = 1,
   maxRows = 5,
+  isRecording = false,
   sourceLanguage,
   sourceLanguageOptions,
   sourceLanguageLabel,
@@ -139,6 +141,9 @@ function ActionInput({
   );
 
   const isVoiceDisabled = typeof onVoice !== "function";
+  const handleEqualizer = useCallback(() => {
+    onEqualizer?.();
+  }, [onEqualizer]);
 
   const handleVoice = useCallback(
     (event) => {
@@ -173,23 +178,21 @@ function ActionInput({
       <SearchBox className={styles["input-surface"]}>
         {showLanguageControls ? (
           <>
-            <div className={styles["lang-rail"]}>
-              <LanguageControls
-                sourceLanguage={sourceLanguage}
-                sourceLanguageOptions={sourceLanguageOptions}
-                sourceLanguageLabel={sourceLanguageLabel}
-                onSourceLanguageChange={onSourceLanguageChange}
-                targetLanguage={targetLanguage}
-                targetLanguageOptions={targetLanguageOptions}
-                targetLanguageLabel={targetLanguageLabel}
-                onTargetLanguageChange={onTargetLanguageChange}
-                onSwapLanguages={onSwapLanguages}
-                swapLabel={swapLabel}
-                normalizeSourceLanguage={normalizeSourceLanguageFn}
-                normalizeTargetLanguage={normalizeTargetLanguageFn}
-                onMenuOpen={onMenuOpen}
-              />
-            </div>
+            <LanguageControls
+              sourceLanguage={sourceLanguage}
+              sourceLanguageOptions={sourceLanguageOptions}
+              sourceLanguageLabel={sourceLanguageLabel}
+              onSourceLanguageChange={onSourceLanguageChange}
+              targetLanguage={targetLanguage}
+              targetLanguageOptions={targetLanguageOptions}
+              targetLanguageLabel={targetLanguageLabel}
+              onTargetLanguageChange={onTargetLanguageChange}
+              onSwapLanguages={onSwapLanguages}
+              swapLabel={swapLabel}
+              normalizeSourceLanguage={normalizeSourceLanguageFn}
+              normalizeTargetLanguage={normalizeTargetLanguageFn}
+              onMenuOpen={onMenuOpen}
+            />
             <div className={styles["language-divider"]} aria-hidden="true" />
           </>
         ) : null}
@@ -210,15 +213,24 @@ function ActionInput({
             aria-hidden="true"
           />
         </div>
-        <div className={styles.actions}>
+        <div className={styles["voice-controls"]}>
           <button
             type="button"
-            className={styles["voice-button"]}
+            className={`${styles["voice-button"]} ${styles["voice-eq"]}`}
+            onClick={handleEqualizer}
+            aria-label={equalizerLabel}
+          >
+            <EqualizerIcon className={styles["equalizer-icon"]} />
+          </button>
+          <button
+            type="button"
+            className={`${styles["voice-button"]} ${styles["voice-rec"]}`}
             onClick={handleVoice}
             aria-label={voiceLabel}
+            aria-pressed={Boolean(isRecording)}
             disabled={isVoiceDisabled}
           >
-            <MicIcon className={styles["voice-icon"]} />
+            <span className={styles["voice-dot"]} />
           </button>
         </div>
       </SearchBox>
@@ -233,14 +245,17 @@ ActionInput.propTypes = {
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
   onVoice: PropTypes.func,
+  onEqualizer: PropTypes.func,
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.any }),
   ]),
   placeholder: PropTypes.string,
   voiceLabel: PropTypes.string,
+  equalizerLabel: PropTypes.string,
   rows: PropTypes.number,
   maxRows: PropTypes.number,
+  isRecording: PropTypes.bool,
   sourceLanguage: PropTypes.oneOfType([PropTypes.string, PropTypes.symbol]),
   sourceLanguageOptions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -270,11 +285,14 @@ ActionInput.defaultProps = {
   onChange: undefined,
   onSubmit: undefined,
   onVoice: undefined,
+  onEqualizer: undefined,
   inputRef: undefined,
   placeholder: undefined,
   voiceLabel: "Voice",
+  equalizerLabel: "Voice settings",
   rows: 1,
   maxRows: 5,
+  isRecording: false,
   sourceLanguage: undefined,
   sourceLanguageOptions: [],
   sourceLanguageLabel: undefined,

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -10,28 +10,43 @@
 
 .input-surface {
   --padding-y: 0;
-  --slot-gap: var(--sb-col-gap, 12px);
+  --slot-gap: var(--sb-gap, 16px);
 }
 
-.lang-rail {
-  display: flex;
-  align-items: center;
-  gap: var(--chip-gap, 8px);
-  height: 100%;
-  padding: 0;
-  margin: 0;
-}
-
-.language-controls {
+.language-shell {
   display: inline-flex;
   align-items: center;
-  gap: var(--chip-gap, 8px);
-  height: 100%;
+  justify-content: center;
+  height: var(--seg-h, 44px);
+  padding-inline: var(--seg-pad-x, 20px);
+  gap: var(--seg-arrow-gap, 12px);
+  border-radius: var(--seg-r, 22px);
+  background: var(--sb-seg, #141b24);
+  color: var(--sb-text, #edeff2);
+  font-size: var(--seg-font-size, 14px);
+  font-weight: var(--seg-font-weight, 600);
+  letter-spacing: var(--seg-letter-space, 0.04em);
+  text-transform: uppercase;
+  text-align: center;
+  flex-shrink: 0;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.language-shell:hover {
+  background: color-mix(in srgb, var(--sb-seg) 96%, white 4%);
+}
+
+.language-shell:focus-within {
+  box-shadow:
+    var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%)),
+    0 0 0 1px rgb(255 255 255 / 6%);
 }
 
 .language-select-wrapper {
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   height: 100%;
 }
@@ -40,65 +55,52 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--chip-gap, 8px);
-  height: 40px;
-  min-width: var(--sb-code-min-width, 64px);
-  padding-inline: 12px;
-  border: 1px solid transparent;
-  border-radius: var(--chip-radius, 16px);
-  background: var(--chip-bg, #252b33);
-  color: var(--chip-text, #d5dbe6);
-  font-size: var(--sb-font-sm, 15px);
-  font-weight: var(--sb-font-strong, 600);
-  letter-spacing: var(--sb-code-letter-spacing, 0.08em);
-  text-transform: uppercase;
+  gap: var(--seg-arrow-gap, 12px);
+  height: 100%;
+  padding: 0;
+  border: none;
+  border-radius: calc(var(--seg-r, 22px) - 6px);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
   cursor: pointer;
   transition:
-    background-color 0.15s ease,
-    color 0.15s ease,
-    box-shadow 0.15s ease,
-    transform 0.15s ease;
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
-.language-trigger:hover,
-.language-trigger[data-open="true"] {
-  background: var(--chip-bg-hover, #2b323c);
+.language-trigger[data-open="true"],
+.language-trigger:hover {
+  background: color-mix(in srgb, var(--sb-seg) 88%, white 12%);
 }
 
 .language-trigger:focus-visible {
   outline: none;
-  box-shadow: var(--sb-ring, 0 0 0 6px rgb(120 160 255 / 6%));
+  box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
 }
 
 .language-trigger-content {
   display: inline-flex;
   align-items: center;
-  gap: var(--chip-gap, 8px);
+  gap: 0;
 }
 
 .language-trigger-code {
-  line-height: 20px;
+  font-variant-numeric: tabular-nums;
 }
 
 .language-trigger-label {
-  font-weight: 500;
-  font-size: var(--sb-font-sm, 15px);
-  letter-spacing: var(--sb-body-letter-spacing, 0.01em);
-  text-transform: none;
-  color: var(--text-muted, #8e97a3);
-}
-
-.language-trigger-label[data-visible="false"] {
   display: none;
 }
 
 .language-divider {
-  width: 1px;
-  height: 24px;
-  margin-block: 16px;
-  background: var(--divider-color, #2b3139);
-  opacity: 0.6;
-  border-radius: 1px;
+  width: var(--sb-divider-w, 1px);
+  align-self: stretch;
+  background: var(--sb-divider, rgb(255 255 255 / 10%));
+  border-radius: 999px;
+  margin-block: calc((var(--sb-h, 56px) - var(--seg-h, 44px)) / 2);
 }
 
 .language-arrow,
@@ -106,45 +108,40 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 16px;
-  color: var(--direction-icon, #a6b0bd);
-  transition:
-    opacity 0.15s ease,
-    transform 0.15s ease,
-    box-shadow 0.15s ease;
+  height: 100%;
+  padding-inline: var(--seg-arrow-gap, 12px);
+  border: none;
+  border-radius: calc(var(--seg-r, 22px) - 6px);
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
 }
 
 .language-arrow {
-  opacity: 0.72;
-  pointer-events: none;
+  cursor: default;
 }
 
 .language-swap {
-  border: none;
-  background: transparent;
   cursor: pointer;
-  opacity: 0.8;
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .language-swap:hover {
-  opacity: 1;
+  background: color-mix(in srgb, var(--sb-seg) 85%, white 15%);
 }
 
 .language-swap:focus-visible {
   outline: none;
-  box-shadow: var(--sb-ring, 0 0 0 6px rgb(120 160 255 / 6%));
+  box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
 }
 
 .language-swap:active {
   transform: scale(0.96);
-}
-
-.direction-icon {
-  width: 16px;
-  height: 16px;
-  color: inherit;
 }
 
 .core-input {
@@ -160,51 +157,51 @@
   margin: 0;
   border: none;
   background: transparent;
-  color: var(--text-primary, #e9edf3);
-  font-size: var(--sb-font, 16px);
-  font-weight: var(--sb-font-weight, 400);
-  line-height: 24px;
-  letter-spacing: var(--sb-body-letter-spacing, 0.01em);
+  color: var(--sb-text, #edeff2);
+  font-size: var(--ph-size, 16px);
+  font-weight: var(--ph-weight, 500);
+  line-height: 1.5;
+  letter-spacing: 0.01em;
   resize: none;
   outline: none;
-  caret-color: var(--sb-caret, #99a6b5);
+  caret-color: var(--sb-icon, #edeff2);
 }
 
 .textarea::placeholder {
-  color: var(--sb-placeholder, #8e97a3);
+  color: var(--sb-muted, #9fa7b3);
 }
 
-.actions {
+.voice-controls {
   display: inline-flex;
   align-items: center;
-  gap: var(--chip-gap, 8px);
+  gap: var(--btn-gap, 12px);
+  margin-inline-start: auto;
+  flex-shrink: 0;
 }
 
 .voice-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--sb-action-size, 40px);
-  height: var(--sb-action-size, 40px);
-  border-radius: calc(var(--sb-action-size, 40px) / 2);
-  border: 1px solid var(--sb-border, #2a313b);
-  background: var(--chip-bg, #252b33);
-  color: var(--menu-check-color, #d9dee7);
-  box-shadow: var(--sb-shadow-soft, 0 10px 24px rgb(0 0 0 / 14%));
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 999px;
+  background: var(--sb-cta, #fff);
+  color: var(--sb-cta-icon, #0e1116);
+  box-shadow: var(--sb-cta-shadow, 0 10px 30px rgb(0 0 0 / 30%));
   cursor: pointer;
   transition:
-    background-color 0.15s ease,
-    box-shadow 0.15s ease,
-    transform 0.15s ease;
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
 }
 
-.voice-button:hover,
+.voice-button:hover {
+  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
+}
+
 .voice-button:focus-visible {
-  background: var(--chip-bg-hover, #2b323c);
   outline: none;
   box-shadow:
-    var(--sb-ring, 0 0 0 6px rgb(120 160 255 / 6%)),
-    var(--sb-shadow-soft, 0 10px 24px rgb(0 0 0 / 14%));
+    var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%)),
+    var(--sb-cta-shadow, 0 10px 30px rgb(0 0 0 / 30%));
 }
 
 .voice-button:active {
@@ -217,10 +214,28 @@
   box-shadow: none;
 }
 
-.voice-icon {
-  width: var(--sb-icon-size, 18px);
-  height: var(--sb-icon-size, 18px);
+.voice-eq {
+  width: var(--btn-eq, 36px);
+  height: var(--btn-eq, 36px);
+}
+
+.voice-rec {
+  width: var(--btn-rec, 44px);
+  height: var(--btn-rec, 44px);
+}
+
+.equalizer-icon {
+  width: 18px;
+  height: 18px;
   display: block;
+}
+
+.voice-dot {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--sb-cta-icon, #0e1116);
 }
 
 .submit-proxy {
@@ -244,24 +259,24 @@
   flex-direction: column;
   gap: 4px;
   border-radius: var(--sb-menu-radius, 16px);
-  background: var(--menu-bg, #1f252c);
-  border: 1px solid var(--menu-border, #2a3038);
-  box-shadow: var(--sb-shadow, 0 10px 24px rgb(0 0 0 / 35%));
+  background: var(--menu-bg, #11161e);
+  border: 1px solid var(--menu-border, rgb(255 255 255 / 10%));
+  box-shadow: var(--sb-menu-shadow, 0 18px 44px rgb(0 0 0 / 45%));
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--menu-scroll-thumb, #2c3440)
     var(--menu-scroll-track, #1b2026);
   opacity: 0;
-  transform: scale(0.98);
+  transform: translateY(4px) scale(0.98);
   transform-origin: top center;
   transition:
-    opacity 0.15s ease,
-    transform 0.15s ease;
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .language-menu[data-open="true"] {
   opacity: 1;
-  transform: scale(1);
+  transform: translateY(0) scale(1);
 }
 
 .language-menu::-webkit-scrollbar {
@@ -311,12 +326,15 @@
 .language-menu-button:hover,
 .language-menu-button:focus-visible,
 .language-menu-button[data-active="true"] {
-  background: var(--menu-hover, #2b323c);
+  background: var(
+    --menu-hover,
+    color-mix(in srgb, var(--sb-inner) 88%, white 12%)
+  );
   outline: none;
 }
 
 .language-option-code {
-  color: var(--menu-code-color, #e4e9f2);
+  color: var(--menu-code-color, #f1f4f8);
   font-weight: 700;
   letter-spacing: var(--sb-code-letter-spacing, 0.08em);
   text-transform: uppercase;
@@ -341,4 +359,10 @@
 
 .language-menu-button[data-active="true"] .language-option-check {
   opacity: 1;
+}
+
+@media (width <= 360px) {
+  .voice-eq {
+    display: none;
+  }
 }

--- a/website/src/components/ui/ChatInput/LanguageControls.jsx
+++ b/website/src/components/ui/ChatInput/LanguageControls.jsx
@@ -2,50 +2,6 @@ import PropTypes from "prop-types";
 import LanguageMenu from "./parts/LanguageMenu.jsx";
 import styles from "./ChatInput.module.css";
 
-function DirectionIcon({ className }) {
-  return (
-    <svg
-      className={className}
-      width={16}
-      height={16}
-      viewBox="0 0 16 16"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-    >
-      <path
-        d="M5.25 4.5 2.5 7.25 5.25 10"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M10.75 4.5 13.5 7.25 10.75 10"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M2.75 7.25h10.5"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-DirectionIcon.propTypes = {
-  className: PropTypes.string,
-};
-
-DirectionIcon.defaultProps = {
-  className: undefined,
-};
-
 export default function LanguageControls({
   sourceLanguage,
   sourceLanguageOptions,
@@ -83,8 +39,16 @@ export default function LanguageControls({
       ? normalizeTargetLanguage
       : (value) => value;
 
+  const groupLabel =
+    [sourceLanguageLabel, targetLanguageLabel].filter(Boolean).join(" → ") ||
+    "language selection";
+
   return (
-    <div className={styles["language-controls"]}>
+    <div
+      className={styles["language-shell"]}
+      role="group"
+      aria-label={groupLabel}
+    >
       <LanguageMenu
         options={sourceLanguageOptions}
         value={sourceLanguage}
@@ -107,11 +71,11 @@ export default function LanguageControls({
           aria-label={swapLabel}
           title={swapLabel}
         >
-          <DirectionIcon className={styles["direction-icon"]} />
+          →
         </button>
       ) : (
         <span className={styles["language-arrow"]} aria-hidden="true">
-          <DirectionIcon className={styles["direction-icon"]} />
+          →
         </span>
       )}
       <LanguageMenu

--- a/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
@@ -2,12 +2,14 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import { jest } from "@jest/globals";
 import { useState } from "react";
 
-jest.mock("@/components/ui/Popover/Popover.jsx", () => ({
+await jest.unstable_mockModule("@/components/ui/Popover/Popover.jsx", () => ({
   __esModule: true,
   default: ({ isOpen, children }) => (isOpen ? <div>{children}</div> : null),
 }));
 
-import ActionInput from "@/components/ui/ChatInput/ActionInput.jsx";
+const { default: ActionInput } = await import(
+  "@/components/ui/ChatInput/ActionInput.jsx"
+);
 
 /**
  * 验证输入框在不同回车场景下的提交行为：
@@ -83,14 +85,14 @@ test("handles language selection and swapping", async () => {
   const sourceButton = screen.getByRole("button", { name: "源语言" });
   fireEvent.click(sourceButton);
   fireEvent.click(
-    await screen.findByRole("menuitemradio", { name: "英文词条" }),
+    await screen.findByRole("menuitemradio", { name: /英文词条/ }),
   );
   expect(handleSourceChange).toHaveBeenCalledWith("ENGLISH");
 
   const targetButton = screen.getByRole("button", { name: "目标语言" });
   fireEvent.click(targetButton);
   fireEvent.click(
-    await screen.findByRole("menuitemradio", { name: "中文释义" }),
+    await screen.findByRole("menuitemradio", { name: /中文释义/ }),
   );
   expect(handleTargetChange).toHaveBeenCalledWith("CHINESE");
 

--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -4,39 +4,36 @@
   align-items: center;
   width: 100%;
   min-height: var(--sb-h, 56px);
-  padding: var(--padding-y, 0) var(--padding-x, var(--sb-pad-x, 20px));
-  gap: var(--slot-gap, var(--sb-col-gap, 12px));
-  border-radius: var(--sb-radius, 24px);
-  border: 1px solid var(--sb-border, #2a313b);
-  background: var(--sb-bg, #1e2329);
-  box-shadow:
-    var(--sb-shadow, 0 10px 24px rgb(0 0 0 / 35%)),
-    inset 0 1px 0 var(--sb-inner-highlight, rgb(255 255 255 / 12%));
-  color: var(--sb-text, #e9edf3);
-  font-size: var(--sb-font, 16px);
+  padding-block: var(--padding-y, 0);
+  padding-inline: var(--sb-pad-x, 20px);
+  gap: var(--slot-gap, var(--sb-gap, 16px));
+  border-radius: var(--sb-r, 28px);
+  background: var(--sb-surface, #0e1116);
+  color: var(--sb-text, #edeff2);
+  outline: 1px solid var(--sb-stroke, rgb(255 255 255 / 6%));
+  box-shadow: var(--sb-shadow, 0 6px 20px rgb(0 0 0 / 25%));
   line-height: 1.5;
   box-sizing: border-box;
   transition:
-    background-color 0.15s ease,
-    border-color 0.15s ease,
-    box-shadow 0.15s ease,
-    color 0.15s ease;
+    background-color 0.2s ease,
+    outline-color 0.2s ease,
+    box-shadow 0.2s ease;
+  overflow: visible;
 }
 
 .search-box:hover {
-  border-color: var(--sb-border-active, #3a4452);
   background: var(
     --sb-bg-hover,
-    color-mix(in srgb, var(--sb-bg) 98%, white 2%)
+    color-mix(in srgb, var(--sb-surface) 94%, white 6%)
   );
+  outline-color: var(--sb-border-active, rgb(255 255 255 / 12%));
 }
 
 .search-box:focus-within {
-  border-color: var(--sb-border-active, #3a4452);
+  outline-color: var(--sb-border-active, rgb(255 255 255 / 12%));
   box-shadow:
-    var(--sb-ring, 0 0 0 6px rgb(120 160 255 / 6%)),
-    var(--sb-shadow, 0 10px 24px rgb(0 0 0 / 35%)),
-    inset 0 1px 0 var(--sb-inner-highlight, rgb(255 255 255 / 12%));
+    var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%)),
+    var(--sb-shadow, 0 6px 20px rgb(0 0 0 / 25%));
 }
 
 .search-box :global(button),
@@ -44,4 +41,16 @@
 .search-box :global(textarea) {
   font: inherit;
   color: inherit;
+}
+
+.search-box :global(button:focus-visible),
+.search-box :global(input:focus-visible),
+.search-box :global(textarea:focus-visible) {
+  outline: none;
+}
+
+@media (width <= 360px) {
+  .search-box {
+    padding-inline: var(--sb-pad-x-compact, 12px);
+  }
 }

--- a/website/src/components/ui/SearchBox/index.jsx
+++ b/website/src/components/ui/SearchBox/index.jsx
@@ -6,21 +6,52 @@ import styles from "./SearchBox.module.css";
  * 通过 CSS 变量 `--padding-y` 可灵活调整上下间距，
  * 默认情况下遵循 search bar 设计令牌定义的尺寸。
  */
-export default function SearchBox({ children, paddingY, className }) {
-  const style = paddingY ? { "--padding-y": paddingY } : undefined;
+export default function SearchBox({
+  children,
+  paddingY,
+  className,
+  style: styleProp,
+  role,
+  ...rest
+}) {
+  const inlineStyle = {
+    ...(paddingY ? { "--padding-y": paddingY } : {}),
+    ...(styleProp || {}),
+  };
   const classNames = [styles["search-box"], className]
     .filter(Boolean)
     .join(" ");
 
-  return (
-    <div className={classNames} style={style}>
-      {children}
-    </div>
-  );
+  const resolvedRole = role ?? "search";
+  const resolvedAriaLabel =
+    rest["aria-label"] ?? rest.ariaLabel ?? "dictionary search";
+  const resolvedTestId = rest["data-testid"] ?? "searchbar";
+
+  const finalProps = {
+    ...rest,
+    role: resolvedRole,
+    "aria-label": resolvedAriaLabel,
+    "data-testid": resolvedTestId,
+    className: classNames,
+    style: inlineStyle,
+  };
+
+  delete finalProps.ariaLabel;
+
+  return <div {...finalProps}>{children}</div>;
 }
 
 SearchBox.propTypes = {
   children: PropTypes.node.isRequired,
   paddingY: PropTypes.string,
   className: PropTypes.string,
+  style: PropTypes.object,
+  role: PropTypes.string,
+};
+
+SearchBox.defaultProps = {
+  paddingY: undefined,
+  className: undefined,
+  style: undefined,
+  role: undefined,
 };

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -44,29 +44,38 @@
   --item-weight: 400;
 
   /* search bar tokens */
+  --sb-surface: #0e1116;
+  --sb-inner: #11161e;
+  --sb-seg: #141b24;
+  --sb-stroke: rgb(255 255 255 / 6%);
+  --sb-divider: rgb(255 255 255 / 10%);
+  --sb-text: #edeff2;
+  --sb-muted: #9fa7b3;
+  --sb-icon: #edeff2;
+  --sb-cta: #fff;
+  --sb-cta-icon: #0e1116;
   --sb-h: 56px;
-  --sb-radius: 24px;
+  --sb-r: 28px;
+  --sb-radius: var(--sb-r);
   --sb-pad-x: 20px;
-  --sb-border: #2a313b;
-  --sb-border-active: #3a4452;
-  --sb-bg: #1e2329;
-  --sb-bg-hover: color-mix(in srgb, var(--sb-bg) 98%, white 2%);
-  --sb-panel: #1f252c;
-  --sb-panel-strong: #252b33;
+  --sb-pad-x-compact: 12px;
+  --sb-gap: 16px;
+  --sb-divider-w: 1px;
+  --sb-border: var(--sb-stroke);
+  --sb-border-active: color-mix(in srgb, var(--sb-stroke) 60%, white 40%);
+  --sb-bg: var(--sb-surface);
+  --sb-bg-hover: color-mix(in srgb, var(--sb-surface) 94%, white 6%);
+  --sb-panel: var(--sb-inner);
+  --sb-panel-strong: color-mix(in srgb, var(--sb-inner) 88%, black 12%);
   --sb-inner-highlight: rgb(255 255 255 / 12%);
-  --sb-text: #e9edf3;
-  --sb-muted: #8e97a3;
-  --sb-placeholder: #8e97a3;
-  --sb-ring: 0 0 0 6px rgb(120 160 255 / 6%);
-  --sb-shadow: 0 10px 24px rgb(0 0 0 / 35%);
-  --sb-shadow-soft: 0 10px 24px rgb(0 0 0 / 14%);
-  --sb-menu-shadow: 0 20px 56px rgb(0 0 0 / 45%);
-  --sb-gap: 8px;
-  --sb-col-gap: 12px;
+  --sb-ring: 0 0 0 2px rgb(255 255 255 / 8%);
+  --sb-shadow: 0 6px 20px rgb(0 0 0 / 25%);
+  --sb-shadow-soft: 0 4px 16px rgb(0 0 0 / 22%);
+  --sb-menu-shadow: 0 18px 44px rgb(0 0 0 / 45%);
   --sb-font: 16px;
   --sb-font-sm: 15px;
   --sb-font-strong: 600;
-  --sb-font-weight: 400;
+  --sb-font-weight: 500;
   --sb-body-letter-spacing: 0.01em;
   --sb-code-letter-spacing: 0.08em;
   --sb-code-min-width: 64px;
@@ -86,32 +95,42 @@
   --chip-bg: #252b33;
   --chip-bg-hover: #2b323c;
   --chip-text: #d5dbe6;
-  --divider-color: #2b3139;
-  --menu-bg: #1f252c;
-  --menu-border: #2a3038;
-  --menu-hover: #2b323c;
-  --menu-code-color: #e4e9f2;
+  --divider-color: var(--sb-divider);
+  --menu-bg: var(--sb-inner);
+  --menu-border: color-mix(in srgb, var(--sb-stroke) 80%, black 20%);
+  --menu-hover: color-mix(in srgb, var(--sb-inner) 88%, white 12%);
+  --menu-code-color: #f1f4f8;
   --menu-name-color: #c6ccd7;
   --menu-check-color: #d9dee7;
-  --menu-scroll-track: #1b2026;
-  --menu-scroll-thumb: #2c3440;
-  --menu-scroll-thumb-hover: #354050;
-  --direction-icon: #a6b0bd;
+  --menu-scroll-track: color-mix(in srgb, var(--sb-inner) 70%, transparent);
+  --menu-scroll-thumb: color-mix(in srgb, var(--sb-inner) 20%, white 12%);
+  --menu-scroll-thumb-hover: color-mix(
+    in srgb,
+    var(--menu-scroll-thumb) 70%,
+    white 30%
+  );
+  --direction-icon: #b8c2cf;
   --text-primary: var(--sb-text);
   --text-muted: var(--sb-muted);
-  --sb-scroll-track: color-mix(
-    in srgb,
-    var(--color-border-strong) 35%,
-    transparent
-  );
-  --sb-scroll-thumb: color-mix(
-    in srgb,
-    var(--color-border-strong) 65%,
-    transparent
-  );
+  --sb-scroll-track: color-mix(in srgb, var(--sb-inner) 35%, transparent);
+  --sb-scroll-thumb: color-mix(in srgb, var(--sb-inner) 65%, transparent);
   --sb-send-bg: rgb(255 255 255 / 92%);
   --sb-send-color: #0b0d11;
   --sb-ring-width: 2px;
+  --seg-h: 44px;
+  --seg-r: 22px;
+  --seg-pad-x: 20px;
+  --seg-arrow-gap: 12px;
+  --seg-font-size: 14px;
+  --seg-font-weight: 600;
+  --seg-letter-space: 0.04em;
+  --ph-size: 16px;
+  --ph-weight: 500;
+  --btn-eq: 36px;
+  --btn-rec: 44px;
+  --btn-gap: 12px;
+  --ring-focus: 0 0 0 2px rgb(255 255 255 / 8%);
+  --sb-cta-shadow: 0 10px 30px rgb(0 0 0 / 30%);
 
   /* settings dialog */
   --settings-dialog-width-md: 640px;


### PR DESCRIPTION
## Summary
- introduce dedicated dark-mode dictionary search bar design tokens for shared use
- refactor the SearchBox shell and ChatInput UI to the three-column layout with segmented language switch and updated voice controls
- align unit tests with the new accessibility contract and ESM mocking approach

## Testing
- `npx eslint --fix .`
- `npx stylelint "src/**/*.css" --fix`
- `npx prettier -w src/components/ui/ChatInput/ActionInput.jsx src/components/ui/ChatInput/LanguageControls.jsx src/components/ui/SearchBox/index.jsx src/components/ui/SearchBox/SearchBox.module.css src/components/__tests__/SearchBox.test.jsx src/theme/variables.css src/components/ui/ChatInput/ChatInput.module.css`
- `npm run test -- --runTestsByPath src/components/__tests__/SearchBox.test.jsx src/components/ui/ChatInput/__tests__/ActionInput.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68d99b9339fc8332b70daea838cb15f1