### PR TITLE
Align search experience tokens with semantic themes

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -34,7 +34,7 @@
   justify-content: space-between;
   gap: var(--chat-input-bottom-gap, 12px);
   padding-block: var(--chat-input-bottom-pad-y, 12px);
-  border-top: 1px solid var(--sb-divider, rgb(255 255 255 / 10%));
+  border-top: 1px solid var(--sb-divider);
   box-shadow: var(
       --chat-input-bottom-shadow,
       inset 0 1px 0 rgb(255 255 255 / 6%)
@@ -78,8 +78,8 @@
   padding-inline: var(--seg-pad-x, 20px);
   gap: var(--seg-arrow-gap, 12px);
   border-radius: var(--seg-r, 22px);
-  background: var(--sb-seg, #141b24);
-  color: var(--sb-text, #edeff2);
+  background: var(--sb-seg);
+  color: var(--sb-text);
   font-size: var(--seg-font-size, 14px);
   font-weight: var(--seg-font-weight, 600);
   letter-spacing: var(--seg-letter-space, 0.04em);
@@ -96,13 +96,11 @@
    * 交互取舍：通过细致描边保留悬停反馈，避免背景覆盖导致的视觉层级混淆；
    * 若未来需要增强对比，可调整 --seg-hover-outline 的透明度而非改动底色。
    */
-  box-shadow: inset 0 0 0 1px var(--seg-hover-outline, rgb(255 255 255 / 16%));
+  box-shadow: inset 0 0 0 1px var(--seg-hover-outline);
 }
 
 .language-shell:focus-within {
-  box-shadow:
-    var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%)),
-    0 0 0 1px rgb(255 255 255 / 6%);
+  box-shadow: var(--ring-focus), 0 0 0 1px var(--sb-stroke);
 }
 
 .language-select-wrapper {
@@ -138,15 +136,12 @@
    * 交互取舍：采用文字色微调强化状态感，同时保持透明背景以减少分段噪声。
    * 可通过 --seg-hover-foreground 定制不同主题下的可访问对比度。
    */
-  color: var(
-    --seg-hover-foreground,
-    color-mix(in srgb, var(--sb-text) 88%, white 12%)
-  );
+  color: var(--seg-hover-foreground);
 }
 
 .language-trigger:focus-visible {
   outline: none;
-  box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
+  box-shadow: var(--ring-focus);
 }
 
 .language-trigger-content {
@@ -192,12 +187,16 @@
 }
 
 .language-swap:hover {
-  background: color-mix(in srgb, var(--sb-seg) 85%, white 15%);
+  background: color-mix(
+    in srgb,
+    var(--sb-seg) 85%,
+    var(--sb-inner-highlight) 15%
+  );
 }
 
 .language-swap:focus-visible {
   outline: none;
-  box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
+  box-shadow: var(--ring-focus);
 }
 
 .language-swap:active {
@@ -217,18 +216,18 @@
   margin: 0;
   border: none;
   background: transparent;
-  color: var(--sb-text, #edeff2);
+  color: var(--sb-text);
   font-size: var(--ph-size, 16px);
   font-weight: var(--ph-weight, 500);
   line-height: 1.5;
   letter-spacing: 0.01em;
   resize: none;
   outline: none;
-  caret-color: var(--sb-icon, #edeff2);
+  caret-color: var(--sb-icon);
 }
 
 .textarea::placeholder {
-  color: var(--sb-muted, #9fa7b3);
+  color: var(--sb-muted);
 }
 
 
@@ -243,9 +242,9 @@
   height: var(--btn-action, 44px);
   border: none;
   border-radius: 999px;
-  background: var(--sb-cta, #fff);
-  color: var(--sb-cta-icon, #0e1116);
-  box-shadow: var(--sb-cta-shadow, 0 10px 30px rgb(0 0 0 / 30%));
+  background: var(--sb-cta);
+  color: var(--sb-cta-icon);
+  box-shadow: var(--sb-cta-shadow);
   cursor: pointer;
   transition:
     box-shadow 0.2s ease,
@@ -254,14 +253,12 @@
 }
 
 .action-button:hover {
-  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
+  box-shadow: var(--sb-cta-shadow-hover);
 }
 
 .action-button:focus-visible {
   outline: none;
-  box-shadow:
-    var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%)),
-    var(--sb-cta-shadow, 0 10px 30px rgb(0 0 0 / 30%));
+  box-shadow: var(--ring-focus), var(--sb-cta-shadow);
 }
 
 .action-button:active {
@@ -275,7 +272,11 @@
 }
 
 .action-button-voice[aria-pressed="true"] {
-  background: color-mix(in srgb, var(--sb-cta) 85%, black 15%);
+  background: color-mix(
+    in srgb,
+    var(--sb-cta) 85%,
+    var(--sb-cta-icon) 15%
+  );
 }
 
 .action-button-dot {
@@ -283,7 +284,7 @@
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: var(--sb-cta-icon, #0e1116);
+  background: var(--sb-cta-icon);
 }
 
 .action-button-icon {
@@ -313,13 +314,12 @@
   flex-direction: column;
   gap: 4px;
   border-radius: var(--sb-menu-radius, 16px);
-  background: var(--menu-bg, #11161e);
-  border: 1px solid var(--menu-border, rgb(255 255 255 / 10%));
-  box-shadow: var(--sb-menu-shadow, 0 18px 44px rgb(0 0 0 / 45%));
+  background: var(--menu-bg);
+  border: 1px solid var(--menu-border);
+  box-shadow: var(--sb-menu-shadow);
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: var(--menu-scroll-thumb, #2c3440)
-    var(--menu-scroll-track, #1b2026);
+  scrollbar-color: var(--menu-scroll-thumb) var(--menu-scroll-track);
   opacity: 0;
   transform: translateY(4px) scale(0.98);
   transform-origin: top center;
@@ -338,17 +338,17 @@
 }
 
 .language-menu::-webkit-scrollbar-track {
-  background: var(--menu-scroll-track, #1b2026);
+  background: var(--menu-scroll-track);
   border-radius: 8px;
 }
 
 .language-menu::-webkit-scrollbar-thumb {
-  background: var(--menu-scroll-thumb, #2c3440);
+  background: var(--menu-scroll-thumb);
   border-radius: 8px;
 }
 
 .language-menu::-webkit-scrollbar-thumb:hover {
-  background: var(--menu-scroll-thumb-hover, #354050);
+  background: var(--menu-scroll-thumb-hover);
 }
 
 .language-menu-item {
@@ -367,7 +367,7 @@
   border: none;
   border-radius: 12px;
   background: transparent;
-  color: var(--menu-name-color, #c6ccd7);
+  color: var(--menu-name-color);
   font-size: var(--sb-font-sm, 15px);
   font-weight: 500;
   text-align: left;
@@ -380,22 +380,19 @@
 .language-menu-button:hover,
 .language-menu-button:focus-visible,
 .language-menu-button[data-active="true"] {
-  background: var(
-    --menu-hover,
-    color-mix(in srgb, var(--sb-inner) 88%, white 12%)
-  );
+  background: var(--menu-hover);
   outline: none;
 }
 
 .language-option-code {
-  color: var(--menu-code-color, #f1f4f8);
+  color: var(--menu-code-color);
   font-weight: 700;
   letter-spacing: var(--sb-code-letter-spacing, 0.08em);
   text-transform: uppercase;
 }
 
 .language-option-name {
-  color: var(--menu-name-color, #c6ccd7);
+  color: var(--menu-name-color);
   font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -406,7 +403,7 @@
   justify-self: end;
   display: inline-flex;
   align-items: center;
-  color: var(--menu-check-color, #d9dee7);
+  color: var(--menu-check-color);
   opacity: 0;
   transition: opacity 0.15s ease;
 }

--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -8,10 +8,10 @@
   padding-inline: var(--sb-pad-x, 20px);
   gap: var(--slot-gap, var(--sb-gap, 16px));
   border-radius: var(--sb-r, 28px);
-  background: var(--sb-surface, #0e1116);
-  color: var(--sb-text, #edeff2);
-  outline: 1px solid var(--sb-stroke, rgb(255 255 255 / 6%));
-  box-shadow: var(--sb-shadow, 0 6px 20px rgb(0 0 0 / 25%));
+  background: var(--sb-surface);
+  color: var(--sb-text);
+  outline: 1px solid var(--sb-stroke);
+  box-shadow: var(--sb-shadow);
   line-height: 1.5;
   box-sizing: border-box;
   transition:
@@ -22,18 +22,13 @@
 }
 
 .search-box:hover {
-  background: var(
-    --sb-bg-hover,
-    color-mix(in srgb, var(--sb-surface) 94%, white 6%)
-  );
-  outline-color: var(--sb-border-active, rgb(255 255 255 / 12%));
+  background: var(--sb-bg-hover);
+  outline-color: var(--sb-border-active);
 }
 
 .search-box:focus-within {
-  outline-color: var(--sb-border-active, rgb(255 255 255 / 12%));
-  box-shadow:
-    var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%)),
-    var(--sb-shadow, 0 6px 20px rgb(0 0 0 / 25%));
+  outline-color: var(--sb-border-active);
+  box-shadow: var(--ring-focus), var(--sb-shadow);
 }
 
 .search-box :global(button),

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -6,8 +6,7 @@
   width: 100%;
   align-items: center;
   flex-wrap: nowrap;
-  box-shadow:
-    var(--sb-shadow, 0 6px 20px rgb(0 0 0 / 25%)),
+  box-shadow: var(--sb-shadow),
     var(--chat-input-bottom-shadow, inset 0 1px 0 rgb(255 255 255 / 6%));
 }
 
@@ -17,7 +16,7 @@
   inset-inline: var(--chat-input-bottom-divider-inset, 0);
   top: 0;
   height: 1px;
-  background: var(--sb-divider, rgb(255 255 255 / 10%));
+  background: var(--sb-divider);
   pointer-events: none;
 }
 
@@ -30,7 +29,7 @@
   border-radius: 50%;
   border: none;
   background: transparent;
-  color: var(--sb-text, #edeff2);
+  color: var(--sb-text);
   cursor: pointer;
   transition:
     background-color 0.2s ease,
@@ -39,12 +38,16 @@
 }
 
 .search-toggle:hover {
-  background: color-mix(in srgb, var(--sb-surface, #0e1116) 85%, white 15%);
+  background: color-mix(
+    in srgb,
+    var(--sb-surface) 85%,
+    var(--sb-inner-highlight) 15%
+  );
 }
 
 .search-toggle:focus-visible {
   outline: none;
-  box-shadow: var(--ring-focus, 0 0 0 2px rgb(255 255 255 / 8%));
+  box-shadow: var(--ring-focus);
 }
 
 @media (width <= 640px) {

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -134,6 +134,7 @@
   --btn-gap: 12px;
   --ring-focus: 0 0 0 2px rgb(255 255 255 / 8%);
   --sb-cta-shadow: 0 10px 30px rgb(0 0 0 / 30%);
+  --sb-cta-shadow-hover: 0 12px 32px rgb(0 0 0 / 32%);
 
   /* settings dialog */
   --settings-dialog-width-md: 640px;
@@ -154,4 +155,112 @@
   --settings-dialog-navigation-width: 240px;
   --settings-dialog-gap-sm: 16px;
   --settings-dialog-gap-md: 24px;
+}
+
+/*
+ * 背景：SearchBox 与 ChatInput 依赖 --sb-* 令牌，需与语义色系统联动，支持浅色与系统主题。
+ * 取舍：通过在 data-theme 作用域内覆写关键色彩，避免重复定义具体色值，保留暗色默认声明。
+ */
+:root[data-theme="light"],
+:root[data-theme="system"] {
+  --sb-surface: color-mix(in srgb, var(--color-surface-alt) 88%, white 12%);
+  --sb-inner: color-mix(in srgb, var(--color-surface-alt) 92%, white 8%);
+  --sb-seg: color-mix(in srgb, var(--color-surface-alt) 82%, white 18%);
+  --sb-stroke: color-mix(in srgb, var(--border-color) 65%, transparent 35%);
+  --sb-divider: color-mix(in srgb, var(--border-color) 45%, transparent 55%);
+  --sb-text: var(--color-text);
+  --sb-muted: color-mix(in srgb, var(--color-text) 55%, transparent 45%);
+  --sb-icon: var(--color-text);
+  --sb-cta: color-mix(in srgb, var(--color-text) 6%, white 94%);
+  --sb-cta-icon: var(--color-text);
+  --sb-inner-highlight: color-mix(in srgb, var(--color-text) 8%, transparent);
+  --sb-ring: 0 0 0 var(--sb-ring-width, 2px)
+    color-mix(in srgb, var(--border-color) 35%, transparent 65%);
+  --sb-shadow: 0 18px 44px color-mix(in srgb, var(--shadow-color) 55%, transparent 45%);
+  --sb-shadow-soft: 0 12px 28px
+    color-mix(in srgb, var(--shadow-color) 45%, transparent 55%);
+  --sb-menu-shadow: 0 22px 50px
+    color-mix(in srgb, var(--shadow-color) 60%, transparent 40%);
+  --sb-bg-hover: color-mix(
+    in srgb,
+    var(--sb-surface) 92%,
+    var(--sb-inner-highlight) 8%
+  );
+  --ring-focus: 0 0 0 var(--sb-ring-width, 2px)
+    color-mix(in srgb, var(--border-color) 40%, transparent 60%);
+  --seg-hover-outline: color-mix(in srgb, var(--border-color) 40%, transparent 60%);
+  --seg-hover-foreground: color-mix(in srgb, var(--color-text) 80%, transparent 20%);
+  --menu-bg: color-mix(in srgb, var(--color-surface-alt) 95%, white 5%);
+  --menu-border: color-mix(in srgb, var(--border-color) 60%, transparent 40%);
+  --menu-hover: color-mix(in srgb, var(--color-surface-alt) 85%, white 15%);
+  --menu-code-color: color-mix(in srgb, var(--color-text) 92%, transparent 8%);
+  --menu-name-color: color-mix(in srgb, var(--color-text) 82%, transparent 18%);
+  --menu-check-color: color-mix(in srgb, var(--color-text) 78%, transparent 22%);
+  --menu-scroll-track: color-mix(in srgb, var(--color-surface-alt) 60%, transparent 40%);
+  --menu-scroll-thumb: color-mix(in srgb, var(--color-surface-alt) 80%, transparent 20%);
+  --menu-scroll-thumb-hover: color-mix(
+    in srgb,
+    var(--menu-scroll-thumb) 70%,
+    var(--color-text) 30%
+  );
+  --sb-send-bg: color-mix(in srgb, var(--color-surface-alt) 94%, var(--color-text) 6%);
+  --sb-send-color: var(--color-text);
+  --sb-caret: color-mix(in srgb, var(--color-text) 55%, transparent 45%);
+  --chip-bg: color-mix(in srgb, var(--color-surface-alt) 90%, transparent 10%);
+  --chip-bg-hover: color-mix(in srgb, var(--color-surface-alt) 82%, white 18%);
+  --chip-text: color-mix(in srgb, var(--color-text) 88%, transparent 12%);
+  --sb-scroll-track: color-mix(in srgb, var(--color-surface-alt) 55%, transparent 45%);
+  --sb-scroll-thumb: color-mix(in srgb, var(--color-surface-alt) 80%, transparent 20%);
+  --sb-cta-shadow: 0 14px 40px color-mix(in srgb, var(--shadow-color) 45%, transparent 55%);
+  --sb-cta-shadow-hover: 0 18px 44px
+    color-mix(in srgb, var(--shadow-color) 50%, transparent 50%);
+}
+
+/*
+ * 适配：暗色主题（含系统模式下的 prefers-color-scheme: dark）需回退原生夜间配方。
+ */
+:root.dark,
+:root[data-theme="dark"] {
+  --sb-surface: #0e1116;
+  --sb-inner: #11161e;
+  --sb-seg: #141b24;
+  --sb-stroke: rgb(255 255 255 / 6%);
+  --sb-divider: rgb(255 255 255 / 10%);
+  --sb-text: #edeff2;
+  --sb-muted: #9fa7b3;
+  --sb-icon: #edeff2;
+  --sb-cta: #fff;
+  --sb-cta-icon: #0e1116;
+  --sb-inner-highlight: rgb(255 255 255 / 12%);
+  --sb-ring: 0 0 0 2px rgb(255 255 255 / 8%);
+  --sb-shadow: 0 6px 20px rgb(0 0 0 / 25%);
+  --sb-shadow-soft: 0 4px 16px rgb(0 0 0 / 22%);
+  --sb-menu-shadow: 0 18px 44px rgb(0 0 0 / 45%);
+  --sb-bg-hover: color-mix(in srgb, var(--sb-surface) 94%, white 6%);
+  --ring-focus: 0 0 0 2px rgb(255 255 255 / 8%);
+  --seg-hover-outline: rgb(255 255 255 / 16%);
+  --seg-hover-foreground: color-mix(in srgb, var(--sb-text) 88%, white 12%);
+  --menu-bg: var(--sb-inner);
+  --menu-border: color-mix(in srgb, var(--sb-stroke) 80%, black 20%);
+  --menu-hover: color-mix(in srgb, var(--sb-inner) 88%, white 12%);
+  --menu-code-color: #f1f4f8;
+  --menu-name-color: #c6ccd7;
+  --menu-check-color: #d9dee7;
+  --menu-scroll-track: color-mix(in srgb, var(--sb-inner) 70%, transparent);
+  --menu-scroll-thumb: color-mix(in srgb, var(--sb-inner) 20%, white 12%);
+  --menu-scroll-thumb-hover: color-mix(
+    in srgb,
+    var(--menu-scroll-thumb) 70%,
+    white 30%
+  );
+  --sb-send-bg: rgb(255 255 255 / 92%);
+  --sb-send-color: #0b0d11;
+  --sb-caret: #99a6b5;
+  --chip-bg: #252b33;
+  --chip-bg-hover: #2b323c;
+  --chip-text: #d5dbe6;
+  --sb-scroll-track: color-mix(in srgb, var(--sb-inner) 35%, transparent);
+  --sb-scroll-thumb: color-mix(in srgb, var(--sb-inner) 65%, transparent);
+  --sb-cta-shadow: 0 10px 30px rgb(0 0 0 / 30%);
+  --sb-cta-shadow-hover: 0 12px 32px rgb(0 0 0 / 32%);
 }


### PR DESCRIPTION
## Summary
- map search experience variables to the light/system semantic palette and add a dark override to keep existing recipes intact
- refactor the SearchBox, ChatInput, and DictionaryActionPanel styles to rely on theme tokens for hover, focus, and action states

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68dd5b1877b483328d73c5a5e10d41ee