### PR TITLE
Remove chevron icon from sidebar user button

### DIFF
--- a/website/src/components/Sidebar/UserMenu/UserButton.module.css
+++ b/website/src/components/Sidebar/UserMenu/UserButton.module.css
@@ -63,13 +63,3 @@
   gap: 4px;
 }
 
-.chevron {
-  margin-left: auto;
-  color: var(--menu-muted);
-  transition: transform 160ms ease;
-}
-
-.button[data-open="true"] .chevron {
-  transform: rotate(-180deg);
-  color: var(--menu-text);
-}

--- a/website/src/components/Sidebar/UserMenu/UserButton.tsx
+++ b/website/src/components/Sidebar/UserMenu/UserButton.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, KeyboardEvent, MouseEvent } from "react";
 import Avatar from "@/components/ui/Avatar";
-import ThemeIcon from "@/components/ui/Icon";
 import styles from "./UserButton.module.css";
 
 export interface UserButtonProps {
@@ -45,12 +44,6 @@ const UserButton = forwardRef<HTMLButtonElement, UserButtonProps>(
           <span className={styles.name}>{displayName || ""}</span>
           {planLabel ? <span className={styles.plan}>{planLabel}</span> : null}
         </span>
-        <ThemeIcon
-          name="chevron-up-down"
-          width={18}
-          height={18}
-          className={styles.chevron}
-        />
       </button>
     );
   },


### PR DESCRIPTION
## Summary
- remove the dropdown chevron icon from the sidebar user button per design request
- clean up the unused icon styles from the user button module stylesheet

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68dd512839308332ac4db1ff15cdc67e