### PR TITLE
feat: add switchable dictionary bottom panel

### DIFF
--- a/website/src/components/Layout/index.jsx
+++ b/website/src/components/Layout/index.jsx
@@ -1,16 +1,23 @@
 import { useState, useRef, useMemo, useCallback, useEffect } from "react";
+import PropTypes from "prop-types";
 import Sidebar from "@/components/Sidebar";
 import ThemeIcon from "@/components/ui/Icon";
 import { useIsMobile } from "@/utils";
 import styles from "./Layout.module.css";
 
-function Layout({ children, sidebarProps = {}, bottomContent = null }) {
+function Layout({
+  children,
+  sidebarProps = {},
+  bottomContent = null,
+  onMainMiddleScroll,
+}) {
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(null);
   const containerRef = useRef(null);
   const sidebarRef = useRef(null);
   const resizeFrame = useRef(null);
+  const mainMiddleRef = useRef(null);
 
   useEffect(() => {
     if (isMobile) {
@@ -87,6 +94,23 @@ function Layout({ children, sidebarProps = {}, bottomContent = null }) {
     return { "--layout-sidebar-width": `${Math.round(sidebarWidth)}px` };
   }, [sidebarWidth, isMobile]);
 
+  useEffect(() => {
+    if (!onMainMiddleScroll) {
+      return undefined;
+    }
+    const node = mainMiddleRef.current;
+    if (!node) {
+      return undefined;
+    }
+    const handleScroll = (event) => {
+      onMainMiddleScroll(event);
+    };
+    node.addEventListener("scroll", handleScroll);
+    return () => {
+      node.removeEventListener("scroll", handleScroll);
+    };
+  }, [onMainMiddleScroll]);
+
   return (
     <div ref={containerRef} className={styles.container} style={containerStyle}>
       <Sidebar
@@ -119,7 +143,9 @@ function Layout({ children, sidebarProps = {}, bottomContent = null }) {
           </div>
         ) : null}
         <div className={styles["main-content"]}>
-          <div className={styles["main-middle"]}>{children}</div>
+          <div ref={mainMiddleRef} className={styles["main-middle"]}>
+            {children}
+          </div>
         </div>
         {bottomContent ? (
           <div className={styles["main-bottom"]}>
@@ -132,3 +158,16 @@ function Layout({ children, sidebarProps = {}, bottomContent = null }) {
 }
 
 export default Layout;
+
+Layout.propTypes = {
+  children: PropTypes.node.isRequired,
+  sidebarProps: PropTypes.object,
+  bottomContent: PropTypes.node,
+  onMainMiddleScroll: PropTypes.func,
+};
+
+Layout.defaultProps = {
+  sidebarProps: {},
+  bottomContent: null,
+  onMainMiddleScroll: undefined,
+};

--- a/website/src/components/ui/ChatInput/ActionInput/index.jsx
+++ b/website/src/components/ui/ChatInput/ActionInput/index.jsx
@@ -60,32 +60,7 @@ ActionInput.propTypes = {
   normalizeSourceLanguageFn: PropTypes.func,
   normalizeTargetLanguageFn: PropTypes.func,
   onMenuOpen: PropTypes.func,
-  dictionaryActionBarProps: PropTypes.shape({
-    term: PropTypes.string,
-    lang: PropTypes.string,
-    onReoutput: PropTypes.func,
-    disabled: PropTypes.bool,
-    versions: PropTypes.arrayOf(PropTypes.object),
-    activeVersionId: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.oneOf([null]),
-    ]),
-    onNavigate: PropTypes.func,
-    onCopy: PropTypes.func,
-    canCopy: PropTypes.bool,
-    favorited: PropTypes.bool,
-    onToggleFavorite: PropTypes.func,
-    canFavorite: PropTypes.bool,
-    canDelete: PropTypes.bool,
-    onDelete: PropTypes.func,
-    canShare: PropTypes.bool,
-    onShare: PropTypes.func,
-    canReport: PropTypes.bool,
-    onReport: PropTypes.func,
-    className: PropTypes.string,
-  }),
-  hasDefinition: PropTypes.bool,
+  onFocusChange: PropTypes.func,
 };
 
 ActionInput.defaultProps = {
@@ -112,8 +87,7 @@ ActionInput.defaultProps = {
   normalizeSourceLanguageFn: (value) => value,
   normalizeTargetLanguageFn: (value) => value,
   onMenuOpen: undefined,
-  dictionaryActionBarProps: undefined,
-  hasDefinition: false,
+  onFocusChange: undefined,
 };
 
 export default ActionInput;

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -41,10 +41,6 @@
     );
 }
 
-.input-surface-bottom[data-mode="toolbar"] {
-  align-items: flex-start;
-}
-
 .input-bottom-left {
   flex: 1 1 auto;
   display: flex;
@@ -52,30 +48,10 @@
   min-width: 0;
 }
 
-.input-surface-bottom[data-mode="toolbar"] .input-bottom-left {
-  flex-direction: column;
-  align-items: stretch;
-  gap: var(--chat-input-toolbar-gap, 8px);
-}
-
 .input-bottom-right {
   flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;
-}
-
-.input-surface-bottom[data-mode="toolbar"] .input-bottom-right {
-  align-self: flex-start;
-}
-
-.dictionary-toolbar-wrapper {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-}
-
-.dictionary-toolbar {
-  width: 100%;
 }
 
 @media (width <= 640px) {

--- a/website/src/components/ui/ChatInput/hooks/useActionInputBehavior.ts
+++ b/website/src/components/ui/ChatInput/hooks/useActionInputBehavior.ts
@@ -11,7 +11,7 @@
  * 演进与TODO：
  *  - 后续可在此处扩展动作策略映射或接入特性开关以支持更多输入模式。
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 export type LanguageValue = string | symbol | undefined;
 
@@ -19,32 +19,6 @@ export interface LanguageOption {
   value: string | symbol;
   label: string;
 }
-
-export interface DictionaryToolbarProps {
-  visible?: boolean;
-  term?: string;
-  lang?: string;
-  onReoutput?: () => void;
-  disabled?: boolean;
-  versions?: Array<Record<string, unknown>>;
-  activeVersionId?: string | number | null;
-  onNavigate?: (versionId: string | number | null) => void;
-  onCopy?: () => void;
-  canCopy?: boolean;
-  favorited?: boolean;
-  onToggleFavorite?: () => void;
-  canFavorite?: boolean;
-  canDelete?: boolean;
-  onDelete?: () => void;
-  canShare?: boolean;
-  onShare?: () => void;
-  canReport?: boolean;
-  onReport?: () => void;
-  className?: string;
-  [key: string]: unknown;
-}
-
-export type SanitizedDictionaryToolbarProps = Omit<DictionaryToolbarProps, "visible">;
 
 export interface UseActionInputBehaviorParams {
   value: string;
@@ -71,8 +45,7 @@ export interface UseActionInputBehaviorParams {
   normalizeSourceLanguageFn?: (value: LanguageValue) => LanguageValue;
   normalizeTargetLanguageFn?: (value: LanguageValue) => LanguageValue;
   onMenuOpen?: () => void;
-  dictionaryActionBarProps?: DictionaryToolbarProps | null;
-  hasDefinition?: boolean;
+  onFocusChange?: (isFocused: boolean) => void;
 }
 
 export interface UseActionInputBehaviorResult {
@@ -108,11 +81,6 @@ export interface UseActionInputBehaviorResult {
       onMenuOpen?: () => void;
     };
   };
-  dictionaryToolbar: {
-    isVisible: boolean;
-    props: SanitizedDictionaryToolbarProps | null;
-  };
-  featureMode: "language" | "toolbar";
   actionButtonProps: {
     value: string;
     isRecording?: boolean;
@@ -164,13 +132,11 @@ export default function useActionInputBehavior({
   normalizeSourceLanguageFn = (language) => language,
   normalizeTargetLanguageFn = (language) => language,
   onMenuOpen,
-  dictionaryActionBarProps,
-  hasDefinition = false,
+  onFocusChange,
 }: UseActionInputBehaviorParams): UseActionInputBehaviorResult {
   const formRef = useRef<HTMLFormElement | null>(null);
   const internalTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const voiceCooldownRef = useRef<number>(0);
-  const [isTextareaFocused, setIsTextareaFocused] = useState(false);
 
   const setTextareaRef = useCallback(
     (node: HTMLTextAreaElement | null) => {
@@ -214,12 +180,12 @@ export default function useActionInputBehavior({
   }, [autoResize, value]);
 
   const handleFocus = useCallback(() => {
-    setIsTextareaFocused(true);
-  }, []);
+    onFocusChange?.(true);
+  }, [onFocusChange]);
 
   const handleBlur = useCallback(() => {
-    setIsTextareaFocused(false);
-  }, []);
+    onFocusChange?.(false);
+  }, [onFocusChange]);
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -265,37 +231,6 @@ export default function useActionInputBehavior({
   const isVoiceDisabled = typeof onVoice !== "function";
   const isLanguageControlsVisible =
     languageOptions.source.length > 0 || languageOptions.target.length > 0;
-  const normalizedToolbar = useMemo(
-    () => dictionaryActionBarProps ?? null,
-    [dictionaryActionBarProps],
-  );
-  /**
-   * 意图：通过最小状态机在语言切换与工具栏之间流转，遵循“输入优先、复用工具栏”的交互规则。
-   * 取舍：
-   *  - 采用本地聚焦状态避免引入全局 context，保证 Hook 自洽；
-   *  - 工具栏显隐依赖 hasDefinition 与输入内容，避免渲染抖动。
-   */
-  const sanitizedToolbarProps = useMemo<SanitizedDictionaryToolbarProps | null>(
-    () => {
-      if (!normalizedToolbar) {
-        return null;
-      }
-      const { visible: _visible, ...rest } = normalizedToolbar;
-      return rest;
-    },
-    [normalizedToolbar],
-  );
-  const hasTypedContent = value.trim().length > 0;
-  const shouldShowToolbar =
-    Boolean(hasDefinition) &&
-    !isTextareaFocused &&
-    !hasTypedContent &&
-    Boolean(normalizedToolbar) &&
-    (normalizedToolbar?.visible ?? true);
-  const featureMode: "language" | "toolbar" = shouldShowToolbar
-    ? "toolbar"
-    : "language";
-
   return {
     formProps: {
       ref: formRef,
@@ -329,11 +264,6 @@ export default function useActionInputBehavior({
         onMenuOpen,
       },
     },
-    dictionaryToolbar: {
-      isVisible: shouldShowToolbar,
-      props: sanitizedToolbarProps,
-    },
-    featureMode,
     actionButtonProps: {
       value,
       isRecording,

--- a/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
+++ b/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
@@ -13,7 +13,6 @@
 import PropTypes from "prop-types";
 
 import SearchBox from "@/components/ui/SearchBox";
-import DictionaryEntryActionBar from "@/components/DictionaryEntryActionBar";
 import LanguageControls from "../LanguageControls.jsx";
 import ActionButton from "./ActionButton.jsx";
 import styles from "../ChatInput.module.css";
@@ -22,22 +21,11 @@ function ActionInputView({
   formProps,
   textareaProps,
   languageControls,
-  dictionaryToolbar,
-  featureMode,
   actionButtonProps,
 }) {
   const { onFocus, onBlur, ...restTextareaProps } = textareaProps;
   const { isVisible, props: languageProps } = languageControls;
-  const toolbarProps = dictionaryToolbar?.props ?? null;
-  const toolbarClassName = toolbarProps
-    ? [styles["dictionary-toolbar"], toolbarProps.className]
-        .filter(Boolean)
-        .join(" ")
-    : styles["dictionary-toolbar"];
-  const shouldRenderLanguageControls =
-    featureMode === "language" && isVisible;
-  const shouldRenderToolbar =
-    featureMode === "toolbar" && dictionaryToolbar?.isVisible && toolbarProps;
+  const shouldRenderLanguageControls = isVisible;
 
   return (
     <form {...formProps} className={styles["input-wrapper"]}>
@@ -58,21 +46,10 @@ function ActionInputView({
             />
           </div>
         </div>
-        <div
-          className={styles["input-surface-bottom"]}
-          data-mode={featureMode}
-        >
+        <div className={styles["input-surface-bottom"]} data-mode="language">
           <div className={styles["input-bottom-left"]}>
             {shouldRenderLanguageControls ? (
               <LanguageControls {...languageProps} />
-            ) : null}
-            {shouldRenderToolbar ? (
-              <div className={styles["dictionary-toolbar-wrapper"]}>
-                <DictionaryEntryActionBar
-                  {...toolbarProps}
-                  className={toolbarClassName}
-                />
-              </div>
             ) : null}
           </div>
           <div className={styles["input-bottom-right"]}>
@@ -127,11 +104,6 @@ ActionInputView.propTypes = {
       onMenuOpen: PropTypes.func,
     }).isRequired,
   }).isRequired,
-  dictionaryToolbar: PropTypes.shape({
-    isVisible: PropTypes.bool.isRequired,
-    props: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf([null])]),
-  }).isRequired,
-  featureMode: PropTypes.oneOf(["language", "toolbar"]).isRequired,
   actionButtonProps: PropTypes.shape({
     value: PropTypes.string.isRequired,
     isRecording: PropTypes.bool,

--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -11,11 +11,15 @@ import {
   normalizeWordTargetLanguage,
 } from "@/utils";
 import { useDictionaryExperience } from "./hooks/useDictionaryExperience";
+import useBottomPanelState from "./hooks/useBottomPanelState";
+import BottomPanelSwitcher from "./components/BottomPanelSwitcher.jsx";
+import DictionaryActionPanel from "./components/DictionaryActionPanel.jsx";
 import "@/pages/App/App.css";
 
 export default function DictionaryExperience() {
   const {
     inputRef,
+    t,
     text,
     setText,
     dictionarySourceLanguage,
@@ -56,6 +60,31 @@ export default function DictionaryExperience() {
 
   const previewContent = finalText || streamText;
   const shouldRenderEntry = entry || previewContent || loading;
+  const hasDefinition = Boolean(entry);
+
+  const {
+    mode: bottomPanelMode,
+    activateSearchMode,
+    activateActionsMode,
+    handleFocusChange: handlePanelFocusChange,
+    handleScrollEscape,
+  } = useBottomPanelState({ hasDefinition, text });
+
+  const handleSearchButtonClick = () => {
+    activateSearchMode();
+    focusInput();
+  };
+
+  const handleInputFocusChange = (focused) => {
+    handlePanelFocusChange(focused);
+    if (!focused) {
+      activateActionsMode();
+    }
+  };
+
+  const handleMainScroll = () => {
+    handleScrollEscape();
+  };
 
   return (
     <>
@@ -66,30 +95,44 @@ export default function DictionaryExperience() {
           onSelectHistory: handleSelectHistory,
           activeView: activeSidebarView,
         }}
+        onMainMiddleScroll={handleMainScroll}
         bottomContent={
           <div className="app-bottom">
-            <ChatInput
-              inputRef={inputRef}
-              value={text}
-              onChange={(event) => setText(event.target.value)}
-              onSubmit={handleSend}
-              onVoice={handleVoice}
-              placeholder={chatInputPlaceholder}
-              maxRows={5}
-              sourceLanguage={dictionarySourceLanguage}
-              sourceLanguageOptions={sourceLanguageOptions}
-              sourceLanguageLabel={dictionarySourceLanguageLabel}
-              onSourceLanguageChange={setDictionarySourceLanguage}
-              targetLanguage={dictionaryTargetLanguage}
-              targetLanguageOptions={targetLanguageOptions}
-              targetLanguageLabel={dictionaryTargetLanguageLabel}
-              onTargetLanguageChange={setDictionaryTargetLanguage}
-              onSwapLanguages={handleSwapLanguages}
-              swapLabel={dictionarySwapLanguagesLabel}
-              normalizeSourceLanguageFn={normalizeWordSourceLanguage}
-              normalizeTargetLanguageFn={normalizeWordTargetLanguage}
-              dictionaryActionBarProps={dictionaryActionBarProps}
-              hasDefinition={Boolean(entry)}
+            <BottomPanelSwitcher
+              mode={bottomPanelMode}
+              searchContent={
+                <ChatInput
+                  inputRef={inputRef}
+                  value={text}
+                  onChange={(event) => setText(event.target.value)}
+                  onSubmit={handleSend}
+                  onVoice={handleVoice}
+                  placeholder={chatInputPlaceholder}
+                  maxRows={5}
+                  sourceLanguage={dictionarySourceLanguage}
+                  sourceLanguageOptions={sourceLanguageOptions}
+                  sourceLanguageLabel={dictionarySourceLanguageLabel}
+                  onSourceLanguageChange={setDictionarySourceLanguage}
+                  targetLanguage={dictionaryTargetLanguage}
+                  targetLanguageOptions={targetLanguageOptions}
+                  targetLanguageLabel={dictionaryTargetLanguageLabel}
+                  onTargetLanguageChange={setDictionaryTargetLanguage}
+                  onSwapLanguages={handleSwapLanguages}
+                  swapLabel={dictionarySwapLanguagesLabel}
+                  normalizeSourceLanguageFn={normalizeWordSourceLanguage}
+                  normalizeTargetLanguageFn={normalizeWordTargetLanguage}
+                  onFocusChange={handleInputFocusChange}
+                />
+              }
+              actionsContent={
+                hasDefinition ? (
+                  <DictionaryActionPanel
+                    actionBarProps={dictionaryActionBarProps ?? {}}
+                    onRequestSearch={handleSearchButtonClick}
+                    searchButtonLabel={t?.returnToSearch || "切换到搜索输入"}
+                  />
+                ) : null
+              }
             />
             <ICP />
           </div>

--- a/website/src/features/dictionary-experience/components/BottomPanelSwitcher.jsx
+++ b/website/src/features/dictionary-experience/components/BottomPanelSwitcher.jsx
@@ -1,0 +1,26 @@
+/**
+ * 背景：
+ *  - DictionaryExperience 底部区域需在不同子视图间切换，之前直接在父组件内写条件渲染易引发状态膨胀。
+ * 目的：
+ *  - 提供一个极薄的切换容器，约束互斥渲染语义，便于未来在面板间插入过渡或动画策略。
+ * 关键决策与取舍：
+ *  - 采用组合模式，保持 searchContent 与 actionsContent 为纯节点，容器只负责选择；
+ *  - 预留 data-mode 属性，便于测试与样式钩子扩展，而非直接耦合到具体实现。
+ * 影响范围：
+ *  - DictionaryExperience 底部渲染结构及其测试定位。
+ * 演进与TODO：
+ *  - 若后续需要加入更多模式，可扩展 mode 枚举并在此集中处理。
+ */
+import PropTypes from "prop-types";
+
+export default function BottomPanelSwitcher({ mode, searchContent, actionsContent }) {
+  const content = mode === "actions" ? actionsContent : searchContent;
+
+  return <div data-mode={mode}>{content}</div>;
+}
+
+BottomPanelSwitcher.propTypes = {
+  mode: PropTypes.oneOf(["search", "actions"]).isRequired,
+  searchContent: PropTypes.node.isRequired,
+  actionsContent: PropTypes.node.isRequired,
+};

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
@@ -1,0 +1,67 @@
+/**
+ * 背景：
+ *  - 词典释义按钮组需要与搜索框共享一套视觉语言，但此前直接嵌入 ChatInput，导致职责混杂。
+ * 目的：
+ *  - 构建专用的动作面板组件，在保持 SearchBox 视觉样式的同时注入放大镜入口和工具栏。
+ * 关键决策与取舍：
+ *  - 通过 SearchBox 包裹整体结构，复用现有阴影与圆角 token，避免样式漂移；
+ *  - 放弃在此组件内管理状态，仅暴露按钮点击事件，由外部状态机驱动切换，保持纯粹性。
+ * 影响范围：
+ *  - DictionaryExperience 底部动作区的视觉与交互结构。
+ * 演进与TODO：
+ *  - 若需引入更多辅助按钮，可在左侧 slot 内扩展并复用相同的 aria 语义。
+ */
+import PropTypes from "prop-types";
+
+import SearchBox from "@/components/ui/SearchBox";
+import DictionaryEntryActionBar from "@/components/DictionaryEntryActionBar";
+import ThemeIcon from "@/components/ui/Icon";
+
+import styles from "./DictionaryActionPanel.module.css";
+
+export default function DictionaryActionPanel({
+  actionBarProps,
+  onRequestSearch,
+  searchButtonLabel,
+}) {
+  return (
+    <SearchBox
+      className={styles.panel}
+      role="group"
+      aria-label="释义操作区域"
+      data-testid="dictionary-action-panel"
+    >
+      <div className={styles.inner}>
+        <button
+          type="button"
+          className={styles["search-toggle"]}
+          onClick={onRequestSearch}
+          aria-label={searchButtonLabel}
+          title={searchButtonLabel}
+        >
+          <ThemeIcon name="search" width={18} height={18} />
+        </button>
+        <div className={styles["toolbar-wrapper"]}>
+          <DictionaryEntryActionBar
+            {...actionBarProps}
+            className={[styles.toolbar, actionBarProps.className]
+              .filter(Boolean)
+              .join(" ")}
+          />
+        </div>
+      </div>
+    </SearchBox>
+  );
+}
+
+DictionaryActionPanel.propTypes = {
+  actionBarProps: PropTypes.shape({
+    className: PropTypes.string,
+  }).isRequired,
+  onRequestSearch: PropTypes.func.isRequired,
+  searchButtonLabel: PropTypes.string,
+};
+
+DictionaryActionPanel.defaultProps = {
+  searchButtonLabel: "返回搜索",
+};

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -1,0 +1,66 @@
+.panel {
+  --padding-y: 0;
+  --slot-gap: 0;
+
+  display: flex;
+  width: 100%;
+}
+
+.inner {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--chat-input-bottom-gap, 12px);
+  padding-block: var(--chat-input-bottom-pad-y, 12px);
+  border-top: 1px solid var(--sb-divider, rgb(255 255 255 / 10%));
+  box-shadow: var(
+      --chat-input-bottom-shadow,
+      inset 0 1px 0 rgb(255 255 255 / 6%)
+    );
+}
+
+.search-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--chat-input-action-size, 40px);
+  height: var(--chat-input-action-size, 40px);
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--sb-text, #edeff2);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.search-toggle:hover {
+  background: color-mix(in srgb, var(--sb-surface, #0e1116) 85%, white 15%);
+}
+
+.search-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
+}
+
+.toolbar-wrapper {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.toolbar {
+  width: 100%;
+}
+
+@media (width <= 640px) {
+  .inner {
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .toolbar-wrapper {
+    width: 100%;
+  }
+}

--- a/website/src/features/dictionary-experience/hooks/__tests__/useBottomPanelState.test.ts
+++ b/website/src/features/dictionary-experience/hooks/__tests__/useBottomPanelState.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+
+import useBottomPanelState, {
+  PANEL_MODE_ACTIONS,
+  PANEL_MODE_SEARCH,
+} from "../useBottomPanelState";
+
+/**
+ * 测试目标：在存在释义且输入为空时自动回落至动作面板。
+ * 前置条件：hasDefinition=true，text=""。
+ * 步骤：
+ *  1) 渲染 Hook 并保持默认焦点状态（未聚焦）。
+ *  2) 触发 effect 观察 mode 变化。
+ * 断言：
+ *  - mode 切换为 PANEL_MODE_ACTIONS。
+ * 边界/异常：
+ *  - 当 hasDefinition 置为 false 时自动回到搜索模式。
+ */
+test("GivenDefinitionWithoutFocus_WhenEvaluating_ThenFallbackToActionsPanel", () => {
+  const { result, rerender } = renderHook(
+    ({ hasDefinition, text }) => useBottomPanelState({ hasDefinition, text }),
+    {
+      initialProps: { hasDefinition: true, text: "" },
+    },
+  );
+
+  expect(result.current.mode).toBe(PANEL_MODE_ACTIONS);
+
+  rerender({ hasDefinition: false, text: "" });
+
+  expect(result.current.mode).toBe(PANEL_MODE_SEARCH);
+});
+
+/**
+ * 测试目标：点击搜索按钮激活搜索模式并在聚焦后保持该状态。
+ * 前置条件：hasDefinition=true，text=空字符串。
+ * 步骤：
+ *  1) 主动调用 activateSearchMode。
+ *  2) 触发 handleFocusChange(true)。
+ * 断言：
+ *  - mode 维持在 PANEL_MODE_SEARCH。
+ * 边界/异常：
+ *  - 失焦后回落至动作模式。
+ */
+test("GivenManualSearchRequest_WhenFocusGained_ThenStayInSearchMode", () => {
+  const { result } = renderHook(() =>
+    useBottomPanelState({ hasDefinition: true, text: "" }),
+  );
+
+  act(() => {
+    result.current.activateSearchMode();
+    result.current.handleFocusChange(true);
+  });
+
+  expect(result.current.mode).toBe(PANEL_MODE_SEARCH);
+
+  act(() => {
+    result.current.handleFocusChange(false);
+  });
+
+  expect(result.current.mode).toBe(PANEL_MODE_ACTIONS);
+});
+
+/**
+ * 测试目标：滚动事件在存在释义时强制回退至动作面板。
+ * 前置条件：hasDefinition=true，先进入搜索模式。
+ * 步骤：
+ *  1) 通过 handleFocusChange(true) 进入搜索模式。
+ *  2) 调用 handleScrollEscape。
+ * 断言：
+ *  - mode 最终为 PANEL_MODE_ACTIONS。
+ * 边界/异常：
+ *  - 若 hasDefinition=false 不应切换（通过先验用例覆盖）。
+ */
+test("GivenScrollEscape_WhenDefinitionExists_ThenReturnToActionsMode", () => {
+  const { result } = renderHook(() =>
+    useBottomPanelState({ hasDefinition: true, text: "query" }),
+  );
+
+  act(() => {
+    result.current.handleFocusChange(true);
+  });
+
+  expect(result.current.mode).toBe(PANEL_MODE_SEARCH);
+
+  act(() => {
+    result.current.handleScrollEscape();
+  });
+
+  expect(result.current.mode).toBe(PANEL_MODE_ACTIONS);
+});

--- a/website/src/features/dictionary-experience/hooks/useBottomPanelState.ts
+++ b/website/src/features/dictionary-experience/hooks/useBottomPanelState.ts
@@ -1,0 +1,103 @@
+/**
+ * 背景：
+ *  - 词典体验底部面板需要在搜索输入与释义操作之间切换，原实现分散在视图组件中，状态难以追踪。
+ * 目的：
+ *  - 以单一 Hook 封装面板状态机，集中管理显隐条件与外部事件（焦点、滚动）的响应，便于复用与测试。
+ * 关键决策与取舍：
+ *  - 采用有限状态模式，仅维护 "search" 与 "actions" 两种模式，配合显式的事件处理函数，保持可预测性。
+ *  - 放弃在组件外部直接写 DOM，所有外部驱动（滚动/聚焦）通过语义化回调进入，保障抽象清晰。
+ * 影响范围：
+ *  - DictionaryExperience 底部面板的渲染逻辑与相关测试策略。
+ * 演进与TODO：
+ *  - 若后续需要新增模式（如语音录制面板），可在此扩展枚举与转换图并补充测试。
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+export const PANEL_MODE_SEARCH = "search" as const;
+export const PANEL_MODE_ACTIONS = "actions" as const;
+
+type PanelMode = typeof PANEL_MODE_SEARCH | typeof PANEL_MODE_ACTIONS;
+
+type UseBottomPanelStateParams = {
+  hasDefinition: boolean;
+  text: string;
+};
+
+type UseBottomPanelStateResult = {
+  mode: PanelMode;
+  isSearchMode: boolean;
+  isActionsMode: boolean;
+  handleFocusChange: (focused: boolean) => void;
+  activateSearchMode: () => void;
+  activateActionsMode: () => void;
+  handleScrollEscape: () => void;
+};
+
+const trimText = (value: string): string => value.trim();
+
+export default function useBottomPanelState({
+  hasDefinition,
+  text,
+}: UseBottomPanelStateParams): UseBottomPanelStateResult {
+  const [mode, setMode] = useState<PanelMode>(PANEL_MODE_SEARCH);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const latestHasDefinition = useRef(hasDefinition);
+
+  useEffect(() => {
+    latestHasDefinition.current = hasDefinition;
+  }, [hasDefinition]);
+
+  const evaluateActionsFallback = useCallback(() => {
+    if (!latestHasDefinition.current) {
+      return;
+    }
+    setMode(PANEL_MODE_ACTIONS);
+    setIsInputFocused(false);
+  }, []);
+
+  const handleFocusChange = useCallback(
+    (focused: boolean) => {
+      setIsInputFocused(focused);
+      if (focused) {
+        setMode(PANEL_MODE_SEARCH);
+        return;
+      }
+      evaluateActionsFallback();
+    },
+    [evaluateActionsFallback],
+  );
+
+  const activateSearchMode = useCallback(() => {
+    setMode(PANEL_MODE_SEARCH);
+  }, []);
+
+  const activateActionsMode = useCallback(() => {
+    evaluateActionsFallback();
+  }, [evaluateActionsFallback]);
+
+  const handleScrollEscape = useCallback(() => {
+    evaluateActionsFallback();
+  }, [evaluateActionsFallback]);
+
+  const normalizedText = useMemo(() => trimText(text), [text]);
+
+  useEffect(() => {
+    if (!hasDefinition) {
+      setMode(PANEL_MODE_SEARCH);
+      return;
+    }
+    if (!isInputFocused && normalizedText.length === 0) {
+      setMode(PANEL_MODE_ACTIONS);
+    }
+  }, [hasDefinition, isInputFocused, normalizedText]);
+
+  return {
+    mode,
+    isSearchMode: mode === PANEL_MODE_SEARCH,
+    isActionsMode: mode === PANEL_MODE_ACTIONS,
+    handleFocusChange,
+    activateSearchMode,
+    activateActionsMode,
+    handleScrollEscape,
+  };
+}


### PR DESCRIPTION
## Summary
- add a bottom panel state machine and switcher so the dictionary experience can swap between input and action views based on focus, scroll, and definition state
- extract the dictionary action toolbar into a dedicated SearchBox-styled panel with a magnifier shortcut and wire Layout scroll notifications
- simplify ChatInput behavior by removing embedded toolbar rendering, exposing focus callbacks, and updating accompanying styles and tests

## Testing
- npm run lint
- npm run lint:css
- npm test *(fails: Node.js heap out of memory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc106235188332899ea9326f34fa90