### PR TITLE
Fix sidebar user menu crash after login

### DIFF
--- a/website/src/components/Sidebar/NavItem.jsx
+++ b/website/src/components/Sidebar/NavItem.jsx
@@ -30,7 +30,7 @@ const NavItem = forwardRef(function NavItem(
     tone = "default",
     onClick,
     type = "button",
-    children,
+    children = null,
     ...rest
   },
   ref,
@@ -123,19 +123,6 @@ NavItem.propTypes = {
   type: PropTypes.oneOf(["button", "submit", "reset"]),
   children: PropTypes.node,
   tone: PropTypes.oneOf(["default", "muted"]),
-};
-
-NavItem.defaultProps = {
-  icon: undefined,
-  description: undefined,
-  active: false,
-  to: undefined,
-  href: undefined,
-  className: undefined,
-  onClick: undefined,
-  type: "button",
-  children: null,
-  tone: "default",
 };
 
 export default NavItem;

--- a/website/src/components/Sidebar/Sidebar.jsx
+++ b/website/src/components/Sidebar/Sidebar.jsx
@@ -130,14 +130,4 @@ Sidebar.propTypes = {
   onSelectHistory: PropTypes.func,
 };
 
-Sidebar.defaultProps = {
-  isMobile: undefined,
-  open: false,
-  onClose: undefined,
-  onShowDictionary: undefined,
-  onShowFavorites: undefined,
-  activeView: undefined,
-  onSelectHistory: undefined,
-};
-
 export default forwardRef(Sidebar);

--- a/website/src/components/Sidebar/UserMenu/UserMenu.tsx
+++ b/website/src/components/Sidebar/UserMenu/UserMenu.tsx
@@ -338,6 +338,11 @@ function UserMenu({
     }, SUBMENU_DELAY_OUT);
   }, [cancelScheduledClose, closeSubmenu]);
 
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+    closeSubmenu();
+  }, [closeSubmenu]);
+
   const handleToggle = useCallback(() => {
     if (open) {
       closeMenu();
@@ -346,11 +351,6 @@ function UserMenu({
     setActiveIndex(computeDefaultIndex());
     setOpen(true);
   }, [closeMenu, computeDefaultIndex, open]);
-
-  const closeMenu = useCallback(() => {
-    setOpen(false);
-    closeSubmenu();
-  }, [closeSubmenu]);
 
   const previousOpenRef = useRef(open);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove defaultProps from forwardRef-based sidebar elements to satisfy React 19 runtime expectations
- ensure the user menu closes safely by initializing the close handler before it is referenced, preventing post-login crashes

## Testing
- npm test -- --runTestsByPath src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9fbe56eec83329cc5892f5f01e7b5