### PR TITLE
feat: unify toolbar icon buttons

### DIFF
--- a/website/src/components/OutputToolbar/OutputToolbar.module.css
+++ b/website/src/components/OutputToolbar/OutputToolbar.module.css
@@ -41,6 +41,15 @@
   --toolbar-icon-opacity: 0.84;
   --toolbar-icon-opacity-hover: 1;
   --toolbar-icon-opacity-disabled: 0.46;
+  --toolbar-button-size: 36px;
+  --toolbar-button-opacity-base: var(--toolbar-icon-opacity);
+  --toolbar-button-opacity-hover: var(--toolbar-icon-opacity-hover);
+  --toolbar-button-opacity-disabled: var(--toolbar-icon-opacity-disabled);
+  --toolbar-button-focus-ring-color: color-mix(
+    in srgb,
+    var(--accent-color) 35%,
+    transparent
+  );
   --toolbar-nav-color: color-mix(
     in srgb,
     var(--color-text-secondary) 82%,
@@ -71,43 +80,46 @@
 }
 
 .tool-button {
+  --tool-button-opacity-base: var(--toolbar-button-opacity-base);
+  --tool-button-opacity-hover: var(--toolbar-button-opacity-hover);
+  --tool-button-opacity-disabled: var(--toolbar-button-opacity-disabled);
+  --tool-button-focus-ring-color: var(--toolbar-button-focus-ring-color);
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: var(--toolbar-button-size);
+  height: var(--toolbar-button-size);
   border: none;
-  border-radius: var(--radius-lg, 12px);
+  border-radius: 50%;
+  padding: 0;
   background: none;
   color: var(--toolbar-icon-color);
-  opacity: var(--toolbar-icon-opacity);
+  opacity: var(--tool-button-opacity-base);
   cursor: pointer;
-  transition:
-    color 0.2s ease,
-    opacity 0.2s ease,
-    transform 0.2s ease;
+  transition: opacity 0.2s ease;
 }
 
 .tool-button:hover,
 .tool-button:focus-visible {
-  opacity: var(--toolbar-icon-opacity-hover);
-  color: var(--toolbar-icon-color-hover);
-  transform: translateY(-1px);
+  opacity: var(--tool-button-opacity-hover);
 }
 
 .tool-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent-color) 35%, transparent);
