### PR TITLE
Refactor dictionary toolbar into chat input action area

### DIFF
--- a/website/src/components/DictionaryEntryActionBar/DictionaryEntryActionBar.module.css
+++ b/website/src/components/DictionaryEntryActionBar/DictionaryEntryActionBar.module.css
@@ -1,11 +1,4 @@
 .toolbar {
-  width: min(960px, 100%);
-  margin: 0 auto;
+  width: 100%;
   box-sizing: border-box;
-}
-
-@media (width <= 768px) {
-  .toolbar {
-    width: 100%;
-  }
 }

--- a/website/src/components/DictionaryEntryActionBar/index.jsx
+++ b/website/src/components/DictionaryEntryActionBar/index.jsx
@@ -2,15 +2,16 @@ import PropTypes from "prop-types";
 import OutputToolbar from "@/components/OutputToolbar";
 import styles from "./DictionaryEntryActionBar.module.css";
 
-export default function DictionaryEntryActionBar({ visible, ...toolbarProps }) {
-  if (!visible) {
-    return null;
-  }
+export default function DictionaryEntryActionBar(toolbarProps) {
+  const { className, ...restProps } = toolbarProps;
+  const toolbarClassName = [styles.toolbar, className]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <OutputToolbar
-      {...toolbarProps}
-      className={styles.toolbar}
+      {...restProps}
+      className={toolbarClassName}
       role="toolbar"
       ariaLabel="词条工具栏"
     />
@@ -18,9 +19,9 @@ export default function DictionaryEntryActionBar({ visible, ...toolbarProps }) {
 }
 
 DictionaryEntryActionBar.propTypes = {
-  visible: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 DictionaryEntryActionBar.defaultProps = {
-  visible: false,
+  className: undefined,
 };

--- a/website/src/components/ui/ChatInput/ActionInput/index.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput/index.jsx
@@ -60,6 +60,32 @@ ActionInput.propTypes = {
   normalizeSourceLanguageFn: PropTypes.func,
   normalizeTargetLanguageFn: PropTypes.func,
   onMenuOpen: PropTypes.func,
+  dictionaryActionBarProps: PropTypes.shape({
+    term: PropTypes.string,
+    lang: PropTypes.string,
+    onReoutput: PropTypes.func,
+    disabled: PropTypes.bool,
+    versions: PropTypes.arrayOf(PropTypes.object),
+    activeVersionId: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.oneOf([null]),
+    ]),
+    onNavigate: PropTypes.func,
+    onCopy: PropTypes.func,
+    canCopy: PropTypes.bool,
+    favorited: PropTypes.bool,
+    onToggleFavorite: PropTypes.func,
+    canFavorite: PropTypes.bool,
+    canDelete: PropTypes.bool,
+    onDelete: PropTypes.func,
+    canShare: PropTypes.bool,
+    onShare: PropTypes.func,
+    canReport: PropTypes.bool,
+    onReport: PropTypes.func,
+    className: PropTypes.string,
+  }),
+  hasDefinition: PropTypes.bool,
 };
 
 ActionInput.defaultProps = {
@@ -86,6 +112,8 @@ ActionInput.defaultProps = {
   normalizeSourceLanguageFn: (value) => value,
   normalizeTargetLanguageFn: (value) => value,
   onMenuOpen: undefined,
+  dictionaryActionBarProps: undefined,
+  hasDefinition: false,
 };
 
 export default ActionInput;

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -41,6 +41,10 @@
     );
 }
 
+.input-surface-bottom[data-mode="toolbar"] {
+  align-items: flex-start;
+}
+
 .input-bottom-left {
   flex: 1 1 auto;
   display: flex;
@@ -48,10 +52,30 @@
   min-width: 0;
 }
 
