### PR TITLE
fix: remove pnpm dependency from prebuild script

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "prebuild": "pnpm run icons:mono && pnpm run generate:icons",
+    "prebuild": "npm run icons:mono && npm run generate:icons",
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:icons": "node scripts/generate-icon-manifest.mjs",


### PR DESCRIPTION
## Summary
- update the website prebuild script to call npm instead of pnpm so builds succeed without pnpm installed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db697d2a948332b12ea50d63e39b8d