### PR TITLE
feat: align sidebar history entries with navigation layout

### DIFF
--- a/website/src/components/Sidebar/HistoryList.module.css
+++ b/website/src/components/Sidebar/HistoryList.module.css
@@ -9,3 +9,16 @@
 .item {
   width: 100%;
 }
+
+/*
+ * 调整历史词条的交互区域，使其与头部导航按钮保持统一宽度，并让文本与导航图标左缘对齐。
+ * 备注：这里的 3px 对应 NavItem 中指示条宽度，需配合 sidebar 变量保持一致。
+ */
+.entry-button {
+  width: calc(100% + var(--sidebar-pad-x) * 2);
+  margin-inline: calc(var(--sidebar-pad-x) * -1);
+  padding-left: calc(
+    var(--sidebar-pad-x) + 3px + var(--sidebar-icon-size) +
+      var(--sidebar-item-gap, 12px)
+  );
+}

--- a/website/src/components/Sidebar/HistoryListView.jsx
+++ b/website/src/components/Sidebar/HistoryListView.jsx
@@ -34,6 +34,7 @@ function HistoryListView({ items, onSelect, onNavigate }) {
                   onSelect(item);
                 }
               }}
+              className={styles.entryButton}
               ref={navigationBindings.ref}
               onKeyDown={navigationBindings.onKeyDown}
             />

--- a/website/src/components/Sidebar/NavItem.module.css
+++ b/website/src/components/Sidebar/NavItem.module.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 12px;
+  gap: var(--sidebar-item-gap, 12px);
   height: var(--sidebar-item-h);
   padding: 0 var(--sidebar-pad-x);
   padding-left: calc(var(--sidebar-pad-x) + 3px);

--- a/website/src/components/Sidebar/__tests__/HistoryListView.test.jsx
+++ b/website/src/components/Sidebar/__tests__/HistoryListView.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { jest } from "@jest/globals";
+import styles from "../HistoryList.module.css";
 
 const loadHistory = jest.fn();
 
@@ -41,7 +42,11 @@ jest.unstable_mockModule("@/context", () => ({
     t: { searchHistory: "历史" },
     lang: "zh",
   }),
-  useTheme: () => ({ theme: "light", setTheme: jest.fn(), resolvedTheme: "light" }),
+  useTheme: () => ({
+    theme: "light",
+    setTheme: jest.fn(),
+    resolvedTheme: "light",
+  }),
 }));
 
 const { default: HistoryListView } = await import("../HistoryListView.jsx");
@@ -59,7 +64,7 @@ describe("HistoryListView", () => {
    *  2) 查询具有 listbox 语义的容器与按钮。
    * 断言：
    *  - 存在 role 为 listbox 的元素。
-   *  - 每个词条渲染为可点击按钮。
+   *  - 每个词条渲染为可点击按钮，并继承对齐样式类。
    * 边界/异常：
    *  - 如导航函数返回空对象亦应安全渲染。
    */
@@ -74,8 +79,13 @@ describe("HistoryListView", () => {
     render(<HistoryListView items={items} onNavigate={onNavigate} />);
 
     expect(screen.getByRole("listbox")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "alpha" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "beta" })).toBeInTheDocument();
+    const firstButton = screen.getByRole("button", { name: "alpha" });
+    const secondButton = screen.getByRole("button", { name: "beta" });
+
+    expect(firstButton).toBeInTheDocument();
+    expect(secondButton).toBeInTheDocument();
+    expect(firstButton).toHaveClass(styles.entryButton);
+    expect(secondButton).toHaveClass(styles.entryButton);
     expect(onNavigate).toHaveBeenCalledTimes(items.length);
   });
 

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -34,6 +34,7 @@
   --sidebar-gap-section: 12px;
   --sidebar-icon-size: 18px;
   --sidebar-accent: #96a0ff;
+  --sidebar-item-gap: 12px;
 
   /* popover metrics */
   --popover-w: 304px;


### PR DESCRIPTION
## Summary
- align sidebar history entry buttons with the navigation header width to keep highlights consistent
- introduce a shared sidebar gap token and reuse it for nav item spacing and history entry indentation
- cover the new alignment class with a unit test to guard regression

## Testing
- npm run lint -- --fix
- npx stylelint "src/**/*.css" --fix
- npm test -- HistoryListView

------
https://chatgpt.com/codex/tasks/task_e_68dd5663e12c83328d63a70e85bafcb4