### PR TITLE
Handle SSE streaming errors via global exception flow

### DIFF
--- a/backend/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/backend/src/main/java/com/glancy/backend/controller/WordController.java
@@ -77,6 +77,7 @@ public class WordController {
                     payload.data()
                 )
             )
+            .doOnError(error -> log.error("Controller streaming error for user {} term '{}'", userId, term, error))
             .map(payload -> {
                 ServerSentEvent.Builder<String> builder = ServerSentEvent.builder(payload.data());
                 if (payload.event() != null) {
@@ -85,10 +86,6 @@ public class WordController {
                 return builder.build();
             })
             .doOnCancel(() -> log.info("Streaming canceled for user {} term '{}'", userId, term))
-            .onErrorResume(e -> {
-                log.error("Streaming error for user {} term '{}'", userId, term, e);
-                return Flux.just(ServerSentEvent.<String>builder(e.getMessage()).event("error").build());
-            })
             .doFinally(sig -> log.info("Streaming finished with signal {} for user {} term '{}'", sig, userId, term));
     }
 }


### PR DESCRIPTION
## Summary
- adjust `WordService.streamWordForUser` to propagate `BusinessException` instances while wrapping and logging unexpected system failures
- update `WordController` streaming endpoint to rely on global error handling with explicit logging hooks
- add MVC and Spring Boot integration tests covering SSE error propagation for invalid requests and system failures

## Testing
- mvn test -Dtest=WordControllerStreamingTest,WordControllerStreamTest

------
https://chatgpt.com/codex/tasks/task_e_68daacb231f083328667a7fc51aea964