### PR TITLE
Refactor layout to support fixed docker structure

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -1,7 +1,21 @@
-.container {
+/**
+ * 背景：
+ *  - 旧布局采用多层容器并让 body/主区共同滚动，导致底部工具条与内容区之间互相遮挡。
+ * 目的：
+ *  - 构建 #app > #sidebar + #main(#content + #docker) 的固定布局，限定滚动发生在内容区。
+ * 关键决策与取舍：
+ *  - 通过 CSS 变量暴露侧边栏宽度与 docker 高度，便于拖拽/断点同步；
+ *  - 选用 fixed docker 搭配 backdrop，放弃 sticky 实现以规避移动端滚动兼容性问题。
+ * 影响范围：
+ *  - App 页面主体区域、底部搜索工具条、侧边栏拖拽宽度。
+ * 演进与TODO：
+ *  - 后续可将断点与 token 抽至主题配置，或拆分出独立的布局主题模块。
+ */
+
+.app {
   --layout-sidebar-min: 240px;
   --layout-sidebar-max: 420px;
-  --layout-sidebar-default: clamp(
+  --sidebar-w: clamp(
     var(--layout-sidebar-min),
     24vw,
     var(--layout-sidebar-max)
@@ -10,23 +24,26 @@
   --layout-content-padding-x: clamp(20px, 5vw, 48px);
   --layout-content-padding-top: clamp(24px, 5vw, 36px);
   --layout-content-padding-bottom: clamp(24px, 6vh, 36px);
+  --docker-h: 0px;
+  --docker-padding-y: clamp(16px, 4vw, 24px);
+  --docker-padding-x: clamp(20px, 5vw, 32px);
 
-  display: flex;
-  align-items: stretch;
+  position: relative;
   min-height: var(--vh);
+  width: 100%;
   background: var(--app-bg);
   color: var(--app-color);
-  position: relative;
-  overflow: hidden;
 }
 
 .resizer {
-  position: relative;
-  z-index: 2;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--sidebar-w) - 3px);
   width: 6px;
-  min-height: 100%;
   cursor: col-resize;
   touch-action: none;
+  z-index: 120;
   transition: background 0.2s ease;
 }
 
@@ -58,9 +75,9 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  flex: 1 1 auto;
+  align-items: stretch;
   min-height: var(--vh);
+  margin-left: var(--sidebar-w);
   background: var(--chat-window-bg);
   color: inherit;
   overflow: hidden;
@@ -71,7 +88,7 @@
   min-height: var(--bar-height);
   position: sticky;
   top: 0;
-  z-index: 3;
+  z-index: 65;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -138,17 +155,32 @@
     0 14px 24px color-mix(in srgb, var(--shadow-color) 18%, transparent);
 }
 
