### PR TITLE
Fix stylelint import order in global CSS entrypoint

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1,20 +1,17 @@
 /*
  * 背景：
- *  - 引入 Tailwind 后需要统一入口承载基础指令与语义 token。
+ *  - Tailwind 指令与设计 token 原先混杂在同一文件，导致 @import 顺序不符合规范。
  * 目的：
- *  - 通过单一入口串联 palette/roles/components/utilities，并兼容 legacy 样式。
+ *  - 通过显式聚合入口维护全局样式装配顺序，并消除 stylelint 对 @import 位置的告警。
  * 关键决策与取舍：
- *  - 先执行 Tailwind 层，再按 tokens → 组件 → 工具顺序导入，最后保留旧全局样式；
- *  - 使用相对路径指向 src/styles，方便 Vite 与 Jest 解析。
+ *  - 拆分 Tailwind 指令至独立 tailwind.css，再以 @import 顺序表达依赖链，避免禁用规则的权宜之计；
+ *  - 保持 tokens → 组件 → 工具 → legacy 的加载节奏，兼容既有样式的演进计划。
  * 影响范围：
- *  - 全局样式初始化流程以及所有页面的样式注入顺序。
+ *  - 全局样式初始化流程以及任何依赖 index.css 的页面入口。
  * 演进与TODO：
- *  - 后续逐步拆解 legacy 样式至 Tailwind 或 tokens 体系，减少冗余规则。
+ *  - 后续可将 legacy 样式逐步迁移至分层 tokens/组件中，进一步减少跨文件耦合。
  */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
+@import url("./tailwind.css");
 @import url("./styles/tokens/palette.css");
 @import url("./styles/tokens/roles.css");
 @import url("./styles/components/button.css");

--- a/website/src/tailwind.css
+++ b/website/src/tailwind.css
@@ -1,0 +1,16 @@
+/**
+ * 背景：
+ *  - 需要在不违反 CSS @import 规范的前提下保留 Tailwind 指令的优先加载顺序。
+ * 目的：
+ *  - 以独立文件承载 Tailwind 层定义，便于 index.css 作为聚合器显式控制导入顺序。
+ * 关键决策与取舍：
+ *  - 采用单一入口文件暴露 Tailwind 指令，避免在多个文件中重复声明；
+ *  - 未引入额外构建插件或禁用 lint 规则，降低后续维护成本。
+ * 影响范围：
+ *  - 所有依赖 Tailwind 生成的基础、组件与工具类样式的前端页面。
+ * 演进与TODO：
+ *  - 未来如需扩展 Tailwind 层，可在此处引入自定义 layer，保持聚合点的一致性。
+ */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- move Tailwind directives into a dedicated `tailwind.css` file to preserve load order without violating CSS import rules
- refactor `index.css` into a pure aggregator that imports Tailwind, tokens, components, utilities, and legacy styles in sequence

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68db67df4c3c83329bdd347b12364bb6