### PR TITLE
Add robust cleanup for dictionary lookup controller

### DIFF
--- a/website/src/features/dictionary-experience/hooks/useDictionaryLookupController.ts
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryLookupController.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useDictionaryLookupController() {
+  const abortRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+
+  const cancelActiveLookup = useCallback(() => {
+    if (!abortRef.current) {
+      return;
+    }
+    abortRef.current.abort();
+    abortRef.current = null;
+  }, []);
+
+  const clearActiveLookup = useCallback(() => {
+    abortRef.current = null;
+  }, []);
+
+  const beginLookup = useCallback(() => {
+    cancelActiveLookup();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    return controller;
+  }, [cancelActiveLookup]);
+
+  const isMounted = useCallback(() => isMountedRef.current, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      cancelActiveLookup();
+    };
+  }, [cancelActiveLookup]);
+
+  return {
+    beginLookup,
+    cancelActiveLookup,
+    clearActiveLookup,
+    isMounted,
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated useDictionaryLookupController hook to centralize abort lifecycle handling
- refactor dictionary experience lookup flows to use the shared cancellation helpers and guard state updates after unmount
- extend the dictionary experience hook test suite to cover component unmount cleanup behaviour

## Testing
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npx jest src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68daab635de08332a59b8a7009b6a56d