### PR TITLE
Adjust sidebar sidebar navigation states

### DIFF
--- a/website/src/components/Sidebar/NavItem.jsx
+++ b/website/src/components/Sidebar/NavItem.jsx
@@ -4,6 +4,18 @@ import { NavLink } from "react-router-dom";
 import ThemeIcon from "@/components/ui/Icon";
 import styles from "./NavItem.module.css";
 
+// 使用策略模式在运行时挑选交互风格，避免在组件内部散落条件判断并便于未来扩展更多变体。
+const INTERACTION_VARIANTS = {
+  accent: {
+    baseClass: "",
+    activeClass: styles.active,
+  },
+  flat: {
+    baseClass: styles.flat,
+    activeClass: styles["flat-active"],
+  },
+};
+
 const joinClassNames = (...tokens) => tokens.filter(Boolean).join(" ");
 
 function renderIcon(icon, label) {
@@ -31,10 +43,16 @@ const NavItem = forwardRef(function NavItem(
     onClick,
     type = "button",
     children = null,
+    variant = "accent",
     ...rest
   },
   ref,
 ) {
+  const variantStyles =
+    INTERACTION_VARIANTS[variant] || INTERACTION_VARIANTS.accent;
+  const baseVariantClass = variantStyles.baseClass;
+  const activeVariantClass = variantStyles.activeClass;
+
   const content = (
     <>
       {renderIcon(icon, typeof label === "string" ? label : undefined)}
@@ -54,10 +72,11 @@ const NavItem = forwardRef(function NavItem(
       joinClassNames(
         styles.item,
         toneClassName,
-        active ? styles.active : "",
+        baseVariantClass,
+        active ? activeVariantClass : "",
         className,
       ),
-    [active, className, toneClassName],
+    [active, baseVariantClass, activeVariantClass, className, toneClassName],
   );
 
   if (to) {
@@ -69,7 +88,8 @@ const NavItem = forwardRef(function NavItem(
           joinClassNames(
             styles.item,
             toneClassName,
-            isActive || active ? styles.active : "",
+            baseVariantClass,
+            isActive || active ? activeVariantClass : "",
             className,
           )
         }
@@ -123,6 +143,7 @@ NavItem.propTypes = {
   type: PropTypes.oneOf(["button", "submit", "reset"]),
   children: PropTypes.node,
   tone: PropTypes.oneOf(["default", "muted"]),
+  variant: PropTypes.oneOf(Object.keys(INTERACTION_VARIANTS)),
 };
 
 export default NavItem;

--- a/website/src/components/Sidebar/NavItem.module.css
+++ b/website/src/components/Sidebar/NavItem.module.css
@@ -106,3 +106,33 @@
 .muted.item[aria-current="page"] {
   color: var(--sidebar-color, var(--text));
 }
+
+.flat {
+  background: transparent;
+}
+
+.flat::before {
+  display: none;
+}
+
+.flat-active {
+  background: transparent;
+  color: var(--sidebar-color, var(--text));
+}
+
+.flat-active::before {
+  opacity: 0;
+  transform: scaleY(0.6);
+}
+
+.flat.item[aria-current="page"],
+.flat-active.item[aria-current="page"] {
+  background: transparent;
+  color: var(--sidebar-color, var(--text));
+}
+
+.flat.item[aria-current="page"]::before,
+.flat-active.item[aria-current="page"]::before {
+  opacity: 0;
+  transform: scaleY(0.6);
+}

--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -50,7 +50,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  padding: 8px 0;
+  padding: 8px 16px;
   overscroll-behavior: contain;
   scrollbar-width: thin;
   scrollbar-color: rgb(255 255 255 / 16%) transparent;

--- a/website/src/components/Sidebar/UserMenu/UserButton.module.css
+++ b/website/src/components/Sidebar/UserMenu/UserButton.module.css
@@ -7,7 +7,7 @@
   padding: 0 12px;
   border-radius: calc(var(--menu-radius) - 2px);
   border: 1px solid transparent;
-  background: color-mix(in srgb, var(--menu-bg) 72%, transparent);
+  background: transparent;
   color: var(--menu-text);
   cursor: pointer;
   transition:

--- a/website/src/components/Sidebar/__tests__/SidebarHeader.test.jsx
+++ b/website/src/components/Sidebar/__tests__/SidebarHeader.test.jsx
@@ -66,4 +66,24 @@ describe("SidebarHeader", () => {
     const activeButton = screen.getByTestId("sidebar-nav-dictionary");
     expect(activeButton).toHaveAttribute("aria-current", "page");
   });
+
+  /**
+   * 测试目标：头部导航应采用平铺交互变体以移除高亮边框。
+   * 前置条件：渲染包含激活项的头部导航列表。
+   * 步骤：
+   *  1) 渲染 SidebarHeader。
+   *  2) 获取任意一个导航按钮。
+   * 断言：
+   *  - 元素包含 flat 类且未包含 active 类（失败信息：头部导航仍使用高亮变体）。
+   * 边界/异常：
+   *  - 若未来允许自定义变体需更新断言，本用例仅覆盖默认头部行为。
+   */
+  test("Given header navigation When rendered Then uses flat variant", () => {
+    const items = createItems();
+    render(<SidebarHeader items={items} ariaLabel="Navigation" />);
+
+    const dictionaryButton = screen.getByTestId("sidebar-nav-dictionary");
+    expect(dictionaryButton).toHaveClass("flat");
+    expect(dictionaryButton).not.toHaveClass("active");
+  });
 });

--- a/website/src/components/Sidebar/header/SidebarHeader.jsx
+++ b/website/src/components/Sidebar/header/SidebarHeader.jsx
@@ -27,6 +27,7 @@ function SidebarHeader({ items, ariaLabel }) {
           label={item.label}
           active={item.active}
           onClick={item.onClick}
+          variant={item.variant || "flat"}
           data-testid={item.testId}
         />
       ))}


### PR DESCRIPTION
## Summary
- add a strategy-backed variant option to `NavItem` so the sidebar header renders flat buttons without accent highlights
- align the history list container padding with the header spacing for consistent layout rhythm
- clear the default background of the user dock trigger to avoid an always-on highlight state

## Testing
- npm run lint
- npm run lint:css
- npm run test -- SidebarHeader

------
https://chatgpt.com/codex/tasks/task_e_68dd499298608332a35857863aad321f