### PR TITLE
Reset error boundary on navigation

### DIFF
--- a/website/src/components/providers/AppProviders/index.jsx
+++ b/website/src/components/providers/AppProviders/index.jsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { useLocation } from "react-router-dom";
 import PropTypes from "prop-types";
 import ErrorBoundary from "@/components/ui/ErrorBoundary";
 import Loader from "@/components/ui/Loader";
@@ -12,6 +13,8 @@ import {
 } from "@/context";
 
 function AppProviders({ children }) {
+  const location = useLocation();
+
   return (
     <AppProvider>
       <ApiProvider>
@@ -19,7 +22,7 @@ function AppProviders({ children }) {
           <ThemeProvider>
             <CookieConsent />
             <AuthWatcher />
-            <ErrorBoundary>
+            <ErrorBoundary resetKeys={[location.key]}>
               <Suspense fallback={<Loader />}>{children}</Suspense>
             </ErrorBoundary>
           </ThemeProvider>

--- a/website/src/components/ui/ErrorBoundary/ErrorBoundary.jsx
+++ b/website/src/components/ui/ErrorBoundary/ErrorBoundary.jsx
@@ -1,16 +1,55 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import styles from "./ErrorBoundary.module.css";
+
+function areResetKeysEqual(prevKeys = [], nextKeys = []) {
+  if (prevKeys === nextKeys) return true;
+  if (!Array.isArray(prevKeys) || !Array.isArray(nextKeys)) {
+    return false;
+  }
+  if (prevKeys.length !== nextKeys.length) {
+    return false;
+  }
+
+  return prevKeys.every((key, index) => Object.is(key, nextKeys[index]));
+}
 
 class ErrorBoundary extends Component {
   constructor(props) {
     super(props);
     this.state = { hasError: false };
+    this.resetErrorBoundary = this.resetErrorBoundary.bind(this);
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
   }
 
   componentDidCatch(error, info) {
-    // report the error and update state
+    const { onError } = this.props;
     console.error("ErrorBoundary caught an error", error, info);
-    this.setState({ hasError: true });
+    if (onError) {
+      onError(error, info);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { resetKeys } = this.props;
+    if (
+      this.state.hasError &&
+      !areResetKeysEqual(prevProps.resetKeys, resetKeys)
+    ) {
+      this.resetErrorBoundary();
+    }
+  }
+
+  resetErrorBoundary() {
+    if (!this.state.hasError) return;
+    this.setState({ hasError: false });
+    const { onReset } = this.props;
+    if (onReset) {
+      onReset();
+    }
   }
 
   render() {
@@ -26,5 +65,20 @@ class ErrorBoundary extends Component {
     return children;
   }
 }
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+  fallback: PropTypes.node,
+  resetKeys: PropTypes.arrayOf(PropTypes.any),
+  onReset: PropTypes.func,
+  onError: PropTypes.func,
+};
+
+ErrorBoundary.defaultProps = {
+  fallback: null,
+  resetKeys: undefined,
+  onReset: undefined,
+  onError: undefined,
+};
 
 export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- enhance the shared ErrorBoundary with reset key support and prop validations so it can recover cleanly after errors
- reset the boundary whenever the current location changes by wiring the router location key through AppProviders

## Testing
- npx eslint . --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/ui/ErrorBoundary/ErrorBoundary.jsx src/components/providers/AppProviders/index.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9e8ff4d5083329540d0751025834a