### PR TITLE
Refactor dictionary action panel layout

### DIFF
--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
@@ -24,6 +24,11 @@ export default function DictionaryActionPanel({
   onRequestSearch,
   searchButtonLabel,
 }) {
+  const { className: actionBarClassName, ...restActionBarProps } = actionBarProps;
+  const mergedActionBarClassName = [styles.toolbar, actionBarClassName]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <SearchBox
       className={styles.panel}
@@ -31,25 +36,19 @@ export default function DictionaryActionPanel({
       aria-label="释义操作区域"
       data-testid="dictionary-action-panel"
     >
-      <div className={styles.inner}>
-        <button
-          type="button"
-          className={styles["search-toggle"]}
-          onClick={onRequestSearch}
-          aria-label={searchButtonLabel}
-          title={searchButtonLabel}
-        >
-          <ThemeIcon name="search" width={18} height={18} />
-        </button>
-        <div className={styles["toolbar-wrapper"]}>
-          <DictionaryEntryActionBar
-            {...actionBarProps}
-            className={[styles.toolbar, actionBarProps.className]
-              .filter(Boolean)
-              .join(" ")}
-          />
-        </div>
-      </div>
+      <button
+        type="button"
+        className={styles["search-toggle"]}
+        onClick={onRequestSearch}
+        aria-label={searchButtonLabel}
+        title={searchButtonLabel}
+      >
+        <ThemeIcon name="search" width={18} height={18} />
+      </button>
+      <DictionaryEntryActionBar
+        {...restActionBarProps}
+        className={mergedActionBarClassName}
+      />
     </SearchBox>
   );
 }

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -1,22 +1,24 @@
 .panel {
-  --padding-y: 0;
-  --slot-gap: 0;
+  --padding-y: var(--chat-input-bottom-pad-y, 12px);
+  --slot-gap: var(--chat-input-bottom-gap, 12px);
 
   display: flex;
   width: 100%;
+  align-items: center;
+  flex-wrap: nowrap;
+  box-shadow:
+    var(--sb-shadow, 0 6px 20px rgb(0 0 0 / 25%)),
+    var(--chat-input-bottom-shadow, inset 0 1px 0 rgb(255 255 255 / 6%));
 }
 
-.inner {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: var(--chat-input-bottom-gap, 12px);
-  padding-block: var(--chat-input-bottom-pad-y, 12px);
-  border-top: 1px solid var(--sb-divider, rgb(255 255 255 / 10%));
-  box-shadow: var(
-      --chat-input-bottom-shadow,
-      inset 0 1px 0 rgb(255 255 255 / 6%)
-    );
+.panel::before {
+  content: "";
+  position: absolute;
+  inset-inline: var(--chat-input-bottom-divider-inset, 0);
+  top: 0;
+  height: 1px;
+  background: var(--sb-divider, rgb(255 255 255 / 10%));
+  pointer-events: none;
 }
 
 .search-toggle {
@@ -45,22 +47,19 @@
   box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
 }
 
-.toolbar-wrapper {
+.toolbar {
   flex: 1 1 auto;
   min-width: 0;
-}
-
-.toolbar {
   width: 100%;
 }
 
 @media (width <= 640px) {
-  .inner {
+  .panel {
     flex-wrap: wrap;
-    justify-content: space-between;
+    row-gap: var(--chat-input-bottom-gap, 12px);
   }
 
-  .toolbar-wrapper {
+  .toolbar {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- flatten `DictionaryActionPanel` so the search toggle and `DictionaryEntryActionBar` are direct `SearchBox` children while preserving aria semantics
- refresh the panel styles to reproduce the divider, gap tokens, and responsive flex behavior without the legacy wrapper

## Testing
- pnpm lint
- pnpm test *(fails: Node.js heap out of memory even with increased `--max-old-space-size`)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4e21a060833282d3a728a9da9f25