### PR TITLE
Rename library navigation labels

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -94,7 +94,7 @@ export default {
   searchButton: "Search",
   primaryNavDictionaryLabel: "Glancy Dictionary",
   primaryNavDictionaryDescription: "Immersive lexical intelligence",
-  primaryNavLibraryLabel: "Gomemo",
+  primaryNavLibraryLabel: "Goyoo",
   primaryNavLibraryDescription: "Your private word atelier",
   primaryNavEntriesLabel: "Entries",
   termLabel: "Term",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -87,7 +87,7 @@ export default {
   searchButton: "搜索",
   primaryNavDictionaryLabel: "格律词典",
   primaryNavDictionaryDescription: "沉浸式灵感解读",
-  primaryNavLibraryLabel: "致知单词",
+  primaryNavLibraryLabel: "致用单词",
   primaryNavLibraryDescription: "私享收藏集",
   primaryNavEntriesLabel: "词条",
   termLabel: "词条",


### PR DESCRIPTION
## Summary
- rename the Chinese primary navigation library label to 致用单词
- update the English primary navigation library label to Goyoo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db67b21ff88332b21e1cd43c3a0464