+  outline: 2px solid var(--tool-button-focus-ring-color);
   outline-offset: 2px;
 }
 
 .tool-button:disabled {
   color: var(--toolbar-icon-color-disabled);
-  opacity: var(--toolbar-icon-opacity-disabled);
+  opacity: var(--tool-button-opacity-disabled);
   cursor: not-allowed;
-  transform: none;
 }
 
 .tool-button[data-active="true"] {
+  --tool-button-opacity-base: var(--tool-button-opacity-hover);
+
   color: var(--toolbar-icon-color-active);
-  opacity: var(--toolbar-icon-opacity-hover);
 }
 
 .tool-button-replay {
@@ -169,18 +181,24 @@
 
 /* stylelint-disable selector-class-pattern */
 :global(.entry__tool-btn) {
+  --tool-button-opacity-base: var(--toolbar-button-opacity-base, 0.84);
+  --tool-button-opacity-hover: var(--toolbar-button-opacity-hover, 1);
+  --tool-button-opacity-disabled: var(--toolbar-button-opacity-disabled, 0.46);
+  --tool-button-focus-ring-color: var(--toolbar-button-focus-ring-color, var(--input-dark-ring, #3a3f46));
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 10px;
+  width: var(--toolbar-button-size, 36px);
+  height: var(--toolbar-button-size, 36px);
+  border: none;
+  border-radius: 50%;
+  padding: 0;
+  background: none;
   cursor: pointer;
   user-select: none;
-  background: none;
-  transition:
-    color 0.15s ease,
-    transform 0.1s ease;
+  opacity: var(--tool-button-opacity-base);
+  transition: opacity 0.2s ease;
 }
 
 :global(.entry__tool-btn svg),
@@ -189,23 +207,23 @@
   height: 18px;
 }
 
-:global(.entry__tool-btn:hover) {
-  background: none;
-}
-
-:global(.entry__tool-btn:active) {
-  transform: scale(0.96);
+:global(.entry__tool-btn:hover),
+:global(.entry__tool-btn:focus-visible) {
+  opacity: var(--tool-button-opacity-hover);
 }
 
 :global(.entry__tool-btn:focus-visible) {
-  outline: 2px solid var(--input-dark-ring, #3a3f46);
+  outline: 2px solid var(--tool-button-focus-ring-color);
   outline-offset: 2px;
-  border-radius: 12px;
+}
+
+:global(.entry__tool-btn:disabled) {
+  opacity: var(--tool-button-opacity-disabled);
+  cursor: not-allowed;
 }
 
 :global(.entry__pager .entry__tool-btn) {
-  width: 34px;
-  height: 34px;
+  --toolbar-button-size: 34px;
 }
 /* stylelint-enable selector-class-pattern */
 

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
@@ -17,6 +17,7 @@ import { useMemo, useCallback } from "react";
 import SearchBox from "@/components/ui/SearchBox";
 import DictionaryEntryActionBar from "@/components/DictionaryEntryActionBar";
 import ThemeIcon from "@/components/ui/Icon";
+import toolbarStyles from "@/components/OutputToolbar/OutputToolbar.module.css";
 
 import styles from "./DictionaryActionPanel.module.css";
 
@@ -33,6 +34,26 @@ export default function DictionaryActionPanel({
   const panelClassName = useMemo(
     () => [styles.panel, actionBarClassName].filter(Boolean).join(" "),
     [actionBarClassName],
+  );
+  const searchToggleClassName = useMemo(
+    /**
+     * 意图：复用 OutputToolbar 的圆形图标按钮基类，并在此处覆写尺寸/不透明度变量，
+     *       保证词典入口按钮与工具栏动作按钮视觉一致。
+     * 输入：无外部依赖，仅取静态样式引用。
+     * 输出：组合后的类名字符串。
+     * 流程：过滤空值后拼接，保证 className 稳定。
+     * 错误处理：均为静态依赖，无异常分支。
+     * 复杂度：O(1)。
+     */
+    () =>
+      [
+        toolbarStyles["tool-button"],
+        "entry__tool-btn",
+        styles["search-toggle"],
+      ]
+        .filter(Boolean)
+        .join(" "),
+    [],
   );
   const toolbarRootRenderer = useCallback(
     /**
@@ -59,7 +80,7 @@ export default function DictionaryActionPanel({
     >
       <button
         type="button"
-        className={styles["search-toggle"]}
+        className={searchToggleClassName}
         onClick={onRequestSearch}
         aria-label={searchButtonLabel}
         title={searchButtonLabel}

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -1,6 +1,9 @@
 .panel {
   --padding-y: var(--chat-input-bottom-pad-y, 12px);
   --slot-gap: var(--chat-input-bottom-gap, 12px);
+  --dictionary-panel-action-size: var(--chat-input-action-size, 40px);
+  --dictionary-panel-icon-size: 18px;
+  --dictionary-panel-icon-color: var(--sb-text, #edeff2);
 
   display: flex;
   width: 100%;
@@ -22,29 +25,22 @@
 }
 
 .search-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--chat-input-action-size, 40px);
-  height: var(--chat-input-action-size, 40px);
-  border-radius: 50%;
-  border: none;
-  background: transparent;
-  color: var(--sb-text, #edeff2);
-  cursor: pointer;
-  transition:
-    background-color 0.2s ease,
-    color 0.2s ease,
-    box-shadow 0.2s ease;
+  --toolbar-button-size: var(--dictionary-panel-action-size);
+  --tool-button-opacity-base: 0.7;
+  --tool-button-opacity-hover: 1;
+  --tool-button-opacity-disabled: 0.32;
+  --tool-button-focus-ring-color: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 16%));
+  --toolbar-icon-color: var(--dictionary-panel-icon-color);
+  --toolbar-icon-color-disabled: color-mix(
+    in srgb,
+    var(--dictionary-panel-icon-color) 40%,
+    transparent
+  );
 }
 
-.search-toggle:hover {
-  background: color-mix(in srgb, var(--sb-surface, #0e1116) 85%, white 15%);
-}
-
-.search-toggle:focus-visible {
-  outline: none;
-  box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
+.search-toggle :global(svg) {
+  width: var(--dictionary-panel-icon-size);
+  height: var(--dictionary-panel-icon-size);
 }
 
 @media (width <= 640px) {


### PR DESCRIPTION
## Summary
- align OutputToolbar icon buttons with the TTS control by adopting circular hit areas, opacity-based states, and shared focus ring variables
- expose dictionary action panel variables so the search toggle can reuse the shared tool-button styling
- wire the dictionary action panel button to the OutputToolbar base class to keep class combinations consistent

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68dd5d1ec82083328bfb9cb244e254d1