### PR TITLE
Adjust ChatInput action button sizing to rely on base styles

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -190,6 +190,8 @@
   flex-shrink: 0;
   display: grid;
   place-items: center;
+  inline-size: var(--btn-action, 44px);
+  block-size: var(--btn-action, 44px);
   width: var(--btn-action, 44px);
   height: var(--btn-action, 44px);
   border: none;
@@ -202,12 +204,6 @@
     box-shadow 0.2s ease,
     transform 0.2s ease,
     background-color 0.2s ease;
-}
-
-.action-button-voice,
-.action-button-send {
-  width: 100%;
-  height: 100%;
 }
 
 .action-button:hover {


### PR DESCRIPTION
## Summary
- ensure the ChatInput action button inherits its geometry from the shared base selector instead of per-state overrides
- add inline and block size declarations on the base action button to preserve its circular silhouette across writing modes

## Testing
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68dbd27b2ab0833284eed9de2b2781b4