### PR TITLE
Center layout bottom controls within content width

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -162,32 +162,25 @@
 
 .main-bottom {
   position: fixed;
-  left: calc(
-    var(--layout-sidebar-width, var(--layout-sidebar-default)) +
-      (100vw - var(--layout-sidebar-width, var(--layout-sidebar-default))) / 2
-  );
-  transform: translateX(-50%);
+  inset-inline: 0;
   bottom: clamp(24px, 6vh, 40px);
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 8px;
-  width: max-content;
+  width: 100%;
   pointer-events: none;
   z-index: 5;
 }
 
 .main-bottom-inner {
-  width: min(
-    clamp(360px, 50vw, 960px),
-    calc(
-      100vw - var(--layout-sidebar-width, var(--layout-sidebar-default)) - 48px
-    )
-  );
+  width: min(clamp(360px, 50vw, 960px), calc(100vw - 48px));
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 8px;
+  margin-inline: auto;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary
- center the fixed main-bottom container relative to the viewport using logical inset positioning
- align the main-bottom-inner width constraints with the content area to keep controls centered on all viewports

## Testing
- `npx prettier -w website/src/components/Layout/Layout.module.css`
- `npm run lint`
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_68dc0eeb26bc83329643134228d4b70f