### PR TITLE
feat: improve language menu popover placement

### DIFF
--- a/website/src/components/ui/ChatInput/parts/LanguageMenu.jsx
+++ b/website/src/components/ui/ChatInput/parts/LanguageMenu.jsx
@@ -205,9 +205,11 @@ export default function LanguageMenu({
         isOpen={open}
         anchorRef={triggerRef}
         onClose={() => setOpen(false)}
-        placement="bottom"
+        placement="top"
         align="start"
-        offset={8}
+        fallbackPlacements={["bottom"]}
+        offset={12}
+        // 优先将菜单展示在按钮上方；当顶部空间不足时自动回退至下方。
       >
         {open ? (
           <ul

--- a/website/src/components/ui/Popover/Popover.jsx
+++ b/website/src/components/ui/Popover/Popover.jsx
@@ -1,3 +1,16 @@
+/**
+ * 背景：
+ *  - 语言切换等场景需要浮层在不同视窗高度下自如翻转，现有实现仅支持单一方向。
+ * 目的：
+ *  - 在 Popover 内部提供可扩展的定位策略，便于统一管理候选方向与间距计算。
+ * 关键决策与取舍：
+ *  - 采用策略映射（Strategy Pattern）封装不同方向的计算，避免调用方各自判断；
+ *  - 优先在主轴空间不足时才尝试备用方向，以减小性能开销。
+ * 影响范围：
+ *  - 所有 Popover 调用方；新增 data-placement 便于调试与测试验证。
+ * 演进与TODO：
+ *  - 后续可扩展更多策略（如自动宽度自适应）并开放配置化入口。
+ */
 import { createPortal } from "react-dom";
 import {
   useCallback,
@@ -22,6 +35,68 @@ function clamp(value, min, max) {
   return value;
 }
 
+const PLACEMENT_CONFIG = {
+  top: {
+    axis: "vertical",
+    compute(anchorRect, popRect, offset) {
+      return {
+        top: anchorRect.top - popRect.height - offset,
+        left: anchorRect.left,
+      };
+    },
+    fits({ top }, popRect) {
+      if (typeof window === "undefined") return true;
+      const bottom = top + popRect.height;
+      return (
+        top >= VIEWPORT_MARGIN &&
+        bottom <= window.innerHeight - VIEWPORT_MARGIN
+      );
+    },
+  },
+  bottom: {
+    axis: "vertical",
+    compute(anchorRect, popRect, offset) {
+      return {
+        top: anchorRect.bottom + offset,
+        left: anchorRect.left,
+      };
+    },
+    fits({ top }, popRect) {
+      if (typeof window === "undefined") return true;
+      const bottom = top + popRect.height;
+      return bottom <= window.innerHeight - VIEWPORT_MARGIN;
+    },
+  },
+  left: {
+    axis: "horizontal",
+    compute(anchorRect, popRect, offset) {
+      return {
+        top: anchorRect.top,
+        left: anchorRect.left - popRect.width - offset,
+      };
+    },
+    fits({ left }, popRect) {
+      if (typeof window === "undefined") return true;
+      const right = left + popRect.width;
+      return left >= VIEWPORT_MARGIN && right <= window.innerWidth - VIEWPORT_MARGIN;
+    },
+  },
+  right: {
+    axis: "horizontal",
+    compute(anchorRect, popRect, offset) {
+      return {
+        top: anchorRect.top,
+        left: anchorRect.right + offset,
+      };
+    },
+    fits({ left }, popRect) {
+      if (typeof window === "undefined") return true;
+      const right = left + popRect.width;
+      return right <= window.innerWidth - VIEWPORT_MARGIN;
+    },
+  },
+};
+
 function Popover({
   anchorRef,
   isOpen,
@@ -30,6 +105,7 @@ function Popover({
   placement = "bottom",
   align = "start",
   offset = 8,
+  fallbackPlacements = [],
   className,
   style,
 }) {
@@ -37,6 +113,7 @@ function Popover({
   const frameRef = useRef(null);
   const [position, setPosition] = useState({ top: 0, left: 0 });
   const [visible, setVisible] = useState(false);
+  const [activePlacement, setActivePlacement] = useState(placement);
 
   const setContentNode = useCallback((node) => {
     contentRef.current = node;
@@ -59,32 +136,43 @@ function Popover({
     const anchorRect = anchorEl.getBoundingClientRect();
     const popRect = popoverEl.getBoundingClientRect();
 
-    let top;
-    let left;
+    const candidatePlacements = [placement, ...fallbackPlacements];
 
-    switch (placement) {
-      case "top":
-        top = anchorRect.top - popRect.height - offset;
-        left = anchorRect.left;
+    let resolution = null;
+
+    for (const candidate of candidatePlacements) {
+      const config = PLACEMENT_CONFIG[candidate];
+      if (!config) {
+        continue;
+      }
+      const basePosition = config.compute(anchorRect, popRect, offset);
+      const nextResolution = {
+        placement: candidate,
+        axis: config.axis,
+        position: basePosition,
+      };
+      if (!resolution) {
+        resolution = nextResolution;
+      }
+      if (config.fits(basePosition, popRect)) {
+        resolution = nextResolution;
         break;
-      case "left":
-        top = anchorRect.top;
-        left = anchorRect.left - popRect.width - offset;
-        break;
-      case "right":
-        top = anchorRect.top;
-        left = anchorRect.right + offset;
-        break;
-      case "bottom":
-      default:
-        top = anchorRect.bottom + offset;
-        left = anchorRect.left;
-        break;
+      }
     }
 
-    const horizontalPlacement = placement === "bottom" || placement === "top";
+    if (!resolution) {
+      resolution = {
+        placement,
+        axis: "vertical",
+        position: { top: anchorRect.bottom + offset, left: anchorRect.left },
+      };
+    }
 
-    if (horizontalPlacement) {
+    let { top, left } = resolution.position;
+    const resolvedPlacement = resolution.placement;
+    const isVerticalAxis = resolution.axis === "vertical";
+
+    if (isVerticalAxis) {
       if (align === "center") {
         left = anchorRect.left + anchorRect.width / 2 - popRect.width / 2;
       } else if (align === "end") {
@@ -96,7 +184,7 @@ function Popover({
       top = anchorRect.bottom - popRect.height;
     }
 
-    if (horizontalPlacement) {
+    if (isVerticalAxis) {
       const minLeft = VIEWPORT_MARGIN;
       const maxLeft = window.innerWidth - popRect.width - VIEWPORT_MARGIN;
       left = clamp(left, minLeft, maxLeft);
@@ -115,8 +203,9 @@ function Popover({
       }
       return { top, left };
     });
+    setActivePlacement(resolvedPlacement);
     setVisible(true);
-  }, [align, anchorRef, isOpen, offset, placement]);
+  }, [align, anchorRef, fallbackPlacements, isOpen, offset, placement]);
 
   const scheduleUpdate = useCallback(() => {
     if (!isOpen || typeof window === "undefined") return;
@@ -196,6 +285,12 @@ function Popover({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      setActivePlacement(placement);
+    }
+  }, [isOpen, placement]);
+
   if (!isOpen) return null;
   if (typeof document === "undefined") return null;
 
@@ -211,6 +306,7 @@ function Popover({
       ref={setContentNode}
       className={classNames}
       data-visible={visible}
+      data-placement={activePlacement}
       style={inlineStyles}
     >
       {children}

--- a/website/src/components/ui/Popover/__tests__/Popover.test.jsx
+++ b/website/src/components/ui/Popover/__tests__/Popover.test.jsx
@@ -1,0 +1,161 @@
+import { render, waitFor, cleanup } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import { useRef } from "react";
+import Popover from "../Popover.jsx";
+
+function toDomRect({ top = 0, left = 0, width = 0, height = 0 }) {
+  return {
+    top,
+    left,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+  };
+}
+
+function TestHarness({ placement, fallbackPlacements, offset, align }) {
+  const anchorRef = useRef(null);
+  return (
+    <>
+      <div data-testid="anchor" ref={anchorRef}>
+        anchor
+      </div>
+      <Popover
+        isOpen
+        anchorRef={anchorRef}
+        placement={placement}
+        fallbackPlacements={fallbackPlacements}
+        offset={offset}
+        align={align}
+        className="qa-popover"
+      >
+        <div>content</div>
+      </Popover>
+    </>
+  );
+}
+
+beforeAll(() => {
+  global.ResizeObserver =
+    global.ResizeObserver ||
+    class {
+      observe() {}
+
+      unobserve() {}
+
+      disconnect() {}
+    };
+});
+
+beforeEach(() => {
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: 600,
+  });
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: 1024,
+  });
+  window.requestAnimationFrame = (callback) => {
+    callback();
+    return 0;
+  };
+  window.cancelAnimationFrame = () => {};
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  cleanup();
+});
+
+/**
+ * 测试目标：验证在顶部空间充足时 Popover 采用主方向。
+ * 前置条件：窗口高度足够且锚点距离顶部有 200px 以上。
+ * 步骤：
+ *  1) 渲染带有顶部候选及底部兜底的 Popover。
+ *  2) 注入锚点与浮层尺寸后等待定位完成。
+ * 断言：
+ *  - data-placement 应为 top；若失败提示未保持顶部定位。
+ * 边界/异常：
+ *  - 顶部空间充足场景，互补场景在回退测试中覆盖。
+ */
+test("respects primary top placement when headroom is sufficient", async () => {
+  const anchorBox = toDomRect({ top: 200, left: 100, width: 80, height: 40 });
+  const popoverBox = toDomRect({ top: 0, left: 0, width: 140, height: 120 });
+  const defaultRect = toDomRect({});
+  jest
+    .spyOn(Element.prototype, "getBoundingClientRect")
+    .mockImplementation(function getBoundingClientRect() {
+      if (this.dataset?.testid === "anchor") {
+        return anchorBox;
+      }
+      if (this.classList?.contains("qa-popover")) {
+        return popoverBox;
+      }
+      return defaultRect;
+    });
+
+  render(
+    <TestHarness
+      placement="top"
+      fallbackPlacements={[]}
+      offset={12}
+      align="start"
+    />,
+  );
+
+  await waitFor(() => {
+    const popover = document.querySelector(".qa-popover");
+    expect(popover).not.toBeNull();
+    expect(popover?.getAttribute("data-placement")).toBe("top");
+    expect(parseFloat(popover?.style.top ?? "0")).toBeCloseTo(68);
+  });
+});
+
+/**
+ * 测试目标：验证顶部空间不足时能够自动回退到底部方向。
+ * 前置条件：锚点距顶部仅 40px，主方向为 top，提供 bottom 作为候选。
+ * 步骤：
+ *  1) 渲染 Popover 并注入导致顶部越界的尺寸。
+ *  2) 等待定位结果。
+ * 断言：
+ *  - data-placement 应为 bottom，top 样式应为 92px；失败提示未触发回退。
+ * 边界/异常：
+ *  - 顶部空间不足；若所有候选均失败则维持默认策略。
+ */
+test("falls back to bottom placement when top overflows viewport", async () => {
+  const anchorBox = toDomRect({ top: 40, left: 100, width: 80, height: 40 });
+  const popoverBox = toDomRect({ top: 0, left: 0, width: 140, height: 120 });
+  const defaultRect = toDomRect({});
+  jest
+    .spyOn(Element.prototype, "getBoundingClientRect")
+    .mockImplementation(function getBoundingClientRect() {
+      if (this.dataset?.testid === "anchor") {
+        return anchorBox;
+      }
+      if (this.classList?.contains("qa-popover")) {
+        return popoverBox;
+      }
+      return defaultRect;
+    });
+
+  render(
+    <TestHarness
+      placement="top"
+      fallbackPlacements={["bottom"]}
+      offset={12}
+      align="start"
+    />,
+  );
+
+  await waitFor(() => {
+    const popover = document.querySelector(".qa-popover");
+    expect(popover).not.toBeNull();
+    expect(popover?.getAttribute("data-placement")).toBe("bottom");
+    expect(parseFloat(popover?.style.top ?? "0")).toBeCloseTo(92);
+  });
+});
+


### PR DESCRIPTION
## Summary
- open the language selector above its trigger with adjusted spacing and automatic fallback
- refactor the shared Popover to use strategy-based placement resolution and expose the active placement
- add unit tests covering primary top placement and fallback behaviour

## Testing
- npm test -- Popover

------
https://chatgpt.com/codex/tasks/task_e_68dbcc1de8c08332b97299d3f1ffb5fc