+.input-surface-bottom[data-mode="toolbar"] .input-bottom-left {
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--chat-input-toolbar-gap, 8px);
+}
+
 .input-bottom-right {
   flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;
+}
+
+.input-surface-bottom[data-mode="toolbar"] .input-bottom-right {
+  align-self: flex-start;
+}
+
+.dictionary-toolbar-wrapper {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.dictionary-toolbar {
+  width: 100%;
 }
 
 @media (width <= 640px) {

--- a/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
@@ -2,7 +2,19 @@ import { render } from "@testing-library/react";
 import { createRef } from "react";
 import { jest } from "@jest/globals";
 
-import ActionInputView from "../parts/ActionInputView.jsx";
+let ActionInputView;
+
+beforeAll(async () => {
+  await jest.unstable_mockModule("@/components/DictionaryEntryActionBar", () => ({
+    __esModule: true,
+    default: ({ className }) => (
+      <div data-testid="dictionary-toolbar-mock" className={className}>
+        DictionaryToolbar
+      </div>
+    ),
+  }));
+  ({ default: ActionInputView } = await import("../parts/ActionInputView.jsx"));
+});
 
 /**
  * 测试目标：视图层在注入标准 Props 时渲染结构保持稳定。
@@ -27,6 +39,8 @@ test("GivenStandardProps_WhenRenderingView_ThenMatchSnapshot", () => {
         value: "example",
         onChange: jest.fn(),
         onKeyDown: jest.fn(),
+        onFocus: jest.fn(),
+        onBlur: jest.fn(),
       }}
       languageControls={{
         isVisible: true,
@@ -52,6 +66,11 @@ test("GivenStandardProps_WhenRenderingView_ThenMatchSnapshot", () => {
           onMenuOpen: jest.fn(),
         },
       }}
+      dictionaryToolbar={{
+        isVisible: false,
+        props: null,
+      }}
+      featureMode="language"
       actionButtonProps={{
         value: "example",
         isRecording: false,
@@ -66,4 +85,66 @@ test("GivenStandardProps_WhenRenderingView_ThenMatchSnapshot", () => {
   );
 
   expect(container).toMatchSnapshot();
+});
+
+/**
+ * 测试目标：当处于工具栏模式时渲染词典操作栏并附带样式容器。
+ * 前置条件：languageControls 隐藏、dictionaryToolbar 提供 props、featureMode=toolbar。
+ * 步骤：
+ *  1) 传入工具栏可见状态并渲染组件。
+ *  2) 捕获 DOM 并断言工具栏节点存在。
+ * 断言：
+ *  - data-mode 属性为 "toolbar"。
+ *  - 工具栏容器内存在 data-testid="output-toolbar" 的节点。
+ * 边界/异常：
+ *  - 即便 languageControls 可见也不会渲染，当 featureMode=toolbar 时仅呈现工具栏。
+ */
+test("GivenToolbarMode_WhenRenderingView_ThenRenderDictionaryToolbar", () => {
+  const formRef = createRef();
+  const onSubmit = jest.fn();
+  const { container, getByTestId } = render(
+    <ActionInputView
+      formProps={{ ref: formRef, onSubmit }}
+      textareaProps={{
+        ref: jest.fn(),
+        rows: 2,
+        placeholder: "",
+        value: "",
+        onChange: jest.fn(),
+        onKeyDown: jest.fn(),
+        onFocus: jest.fn(),
+        onBlur: jest.fn(),
+      }}
+      languageControls={{
+        isVisible: true,
+        props: {
+          sourceLanguage: undefined,
+          sourceLanguageOptions: [],
+          targetLanguage: undefined,
+          targetLanguageOptions: [],
+        },
+      }}
+      dictionaryToolbar={{
+        isVisible: true,
+        props: {
+          term: "hello",
+          lang: "en",
+          onCopy: jest.fn(),
+        },
+      }}
+      featureMode="toolbar"
+      actionButtonProps={{
+        value: "",
+        isRecording: false,
+        voiceCooldownRef: { current: 0 },
+        onSubmit: jest.fn(),
+        isVoiceDisabled: true,
+        sendLabel: "发送",
+        voiceLabel: "语音",
+      }}
+    />,
+  );
+
+  expect(container.querySelector("[data-mode='toolbar']")).not.toBeNull();
+  expect(getByTestId("dictionary-toolbar-mock")).toBeInTheDocument();
 });

--- a/website/src/components/ui/ChatInput/__tests__/__snapshots__/ActionInputView.test.jsx.snap
+++ b/website/src/components/ui/ChatInput/__tests__/__snapshots__/ActionInputView.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`GivenStandardProps_WhenRenderingView_ThenMatchSnapshot 1`] = `
       </div>
       <div
         class="input-surface-bottom"
+        data-mode="language"
       >
         <div
           class="input-bottom-left"

--- a/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
+++ b/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
@@ -13,6 +13,7 @@
 import PropTypes from "prop-types";
 
 import SearchBox from "@/components/ui/SearchBox";
+import DictionaryEntryActionBar from "@/components/DictionaryEntryActionBar";
 import LanguageControls from "../LanguageControls.jsx";
 import ActionButton from "./ActionButton.jsx";
 import styles from "../ChatInput.module.css";
@@ -21,16 +22,34 @@ function ActionInputView({
   formProps,
   textareaProps,
   languageControls,
+  dictionaryToolbar,
+  featureMode,
   actionButtonProps,
 }) {
+  const { onFocus, onBlur, ...restTextareaProps } = textareaProps;
   const { isVisible, props: languageProps } = languageControls;
+  const toolbarProps = dictionaryToolbar?.props ?? null;
+  const toolbarClassName = toolbarProps
+    ? [styles["dictionary-toolbar"], toolbarProps.className]
+        .filter(Boolean)
+        .join(" ")
+    : styles["dictionary-toolbar"];
+  const shouldRenderLanguageControls =
+    featureMode === "language" && isVisible;
+  const shouldRenderToolbar =
+    featureMode === "toolbar" && dictionaryToolbar?.isVisible && toolbarProps;
 
   return (
     <form {...formProps} className={styles["input-wrapper"]}>
       <SearchBox className={styles["input-surface"]}>
         <div className={styles["input-surface-top"]}>
           <div className={styles["core-input"]}>
-            <textarea {...textareaProps} className={styles.textarea} />
+            <textarea
+              {...restTextareaProps}
+              className={styles.textarea}
+              onFocus={onFocus}
+              onBlur={onBlur}
+            />
             <button
               type="submit"
               className={styles["submit-proxy"]}
@@ -39,9 +58,22 @@ function ActionInputView({
             />
           </div>
         </div>
-        <div className={styles["input-surface-bottom"]}>
+        <div
+          className={styles["input-surface-bottom"]}
+          data-mode={featureMode}
+        >
           <div className={styles["input-bottom-left"]}>
-            {isVisible ? <LanguageControls {...languageProps} /> : null}
+            {shouldRenderLanguageControls ? (
+              <LanguageControls {...languageProps} />
+            ) : null}
+            {shouldRenderToolbar ? (
+              <div className={styles["dictionary-toolbar-wrapper"]}>
+                <DictionaryEntryActionBar
+                  {...toolbarProps}
+                  className={toolbarClassName}
+                />
+              </div>
+            ) : null}
           </div>
           <div className={styles["input-bottom-right"]}>
             <ActionButton {...actionButtonProps} />
@@ -64,6 +96,8 @@ ActionInputView.propTypes = {
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onKeyDown: PropTypes.func.isRequired,
+    onFocus: PropTypes.func.isRequired,
+    onBlur: PropTypes.func.isRequired,
   }).isRequired,
   languageControls: PropTypes.shape({
     isVisible: PropTypes.bool.isRequired,
@@ -93,6 +127,11 @@ ActionInputView.propTypes = {
       onMenuOpen: PropTypes.func,
     }).isRequired,
   }).isRequired,
+  dictionaryToolbar: PropTypes.shape({
+    isVisible: PropTypes.bool.isRequired,
+    props: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf([null])]),
+  }).isRequired,
+  featureMode: PropTypes.oneOf(["language", "toolbar"]).isRequired,
   actionButtonProps: PropTypes.shape({
     value: PropTypes.string.isRequired,
     isRecording: PropTypes.bool,

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntryView.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntryView.jsx
@@ -3,16 +3,14 @@ import DictionaryEntry from "./DictionaryEntry.jsx";
 import DictionaryEntryPlaceholder from "./DictionaryEntryPlaceholder.jsx";
 import layoutStyles from "./DictionaryEntryView.module.css";
 
-function DictionaryEntryView({ entry, preview, isLoading, actions }) {
+function DictionaryEntryView({ entry, preview, isLoading }) {
   if (entry) {
     return (
       <section className={`${layoutStyles.entry} entry`}>
-        {/* 使用 grid 保证释义与工具栏在各断点下维持垂直顺序，避免旧 flex 布局并排问题。 */}
         <DictionaryEntry
           entry={entry}
           className={`${layoutStyles.definition} entry__definition`}
         />
-        {actions || null}
       </section>
     );
   }
@@ -24,14 +22,12 @@ DictionaryEntryView.propTypes = {
   entry: PropTypes.object,
   preview: PropTypes.string,
   isLoading: PropTypes.bool,
-  actions: PropTypes.node,
 };
 
 DictionaryEntryView.defaultProps = {
   entry: null,
   preview: "",
   isLoading: false,
-  actions: null,
 };
 
 export default DictionaryEntryView;

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntryView.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntryView.module.css
@@ -1,38 +1,18 @@
 .entry {
-  display: grid;
-  grid-template: "definition" auto "toolbar" auto / 1fr;
-  row-gap: var(--space-4, 16px);
-  align-items: start;
+  display: block;
   width: 100%;
   box-sizing: border-box;
 }
 
 .definition {
-  grid-area: definition;
+  display: block;
 }
 
 /* stylelint-disable selector-class-pattern */
-:global(.entry__definition),
-:global(.entry__toolbar) {
+:global(.entry__definition) {
   float: none !important;
   clear: both;
   position: static !important;
-  width: auto;
-  flex: initial;
-  align-self: auto;
-}
-
-:global(.entry__definition) {
-  grid-area: definition;
-}
-
-:global(.entry__toolbar) {
-  grid-area: toolbar;
+  width: 100%;
 }
 /* stylelint-enable selector-class-pattern */
-
-@media (width >= 768px) {
-  .entry {
-    row-gap: var(--space-5, 20px);
-  }
-}

--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -6,7 +6,6 @@ import { DictionaryEntryView } from "@/components/ui/DictionaryEntry";
 import ChatInput from "@/components/ui/ChatInput";
 import ICP from "@/components/ui/ICP";
 import EmptyState from "@/components/ui/EmptyState";
-import DictionaryEntryActionBar from "@/components/DictionaryEntryActionBar";
 import {
   normalizeWordSourceLanguage,
   normalizeWordTargetLanguage,
@@ -55,9 +54,6 @@ export default function DictionaryExperience() {
     activeSidebarView,
   } = useDictionaryExperience();
 
-  const dictionaryActionBar = (
-    <DictionaryEntryActionBar {...dictionaryActionBarProps} />
-  );
   const previewContent = finalText || streamText;
   const shouldRenderEntry = entry || previewContent || loading;
 
@@ -92,6 +88,8 @@ export default function DictionaryExperience() {
               swapLabel={dictionarySwapLanguagesLabel}
               normalizeSourceLanguageFn={normalizeWordSourceLanguage}
               normalizeTargetLanguageFn={normalizeWordTargetLanguage}
+              dictionaryActionBarProps={dictionaryActionBarProps}
+              hasDefinition={Boolean(entry)}
             />
             <ICP />
           </div>
@@ -125,7 +123,6 @@ export default function DictionaryExperience() {
               entry={entry}
               preview={previewContent}
               isLoading={loading}
-              actions={dictionaryActionBar}
             />
           ) : (
             <EmptyState

--- a/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
@@ -716,7 +716,6 @@ export function useDictionaryExperience() {
 
   const dictionaryActionBarProps = useMemo(
     () => ({
-      visible: hasResolvedEntry,
       term: resolvedTerm,
       lang,
       onReoutput: handleReoutput,


### PR DESCRIPTION
## Summary
- pass dictionary action bar props into the chat input and let the display view focus solely on entry content
- extend the chat input action zone to switch between language controls and the dictionary toolbar with updated layout styles
- enhance action input behavior state tracking and unit tests to cover the new toolbar-toggle interactions

## Testing
- npm run lint
- npm run lint:css
- npm run test -- ActionInputView.test.jsx -u
- npm run test -- useActionInputBehavior.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dbdf962bc48332815b67d20b5397e6