-.main-content {
+.content {
   position: relative;
-  z-index: 1;
   flex: 1 1 auto;
+  min-height: 0;
   width: 100%;
   display: flex;
   justify-content: center;
-  overflow: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-bottom: calc(var(--docker-h, 0px) + env(safe-area-inset-bottom));
 }
 
-.main-middle {
+.content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.content::-webkit-scrollbar-thumb {
+  background: color-mix(
+    in srgb,
+    var(--border-color) 32%,
+    transparent
+  );
+  border-radius: 6px;
+}
+
+.content-inner {
   flex: 1 1 auto;
   width: min(100%, var(--layout-content-max));
   padding: var(--layout-content-padding-top) var(--layout-content-padding-x)
@@ -160,72 +192,73 @@
   gap: clamp(24px, 4vw, 40px);
 }
 
-.main-bottom {
+.docker {
   position: fixed;
-  inset-inline: 0;
-  bottom: clamp(24px, 6vh, 40px);
+  right: 0;
+  bottom: 0;
+  left: var(--sidebar-w);
+  z-index: 70;
+  border-top: 1px solid
+    color-mix(in srgb, var(--border-color) 64%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--chat-window-bg) 92%,
+    transparent
+  );
+  backdrop-filter: blur(18px);
+  padding: var(--docker-padding-y) var(--docker-padding-x);
+  padding-bottom: calc(
+    var(--docker-padding-y) + env(safe-area-inset-bottom)
+  );
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.docker-inner {
+  width: min(100%, 960px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  width: 100%;
-  pointer-events: none;
-  z-index: 5;
-}
-
-.main-bottom-inner {
-  width: min(clamp(360px, 50vw, 960px), calc(100vw - 48px));
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  margin-inline: auto;
-  pointer-events: auto;
+  gap: 12px;
 }
 
 @media (width <= 900px) {
-  .container {
-    --layout-sidebar-default: var(--layout-sidebar-min);
+  .app {
+    --sidebar-w: 0px;
+    --layout-content-padding-x: clamp(16px, 6vw, 28px);
+    --layout-content-padding-top: clamp(24px, 6vw, 32px);
+    --layout-content-padding-bottom: clamp(24px, 8vw, 32px);
   }
 
   .resizer {
     display: none;
   }
 
-  .main-middle {
-    padding: clamp(24px, 6vw, 32px) clamp(16px, 6vw, 28px)
-      calc(160px + env(safe-area-inset-bottom, 0px));
-    gap: clamp(20px, 5vw, 28px);
+  .main {
+    margin-left: 0;
   }
 
-  .main-bottom {
-    position: static;
-    transform: none;
-    width: 100%;
-    padding: clamp(16px, 6vw, 24px) clamp(12px, 6vw, 28px);
+  .docker {
+    left: 0;
+    padding: clamp(18px, 6vw, 28px) clamp(16px, 6vw, 28px);
+    padding-bottom: calc(clamp(18px, 6vw, 28px) + env(safe-area-inset-bottom));
   }
 
-  .main-bottom-inner {
+  .docker-inner {
     width: 100%;
   }
 }
 
 @media (width <= 600px) {
-  .container {
-    display: block;
-    min-height: var(--vh);
+  .app {
+    --layout-content-padding-x: clamp(14px, 6vw, 24px);
+    --layout-content-padding-top: clamp(20px, 6vw, 28px);
   }
 
-  .main {
-    min-height: var(--vh);
-  }
-
-  .main-bottom {
-    padding: clamp(16px, 6vw, 24px);
-  }
-
-  .main-bottom-inner {
-    width: 100%;
+  .docker-inner {
+    gap: 10px;
   }
 }

--- a/website/src/components/Layout/index.jsx
+++ b/website/src/components/Layout/index.jsx
@@ -1,4 +1,26 @@
-import { useState, useRef, useMemo, useCallback, useEffect } from "react";
+/**
+ * 背景：
+ *  - 旧版 Layout 采用 main-middle/main-bottom 的多层容器，底部工具条与滚动上下文割裂，
+ *    导致搜索栏定位与内容滚动互相干扰。
+ * 目的：
+ *  - 实现“sidebar + main(content + docker)”的二层两区结构，固定 docker 于主区底部，
+ *    并确保滚动仅发生在内容区域。
+ * 关键决策与取舍：
+ *  - 以 CSS 变量暴露侧边栏宽度、底部高度，结合 ResizeObserver 同步 content padding，
+ *    兼顾响应式断点；
+ *  - 保留现有侧边栏抽屉逻辑，避免一次性替换导航体系。
+ * 影响范围：
+ *  - App 页面布局、Sidebar 尺寸同步、底部搜索/释义操作条。
+ * 演进与TODO：
+ *  - 后续可将断点阈值抽为配置，或将布局拆分为可测试的 Hooks。
+ */
+import {
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+  useEffect,
+} from "react";
 import PropTypes from "prop-types";
 import Sidebar from "@/components/Sidebar";
 import ThemeIcon from "@/components/ui/Icon";
@@ -17,7 +39,9 @@ function Layout({
   const containerRef = useRef(null);
   const sidebarRef = useRef(null);
   const resizeFrame = useRef(null);
-  const mainMiddleRef = useRef(null);
+  const contentRef = useRef(null);
+  const dockerRef = useRef(null);
+  const [dockerHeight, setDockerHeight] = useState(0);
 
   useEffect(() => {
     if (isMobile) {
@@ -90,15 +114,20 @@ function Layout({
   );
 
   const containerStyle = useMemo(() => {
-    if (!sidebarWidth || isMobile) return undefined;
-    return { "--layout-sidebar-width": `${Math.round(sidebarWidth)}px` };
-  }, [sidebarWidth, isMobile]);
+    const style = {
+      "--docker-h": `${dockerHeight}px`,
+    };
+    if (!isMobile && typeof sidebarWidth === "number") {
+      style["--sidebar-w"] = `${Math.round(sidebarWidth)}px`;
+    }
+    return style;
+  }, [dockerHeight, isMobile, sidebarWidth]);
 
   useEffect(() => {
     if (!onMainMiddleScroll) {
       return undefined;
     }
-    const node = mainMiddleRef.current;
+    const node = contentRef.current;
     if (!node) {
       return undefined;
     }
@@ -111,8 +140,30 @@ function Layout({
     };
   }, [onMainMiddleScroll]);
 
+  useEffect(() => {
+    const node = dockerRef.current;
+    if (!node || typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries?.[0];
+      if (!entry) return;
+      const nextHeight = Math.round(entry.contentRect.height);
+      setDockerHeight((prev) => (prev === nextHeight ? prev : nextHeight));
+    });
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return (
-    <div ref={containerRef} className={styles.container} style={containerStyle}>
+    <div
+      ref={containerRef}
+      id="app"
+      className={styles.app}
+      style={containerStyle}
+    >
       <Sidebar
         {...sidebarProps}
         open={sidebarOpen}
@@ -129,7 +180,7 @@ function Layout({
           onPointerDown={handlePointerDown}
         />
       ) : null}
-      <div className={styles.main}>
+      <main id="main" className={styles.main}>
         {isMobile ? (
           <div className={styles["main-top"]}>
             <button
@@ -142,17 +193,22 @@ function Layout({
             </button>
           </div>
         ) : null}
-        <div className={styles["main-content"]}>
-          <div ref={mainMiddleRef} className={styles["main-middle"]}>
-            {children}
-          </div>
+        <section
+          id="content"
+          ref={contentRef}
+          className={styles.content}
+        >
+          <div className={styles["content-inner"]}>{children}</div>
+        </section>
+        <div
+          id="docker"
+          ref={dockerRef}
+          className={styles.docker}
+          aria-label="底部工具条"
+        >
+          <div className={styles["docker-inner"]}>{bottomContent}</div>
         </div>
-        {bottomContent ? (
-          <div className={styles["main-bottom"]}>
-            <div className={styles["main-bottom-inner"]}>{bottomContent}</div>
-          </div>
-        ) : null}
-      </div>
+      </main>
     </div>
   );
 }

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -1,17 +1,33 @@
 /* stylelint-disable selector-class-pattern */
+
+/**
+ * 背景：
+ *  - 主布局升级为固定侧边栏 + 固定底栏，需要 Sidebar 改为脱离主滚动上下文。
+ * 目的：
+ *  - 将 sidebar 固定在视口左侧，并保持与 Layout 共享的宽度变量；移动端继续沿用抽屉动效。
+ * 关键决策与取舍：
+ *  - 采用 fixed + transform 方案，在移动端通过 mobile-open 类控制显隐，放弃 sticky 以避免
+ *    与 content 滚动冲突；
+ *  - 维持现有宽度变量，便于 Layout 拖拽逻辑与断点共同使用。
+ * 影响范围：
+ *  - Sidebar 定位与遮罩层次；Layout 侧边栏拖拽宽度。
+ * 演进与TODO：
+ *  - 可进一步抽象宽度/断点到主题 token，或支持折叠态导航图标模式。
+ */
 :where(.sidebar, .container) {
   width: var(--sidebar-w);
   min-width: var(--sidebar-w);
   max-width: var(--sidebar-w);
   height: var(--vh);
+  min-height: var(--vh);
   display: flex;
   flex-direction: column;
   color: var(--sidebar-color, var(--text));
   background: var(--sidebar-bg, var(--bg));
   border-right: 1px solid var(--sidebar-border-color, var(--border));
-  position: sticky;
-  top: 0;
-  align-self: start;
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 80;
   box-shadow: none;
   overflow: hidden;
 }
@@ -120,6 +136,13 @@
     width: min(82vw, 320px);
     min-width: min(82vw, 320px);
     max-width: min(82vw, 360px);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 999;
+  }
+
+  :where(.sidebar.mobile-open, .container.mobile-open) {
+    transform: translateX(0);
   }
 }
 

--- a/website/src/components/Sidebar/layout/SidebarLayout.jsx
+++ b/website/src/components/Sidebar/layout/SidebarLayout.jsx
@@ -35,6 +35,7 @@ const SidebarLayout = forwardRef(function SidebarLayout(
       ) : null}
       <aside
         ref={ref}
+        id="sidebar"
         data-testid="sidebar"
         className={`sidebar${isMobile ? (open ? " mobile-open" : "") : ""} ${styles.container}`}
       >

--- a/website/src/components/__tests__/Layout.test.jsx
+++ b/website/src/components/__tests__/Layout.test.jsx
@@ -1,0 +1,143 @@
+/* eslint-env jest */
+/**
+ * 背景：
+ *  - Layout 引入二层两区结构后需要新的快照以保证 DOM 层级稳定。
+ * 目的：
+ *  - 通过单测校验 #app/#sidebar/#main/#content/#docker 的存在与事件绑定。
+ * 关键决策与取舍：
+ *  - 采用模块级 mock 解耦 Sidebar/Icon 依赖，避免上下文耦合；
+ *  - 借助 ResizeObserver mock 驱动 docker 高度同步，放弃真实测量以提升稳定性。
+ * 影响范围：
+ *  - Layout 组件结构、滚动回调、docker 占位逻辑。
+ * 演进与TODO：
+ *  - 后续可覆盖移动端模式与 sidebar 拖拽逻辑。
+ */
+import React, { forwardRef } from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+class ResizeObserverMock {
+  constructor(callback) {
+    this.callback = callback;
+  }
+
+  observe() {
+    this.callback?.([{ contentRect: { height: 96 } }]);
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserverMock;
+
+jest.unstable_mockModule("@/components/Sidebar", () => ({
+  __esModule: true,
+  default: forwardRef(function SidebarStub(
+    { isMobile: _isMobile, open: _open, onClose: _onClose, ...rest },
+    ref,
+  ) {
+    return (
+      <aside
+        {...rest}
+        ref={ref}
+        id="sidebar"
+        data-testid="sidebar-stub"
+        style={{ width: "320px" }}
+      />
+    );
+  }),
+}));
+
+jest.unstable_mockModule("@/components/ui/Icon", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.unstable_mockModule("@/utils", () => ({
+  __esModule: true,
+  useIsMobile: () => false,
+}));
+
+const { default: Layout } = await import("@/components/Layout");
+
+afterAll(() => {
+  delete global.ResizeObserver;
+});
+
+describe("Layout", () => {
+  /**
+   * 测试目标：验证布局渲染出结构化分区并承载底部工具条。
+   * 前置条件：提供 Sidebar/Icon/ResizeObserver 的最小 mock。
+   * 步骤：
+   *  1) 渲染 Layout 并传入子内容与 docker 内容。
+   *  2) 查询结构性节点。
+   * 断言：
+   *  - 存在 #app、#sidebar、#main、#content、#docker。
+   *  - docker 内包含传入的底部内容。
+   * 边界/异常：
+   *  - bottomContent 为空时 docker 仍会渲染空容器（由后续用例覆盖）。
+   */
+  test("renders required structural regions", () => {
+    const { container } = render(
+      <Layout bottomContent={<span data-testid="dock-item">tools</span>}>
+        <div data-testid="content">Hello</div>
+      </Layout>,
+    );
+    expect(container.querySelector("#app")).not.toBeNull();
+    expect(container.querySelector("aside#sidebar")).not.toBeNull();
+    expect(container.querySelector("main#main")).not.toBeNull();
+    expect(container.querySelector("section#content")).not.toBeNull();
+    const docker = container.querySelector("div#docker");
+    expect(docker).not.toBeNull();
+    expect(docker.querySelector("[data-testid='dock-item']")).not.toBeNull();
+  });
+
+  /**
+   * 测试目标：验证滚动事件仅绑定在内容区并透传给回调。
+   * 前置条件：提供可观察的 onMainMiddleScroll mock。
+   * 步骤：
+   *  1) 渲染 Layout 并传入 onMainMiddleScroll。
+   *  2) 触发 content 的 scroll 事件。
+   * 断言：
+   *  - 回调收到滚动事件。
+   * 边界/异常：
+   *  - 未触发滚动时回调保持未调用状态。
+   */
+  test("invokes scroll handler on content scroll", () => {
+    const handleScroll = jest.fn();
+    const { container } = render(
+      <Layout onMainMiddleScroll={handleScroll}>
+        <div style={{ height: "200px" }} />
+      </Layout>,
+    );
+    const content = container.querySelector("#content");
+    expect(content).not.toBeNull();
+    fireEvent.scroll(content, { target: { scrollTop: 40 } });
+    expect(handleScroll).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 测试目标：验证在缺失底部内容时 docker 仍维持结构占位。
+   * 前置条件：无特殊前置，仅使用默认 mock。
+   * 步骤：
+   *  1) 渲染不传 bottomContent 的 Layout。
+   *  2) 查询 docker 节点。
+   * 断言：
+   *  - docker 节点存在且 aria-label 正确。
+   * 边界/异常：
+   *  - 后续若引入可折叠 docker 需扩展此断言。
+   */
+  test("renders docker container without content", () => {
+    const { container } = render(
+      <Layout>
+        <div />
+      </Layout>,
+    );
+    const docker = container.querySelector("#docker");
+    expect(docker).not.toBeNull();
+    expect(docker.getAttribute("aria-label")).toBe("底部工具条");
+    expect(docker?.textContent).toBe("");
+  });
+});

--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -97,7 +97,7 @@ export default function DictionaryExperience() {
         }}
         onMainMiddleScroll={handleMainScroll}
         bottomContent={
-          <div className="app-bottom">
+          <>
             <BottomPanelSwitcher
               mode={bottomPanelMode}
               searchContent={
@@ -135,7 +135,7 @@ export default function DictionaryExperience() {
               }
             />
             <ICP />
-          </div>
+          </>
         }
       >
         <div className={displayClassName}>

--- a/website/src/pages/App/App.css
+++ b/website/src/pages/App/App.css
@@ -8,10 +8,9 @@
   border-right: 1px solid var(--sidebar-border-color, var(--border));
   display: flex;
   flex-direction: column;
-  position: sticky;
-  top: 0;
-  align-self: start;
-  z-index: 1;
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 80;
   overflow: hidden;
 }
 
@@ -28,12 +27,11 @@
   width: min(100%, 960px);
   margin: 0 auto;
   padding: clamp(24px, 5vw, 32px) clamp(20px, 5vw, 28px)
-    clamp(140px, 22vh, 200px);
+    clamp(40px, 6vh, 56px);
   display: flex;
   justify-content: center;
   align-items: flex-start;
   color: var(--app-color);
-  overflow: auto;
 }
 
 .display-empty {
@@ -70,26 +68,14 @@
   font-family: var(--font-mono, monospace);
 }
 
-.app-bottom {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-
 @media (width <= 900px) {
   .sidebar {
-    position: fixed;
-    inset: 0 auto 0 0;
     width: min(82vw, 320px);
     min-width: min(82vw, 320px);
     max-width: min(82vw, 360px);
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 999;
-    border-right: 1px solid var(--sidebar-border-color, var(--border));
-    background: var(--sidebar-bg, var(--bg));
   }
 
   .sidebar.mobile-open {
@@ -99,7 +85,7 @@
   .display {
     width: 100%;
     padding: clamp(24px, 6vw, 32px) clamp(18px, 6vw, 28px)
-      clamp(160px, 30vh, 220px);
+      clamp(48px, 8vh, 72px);
   }
 
   .display-empty {
@@ -117,7 +103,4 @@
     padding: clamp(16px, 6vw, 22px);
   }
 
-  .app-bottom {
-    width: 100%;
-  }
 }


### PR DESCRIPTION
## Summary
- refactor the application layout to use the new #app/#sidebar/#main/#content/#docker structure with a measured docker height
- update sidebar and page styles to align with the fixed layout and remove legacy wrappers
- add layout unit tests covering structural regions and scroll handling

## Testing
- npm run lint
- npm run lint:css
- npm run test -- Layout

------
https://chatgpt.com/codex/tasks/task_e_68dc1af66cbc83329ab3eefdee1cd8fb