### PR TITLE
Refactor dictionary toolbar integration

### DIFF
--- a/website/src/assets/icons/copy.svg
+++ b/website/src/assets/icons/copy.svg
@@ -1,15 +1,15 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
   <path
-    d="M9 7.25C9 6.00736 10.0074 5 11.25 5H18.75C19.9926 5 21 6.00736 21 7.25V14.75C21 15.9926 19.9926 17 18.75 17H11.25C10.0074 17 9 15.9926 9 14.75V7.25Z"
+    d="M10.25 5.5c0-1.3807 1.1193-2.5 2.5-2.5h4.5c1.3807 0 2.5 1.1193 2.5 2.5v4.5c0 1.3807-1.1193 2.5-2.5 2.5h-4.5c-1.3807 0-2.5-1.1193-2.5-2.5V5.5Z"
     stroke="currentColor"
-    stroke-width="1.4"
+    stroke-width="1.6"
     stroke-linecap="round"
     stroke-linejoin="round"
   />
   <path
-    d="M6.75 7H6C4.89543 7 4 7.89543 4 9V16.5C4 17.6046 4.89543 18.5 6 18.5H13.5C14.6046 18.5 15.5 17.6046 15.5 16.5V15.75"
+    d="M7.25 8.5h-1.5c-1.3807 0-2.5 1.1193-2.5 2.5v7c0 1.3807 1.1193 2.5 2.5 2.5h7c1.3807 0 2.5-1.1193 2.5-2.5v-1.5"
     stroke="currentColor"
-    stroke-width="1.4"
+    stroke-width="1.6"
     stroke-linecap="round"
     stroke-linejoin="round"
   />

--- a/website/src/assets/icons/refresh.svg
+++ b/website/src/assets/icons/refresh.svg
@@ -1,8 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" aria-hidden="true" fill="none">
-  <path
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <polyline
+    points="19.5 4 19.5 9 14.5 9"
     stroke="currentColor"
+    stroke-width="1.6"
     stroke-linecap="round"
     stroke-linejoin="round"
-    d="M16.023 9.348h4.992V4.356M21.015 9.348a9 9 0 11-3.64-6.908"
+  />
+  <polyline
+    points="4.5 20 4.5 15 9.5 15"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M6.32 7.08A7.2 7.2 0 0 1 17.5 4.47L19.5 6.5"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M17.68 16.92A7.2 7.2 0 0 1 6.5 19.53L4.5 17.5"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
   />
 </svg>

--- a/website/src/components/DictionaryEntryActionBar/index.jsx
+++ b/website/src/components/DictionaryEntryActionBar/index.jsx
@@ -3,7 +3,7 @@ import OutputToolbar from "@/components/OutputToolbar";
 import styles from "./DictionaryEntryActionBar.module.css";
 
 export default function DictionaryEntryActionBar(toolbarProps) {
-  const { className, ...restProps } = toolbarProps;
+  const { className, renderRoot, ...restProps } = toolbarProps;
   const toolbarClassName = [styles.toolbar, className]
     .filter(Boolean)
     .join(" ");
@@ -14,14 +14,17 @@ export default function DictionaryEntryActionBar(toolbarProps) {
       className={toolbarClassName}
       role="toolbar"
       ariaLabel="词条工具栏"
+      renderRoot={renderRoot}
     />
   );
 }
 
 DictionaryEntryActionBar.propTypes = {
   className: PropTypes.string,
+  renderRoot: PropTypes.func,
 };
 
 DictionaryEntryActionBar.defaultProps = {
   className: undefined,
+  renderRoot: undefined,
 };

--- a/website/src/components/OutputToolbar/__tests__/OutputToolbar.test.jsx
+++ b/website/src/components/OutputToolbar/__tests__/OutputToolbar.test.jsx
@@ -172,4 +172,37 @@ describe("OutputToolbar", () => {
     const shareButton = screen.getByRole("button", { name: "分享" });
     expect(shareButton).toBeDisabled();
   });
+
+  /**
+   * 验证 renderRoot 策略可替换默认容器，且仍保留 aria 语义。
+   */
+  test("supports custom root renderer", () => {
+    const renderRoot = jest.fn(
+      ({ children, className, role, ariaLabel, dataTestId }) => (
+        <section
+          data-testid="custom-toolbar"
+          data-original-testid={dataTestId}
+          data-role={role}
+          aria-label={ariaLabel}
+          className={`host ${className}`}
+        >
+          {children}
+        </section>
+      ),
+    );
+
+    render(
+      <OutputToolbar
+        term="hello"
+        versions={[{ id: "only" }]}
+        renderRoot={renderRoot}
+      />,
+    );
+
+    expect(renderRoot).toHaveBeenCalled();
+    const host = screen.getByTestId("custom-toolbar");
+    expect(host.dataset.role).toBe("toolbar");
+    expect(host.getAttribute("aria-label")).toBe("词条工具栏");
+    expect(host.className).toContain("entry__toolbar");
+  });
 });

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -47,19 +47,9 @@
   box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
 }
 
-.toolbar {
-  flex: 1 1 auto;
-  min-width: 0;
-  width: 100%;
-}
-
 @media (width <= 640px) {
   .panel {
     flex-wrap: wrap;
     row-gap: var(--chat-input-bottom-gap, 12px);
-  }
-
-  .toolbar {
-    width: 100%;
   }
 }

--- a/website/src/features/dictionary-experience/components/__tests__/DictionaryActionPanel.test.jsx
+++ b/website/src/features/dictionary-experience/components/__tests__/DictionaryActionPanel.test.jsx
@@ -14,9 +14,10 @@ jest.unstable_mockModule("@/components/ui/Icon", () => ({
 
 jest.unstable_mockModule("@/components/DictionaryEntryActionBar", () => ({
   __esModule: true,
-  default: ({ className }) => (
-    <div data-testid="dictionary-entry-action-bar" className={className} />
-  ),
+  default: ({ renderRoot }) =>
+    renderRoot({
+      children: <div data-testid="dictionary-entry-action-bar" />,
+    }),
 }));
 
 const DictionaryActionPanel = (await import("../DictionaryActionPanel.jsx"))


### PR DESCRIPTION
## Summary
- flatten the dictionary action panel so the search box directly hosts the toolbar controls via a renderRoot strategy
- allow OutputToolbar callers to customise the root container and cover the new hook-in with unit tests
- refresh the replay and copy SVG assets to match the updated visual style

## Testing
- npm run lint
- npm run lint:css
- npx prettier -w src/components/OutputToolbar/index.jsx src/components/OutputToolbar/__tests__/OutputToolbar.test.jsx src/components/DictionaryEntryActionBar/index.jsx src/features/dictionary-experience/components/DictionaryActionPanel.jsx src/features/dictionary-experience/components/DictionaryActionPanel.module.css src/features/dictionary-experience/components/__tests__/DictionaryActionPanel.test.jsx
- npm run test -- --runTestsByPath src/components/OutputToolbar/__tests__/OutputToolbar.test.jsx src/features/dictionary-experience/components/__tests__/DictionaryActionPanel.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68dd530301a88332879ba0706ec9039b