### PR TITLE
Refine English monolingual prompt structure

### DIFF
--- a/backend/src/main/resources/prompts/english_to_english.txt
+++ b/backend/src/main/resources/prompts/english_to_english.txt
@@ -7,6 +7,7 @@ Output must be pure Markdown（no tables, no code blocks, no trailing commentary
 - max_examples_per_sense: {max_examples_per_sense=3}    # maximum examples per sense
 - max_senses: {max_senses=10}                           # maximum number of senses to surface
 - max_collocations: {max_collocations=8}
+- max_phrases: {max_phrases=8}
 - max_idioms: {max_idioms=8}
 - max_patterns: {max_patterns=6}
 - max_derivatives: {max_derivatives=6}
@@ -20,7 +21,7 @@ Output must be pure Markdown（no tables, no code blocks, no trailing commentary
 4) Enumerate senses with identifiers `s1`, `s2`, … up to `max_senses`. Each sense must carry part-of-speech metadata, register, nuance, and curated examples.
 5) Deliver between `min_examples_per_sense` and `max_examples_per_sense` original sentences per sense. No cross-section reuse of examples.
 6) Examples should be polished, context-rich, and accompanied by succinct usage insights explaining tone, collocation, or pragmatic cues.
-7) Collocations, idioms, patterns, derivatives, usage notes, confusable pairs, and domain usages must cite their originating sense via `[ref: s#]` markers when linkable.
+7) Collocations, set phrases, idioms, patterns, derivatives, usage notes, confusable pairs, and domain usages must cite their originating sense via `[ref: s#]` markers when linkable.
 8) Maintain editorial consistency with premium British and American lexicographic standards (Oxford/Cambridge register naming, APA-style punctuation, etc.).
 9) When data is uncertain, omit the section entirely instead of inserting placeholders like “N/A”.
 10) Close the entry with `<END>` as the final line, with no trailing spaces or blank lines after it.
@@ -28,18 +29,21 @@ Output must be pure Markdown（no tables, no code blocks, no trailing commentary
 ## Output Layout（sections follow this order; skip gracefully if empty）
 # Entry: {term}
 
-## Entry Classification
-- Type: {"Single Word" | "Multi-word Expression" | "Proper Noun"}
-- Register Tier: {CEFR or comparable proficiency indicator, if known}
-- Frequency Band: {e.g., "high-frequency", "academic core"}
-
 ## Pronunciation
 - British: /ˈ.../
 - American: /ˈ.../
 - Audio Notes: {availability of authoritative recordings, if notable}
 
-## Core Definition Overview
-- One-sentence distillation capturing essence, tone, and prototypical usage.
+## Frequency & Proficiency
+- Frequency Band: {e.g., "high-frequency", "academic core"}
+- Proficiency Benchmark: {CEFR or comparable proficiency indicator, if known}
+
+## Lexicographic Notes
+- Entry Type: {"Single Word" | "Multi-word Expression" | "Proper Noun"}
+- Register Labels: {formal / informal / colloquial / literary / technical / etc.}
+- Regional Variation: {British / American / cross-dialectal / other, omit if uncertain}
+- Spelling or Capitalization Variants: {colour vs. color, acronyms, etc., omit if none}
+- Proper Noun Handling: {guidance on transliteration, casing, or article usage where relevant}
 
 ## Senses
 ### s# Definition ({part_of_speech_abbr}. {part_of_speech_full}): {premium definition}
@@ -52,13 +56,30 @@ Output must be pure Markdown（no tables, no code blocks, no trailing commentary
   - **Example 2**: … （ensure example count satisfies min/max constraints）
 - **Extended Notes**: {optional micro-annotations, e.g., contrastive cues, morphological hints}
 
+## Core Definition Overview
+- One-sentence distillation capturing essence, tone, and prototypical usage.
+
+## Cultural or Intertextual Resonance
+- {literary, cultural, or idiomatic allusions worth highlighting}
+
+## Practice Prompts
+- {exercise 1 encouraging production or discrimination}
+- {exercise 2 with specific scenario}
+
 ## Collocations（≤ max_collocations）
 - {collocation}: {concise explanation}  [ref: s#]
 
-## Set Phrases & Idioms（≤ max_idioms）
-- {phrase or idiom}: {definition / usage cue}  [ref: s#]
+## Set Phrases（≤ max_phrases）
+- {set phrase}: {definition / usage cue}  [ref: s#]
   - **Example**: {English sentence}
     **Usage Insight**: {brief commentary}
+- _Monolingual Note_: Preserve nuanced pragmatic cues distinctive to idiomatic sentence frames when curating set phrases.
+
+## Idioms（≤ max_idioms）
+- {idiom}: {definition / usage cue}  [ref: s#]
+  - **Example**: {English sentence}
+    **Usage Insight**: {brief commentary}
+- _Monolingual Note_: Highlight imagery or metaphorical triggers that guide native-speaker interpretation.
 
 ## Grammar & Patterns（≤ max_patterns）
 - {pattern schema}: {guidance on syntax, valency, or complementation}  [ref: s#]
@@ -68,9 +89,11 @@ Output must be pure Markdown（no tables, no code blocks, no trailing commentary
 ## Morphology & Derivatives（≤ max_derivatives）
 - {derivative}: {part of speech + definition + stylistic remark}  [ref: s#]
 
-## Synonyms & Antonyms
-- Synonyms: {synonym1}, {synonym2}, …  [ref: s#]
-- Antonyms: {antonym1}, {antonym2}, …  [ref: s#]
+## Synonyms
+- {synonym1}, {synonym2}, …  [ref: s#]
+
+## Antonyms
+- {antonym1}, {antonym2}, …  [ref: s#]
 
 ## Usage Notes
 - {high-precision guidance on pitfalls, register conflicts, or collocational discipline}  [ref: s#]
@@ -86,12 +109,5 @@ Output must be pure Markdown（no tables, no code blocks, no trailing commentary
 
 ## Historical & Etymological Notes
 - {succinct etymology tracing + notable semantic shifts}
-
-## Cultural or Intertextual Resonance
-- {literary, cultural, or idiomatic allusions worth highlighting}
-
-## Practice Prompts
-- {exercise 1 encouraging production or discrimination}
-- {exercise 2 with specific scenario}
 
 <END>


### PR DESCRIPTION
## Summary
- align the English-to-English prompt ordering with the bilingual template by reordering pronunciation, frequency, lexical notes, senses, and moving monolingual extensions afterward
- split combined sections into dedicated Set Phrases, Idioms, Synonyms, and Antonyms blocks while preserving [ref: s#] guidance and adding monolingual notes
- extend configuration parameters and guidance to keep instructions consistent with the updated layout

## Testing
- mvn spotless:apply

------
https://chatgpt.com/codex/tasks/task_e_68dab5dc484483329954aec1fb5f1230