### PR TITLE
Support monolingual Chinese dictionary output

### DIFF
--- a/backend/src/main/java/com/glancy/backend/entity/DictionaryFlavor.java
+++ b/backend/src/main/java/com/glancy/backend/entity/DictionaryFlavor.java
@@ -12,7 +12,12 @@ public enum DictionaryFlavor {
     /**
      * Monolingual English presentation without any translated content.
      */
-    MONOLINGUAL_ENGLISH;
+    MONOLINGUAL_ENGLISH,
+
+    /**
+     * Monolingual Chinese presentation designed for native-language explanations.
+     */
+    MONOLINGUAL_CHINESE;
 
     public static DictionaryFlavor fromNullable(String raw, DictionaryFlavor fallback) {
         if (raw == null || raw.isBlank()) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -61,6 +61,8 @@ llm:
   prompt-flavor-paths:
     ENGLISH:
       MONOLINGUAL_ENGLISH: prompts/english_to_english.txt
+    CHINESE:
+      MONOLINGUAL_CHINESE: prompts/chinese_to_chinese.txt
 
 thirdparty:
   doubao:

--- a/website/src/utils/__tests__/language.test.js
+++ b/website/src/utils/__tests__/language.test.js
@@ -8,6 +8,7 @@ import {
   WORD_LANGUAGE_AUTO,
   WORD_FLAVOR_BILINGUAL,
   WORD_FLAVOR_MONOLINGUAL_ENGLISH,
+  WORD_FLAVOR_MONOLINGUAL_CHINESE,
 } from "@/utils/language.js";
 
 describe("language utilities", () => {
@@ -59,6 +60,13 @@ describe("language utilities", () => {
       resolveDictionaryConfig("优雅", {
         sourceLanguage: WORD_LANGUAGE_AUTO,
         targetLanguage: "CHINESE",
+      }),
+    ).toEqual({ language: "CHINESE", flavor: WORD_FLAVOR_MONOLINGUAL_CHINESE });
+
+    expect(
+      resolveDictionaryConfig("优雅", {
+        sourceLanguage: "CHINESE",
+        targetLanguage: "ENGLISH",
       }),
     ).toEqual({ language: "CHINESE", flavor: WORD_FLAVOR_BILINGUAL });
   });

--- a/website/src/utils/index.js
+++ b/website/src/utils/index.js
@@ -13,6 +13,7 @@ export {
   resolveWordFlavor,
   WORD_FLAVOR_BILINGUAL,
   WORD_FLAVOR_MONOLINGUAL_ENGLISH,
+  WORD_FLAVOR_MONOLINGUAL_CHINESE,
   normalizeWordSourceLanguage,
   normalizeWordTargetLanguage,
   resolveDictionaryConfig,

--- a/website/src/utils/language.js
+++ b/website/src/utils/language.js
@@ -2,6 +2,7 @@ export const WORD_LANGUAGE_AUTO = "AUTO";
 export const WORD_LANGUAGE_ENGLISH_MONO = "ENGLISH_MONOLINGUAL";
 export const WORD_FLAVOR_BILINGUAL = "BILINGUAL";
 export const WORD_FLAVOR_MONOLINGUAL_ENGLISH = "MONOLINGUAL_ENGLISH";
+export const WORD_FLAVOR_MONOLINGUAL_CHINESE = "MONOLINGUAL_CHINESE";
 
 const LANGUAGE_BADGES = Object.freeze({
   AUTO: "AUTO",
@@ -140,6 +141,9 @@ export function resolveDictionaryFlavor({
 
   if (normalizedSource === "ENGLISH" && normalizedTarget === "ENGLISH") {
     return WORD_FLAVOR_MONOLINGUAL_ENGLISH;
+  }
+  if (normalizedSource === "CHINESE" && normalizedTarget === "CHINESE") {
+    return WORD_FLAVOR_MONOLINGUAL_CHINESE;
   }
   return WORD_FLAVOR_BILINGUAL;
 }


### PR DESCRIPTION
## Summary
- add a dedicated monolingual Chinese dictionary flavor and map it to the correct prompt
- update WordSearcher message composition so prompts and persona guidance honor the requested flavor
- expose the new flavor through the frontend language utilities and refresh the associated tests

## Testing
- npm run test -- --runTestsByPath src/utils/__tests__/language.test.js


------
https://chatgpt.com/codex/tasks/task_e_68daa07dd16c8332b640a8956b17d4f2