### PR TITLE
Stabilize ChatInput language controls layout

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -14,12 +14,32 @@
 }
 
 .language-shell {
+  /*
+   * 约束语言徽标容器的最小宽度，避免不同语言代码导致布局抖动；
+   * 自定义属性允许未来在主题层统一调节数值。
+   */
+  --language-trigger-min-inline: var(--sb-language-trigger-min-inline, 4ch);
+  --language-shell-gap: clamp(10px, 2vw, var(--seg-arrow-gap, 12px));
+  --language-shell-padding-inline: clamp(16px, 4vw, var(--seg-pad-x, 20px));
+  --language-arrow-pad-inline: max(
+    8px,
+    calc(var(--language-shell-gap) * 0.75)
+  );
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
   height: var(--seg-h, 44px);
-  padding-inline: var(--seg-pad-x, 20px);
-  gap: var(--seg-arrow-gap, 12px);
+  padding-inline: var(--language-shell-padding-inline);
+  gap: var(--language-shell-gap);
+  inline-size: fit-content;
+  min-inline-size: calc(
+    (
+        var(--language-trigger-min-inline) +
+          var(--language-shell-gap)
+      ) * 2 +
+      (var(--language-shell-padding-inline) * 2)
+  );
   border-radius: var(--seg-r, 22px);
   background: var(--sb-seg, #141b24);
   color: var(--sb-text, #edeff2);
@@ -57,7 +77,10 @@
   justify-content: center;
   gap: var(--seg-arrow-gap, 12px);
   height: 100%;
+  inline-size: fit-content;
+  min-inline-size: var(--language-trigger-min-inline, 4ch);
   padding: 0;
+  padding-inline: var(--seg-trigger-pad-inline, 4px);
   border: none;
   border-radius: calc(var(--seg-r, 22px) - 6px);
   background: transparent;
@@ -109,7 +132,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  padding-inline: var(--seg-arrow-gap, 12px);
+  padding-inline: var(--language-arrow-pad-inline);
   border: none;
   border-radius: calc(var(--seg-r, 22px) - 6px);
   background: transparent;
@@ -142,6 +165,21 @@
 
 .language-swap:active {
   transform: scale(0.96);
+}
+
+@media (width <= 360px) {
+  .language-shell {
+    --language-shell-gap: 8px;
+    --language-shell-padding-inline: 12px;
+    --language-arrow-pad-inline: max(6px, calc(var(--language-shell-gap) * 0.9));
+
+    justify-content: space-between;
+  }
+
+  .language-trigger {
+    min-inline-size: var(--sb-language-trigger-mobile-inline, 3.5ch);
+    padding-inline: 2px;
+  }
 }
 
 .core-input {

--- a/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInput.test.jsx
@@ -100,3 +100,46 @@ test("handles language selection and swapping", async () => {
   fireEvent.click(swapButton);
   expect(handleSwap).toHaveBeenCalledTimes(1);
 });
+
+/**
+ * 测试目标：确保语言触发按钮在全角/中英文混排的代码下仍保持徽标宽度一致。
+ * 前置条件：源/目标语言选项提供长度为两字符的全角代码与中文标签。
+ * 步骤：
+ *  1) 渲染 ActionInput 并传入包含全角代码的语言配置；
+ *  2) 读取源/目标语言按钮的文本内容。
+ * 断言：
+ *  - 源语言按钮文本前两字符应为“ＺＨ”；
+ *  - 目标语言按钮文本前两字符应为“ＥＮ”。
+ * 边界/异常：
+ *  - 验证文本保留两个字符前缀，以保障布局宽度稳定。
+ */
+test("renders fullwidth language badges consistently", () => {
+  render(
+    <ActionInput
+      value=""
+      onChange={() => {}}
+      onSubmit={() => {}}
+      sourceLanguage="ＺＨ"
+      sourceLanguageOptions={[
+        { value: "ＺＨ", label: "中文词条（全角）" },
+        { value: "ＥＮ", label: "英文词条（全角）" },
+      ]}
+      sourceLanguageLabel="源语言"
+      targetLanguage="ＥＮ"
+      targetLanguageOptions={[
+        { value: "ＥＮ", label: "英文释义（全角）" },
+        { value: "ＺＨ", label: "中文释义（全角）" },
+      ]}
+      targetLanguageLabel="目标语言"
+    />,
+  );
+
+  const sourceButton = screen.getByRole("button", { name: "源语言" });
+  const targetButton = screen.getByRole("button", { name: "目标语言" });
+
+  const sourceText = (sourceButton.textContent || "").trim();
+  const targetText = (targetButton.textContent || "").trim();
+
+  expect(sourceText.slice(0, 2)).toBe("ＺＨ");
+  expect(targetText.slice(0, 2)).toBe("ＥＮ");
+});


### PR DESCRIPTION
## Summary
- enforce consistent inline dimensions and responsive spacing for ChatInput language controls to avoid badge jitter across locales
- add mobile-specific tuning to maintain balance at narrow widths
- extend ActionInput test coverage to assert fullwidth language badge rendering

## Testing
- npm run lint
- npm run lint:css
- npm run test -- ActionInput.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68dbcc1e77b48332a7b616c620b94e87