### PR TITLE
fix: align copy and refresh icon strokes

### DIFF
--- a/website/src/assets/icons/copy.svg
+++ b/website/src/assets/icons/copy.svg
@@ -1,1 +1,16 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M9 7.25C9 6.00736 10.0074 5 11.25 5H18.75C19.9926 5 21 6.00736 21 7.25V14.75C21 15.9926 19.9926 17 18.75 17H11.25C10.0074 17 9 15.9926 9 14.75V7.25Z" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><path d="M6.75 7H6C4.89543 7 4 7.89543 4 9V16.5C4 17.6046 4.89543 18.5 6 18.5H13.5C14.6046 18.5 15.5 17.6046 15.5 16.5V15.75" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path
+    d="M9 7.25C9 6.00736 10.0074 5 11.25 5H18.75C19.9926 5 21 6.00736 21 7.25V14.75C21 15.9926 19.9926 17 18.75 17H11.25C10.0074 17 9 15.9926 9 14.75V7.25Z"
+    stroke="currentColor"
+    stroke-width="1.4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M6.75 7H6C4.89543 7 4 7.89543 4 9V16.5C4 17.6046 4.89543 18.5 6 18.5H13.5C14.6046 18.5 15.5 17.6046 15.5 16.5V15.75"
+    stroke="currentColor"
+    stroke-width="1.4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/website/src/assets/icons/refresh.svg
+++ b/website/src/assets/icons/refresh.svg
@@ -1,1 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" aria-hidden="true" fill="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992V4.356M21.015 9.348a9 9 0 11-3.64-6.908"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" aria-hidden="true" fill="none">
+  <path
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M16.023 9.348h4.992V4.356M21.015 9.348a9 9 0 11-3.64-6.908"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- set the copy icon to rely on stroke rendering with explicit currentColor usage
- align the refresh icon fill and stroke settings with the outlined design expectations

## Testing
- npx prettier -w website/src/assets/icons/copy.svg website/src/assets/icons/refresh.svg *(fails: No parser could be inferred for the SVG assets)*
- npx prettier -w --parser=svg website/src/assets/icons/copy.svg website/src/assets/icons/refresh.svg *(fails: Couldn't resolve parser "svg")

------
https://chatgpt.com/codex/tasks/task_e_68dd4e24a684833280796cb5a926cc7a