### PR TITLE
Align chat input layout with horizontal grid structure

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -11,62 +11,106 @@
 }
 
 /*
- * 结构说明：SearchBox 作为外层容器保持水平 padding，这里重置为纵向布局，
- * 通过上下分区承载 textarea 与操作栏，便于未来扩展更多状态信息。
+ * 结构说明：SearchBox 维持统一的视觉壳层，此处通过 grid 划分语言、分隔符、文本与动作槽位。
+ *  - 桌面端：四列横向排列，并以 column-gap 继承 searchbox 的节奏感。
+ *  - 窄屏：降级为单列栈结构，divider 退化为横向描边，完全移除 flex-wrap 带来的换行抖动。
  */
 .input-surface {
   --padding-y: 0;
   --slot-gap: 0;
 
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns:
+    auto
+    var(--chat-input-divider-width, 1px)
+    minmax(0, 1fr)
+    auto;
+  grid-template-areas: "language divider text action";
   align-items: stretch;
-  gap: 0;
+  column-gap: var(
+    --chat-input-inline-gap,
+    var(--chat-input-bottom-gap, 12px)
+  );
 }
 
-.input-surface-top {
-  padding-block: var(--chat-input-top-pad-y, 16px);
+.input-surface[data-language-visible="false"] {
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas: "text action";
 }
 
-.input-surface-bottom {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--chat-input-bottom-gap, 12px);
-  padding-block: var(--chat-input-bottom-pad-y, 12px);
-  border-top: 1px solid var(--sb-divider);
-  box-shadow: var(
-      --chat-input-bottom-shadow,
-      inset 0 1px 0 rgb(255 255 255 / 6%)
-    );
-}
-
-.input-bottom-left {
-  flex: 1 1 auto;
+.language-slot {
+  grid-area: language;
   display: flex;
   align-items: center;
   min-width: 0;
+  padding-block: var(--chat-input-bottom-pad-y, 12px);
 }
 
-.input-bottom-right {
-  flex: 0 0 auto;
+.language-slot[data-visible="false"] {
+  display: none;
+}
+
+.input-divider {
+  grid-area: divider;
+  width: var(--chat-input-divider-width, 1px);
+  background: var(--chat-input-divider-color, var(--sb-divider));
+  border-radius: 999px;
+  align-self: stretch;
+}
+
+.input-surface[data-language-visible="false"] .input-divider {
+  display: none;
+}
+
+.text-slot {
+  grid-area: text;
   display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-block: var(--chat-input-top-pad-y, 16px);
+  min-width: 0;
+}
+
+.action-slot {
+  grid-area: action;
+  display: flex;
+  align-items: center;
   justify-content: flex-end;
+  padding-block: var(--chat-input-bottom-pad-y, 12px);
 }
 
 @media (width <= 640px) {
-  .input-surface-bottom {
-    flex-wrap: wrap;
-    row-gap: var(--chat-input-bottom-gap, 12px);
+  .input-surface {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "text"
+      "divider"
+      "language"
+      "action";
+    row-gap: var(
+      --chat-input-mobile-gap,
+      var(--chat-input-bottom-gap, 12px)
+    );
   }
 
-  .input-bottom-left {
-    width: 100%;
+  .input-surface[data-language-visible="false"] {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "text"
+      "action";
   }
 
-  .input-bottom-right {
+  .input-divider {
     width: 100%;
-    justify-content: flex-end;
+    height: var(--chat-input-divider-width, 1px);
+  }
+
+  .input-surface[data-language-visible="false"] .input-divider {
+    display: none;
+  }
+
+  .language-slot {
+    padding-block-start: 0;
   }
 }
 

--- a/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
@@ -71,18 +71,19 @@ test("GivenStandardProps_WhenRenderingView_ThenMatchSnapshot", () => {
 });
 
 /**
- * 测试目标：当语言区隐藏时，底部仍保持空容器并维持语义化标记。
+ * 测试目标：当语言区隐藏时，网格属性与语义标记应正确折叠。
  * 前置条件：languageControls.isVisible=false。
  * 步骤：
- *  1) 渲染组件并读取 data-mode 属性。
- *  2) 断言左侧容器为空。
+ *  1) 渲染组件并读取 data-language-visible 属性。
+ *  2) 断言语言槽位与分隔符均被折叠。
  * 断言：
- *  - data-mode 恒为 "language"。
- *  - input-bottom-left 不包含子节点。
+ *  - data-language-visible === "false"。
+ *  - language-slot 不包含子节点并具有 data-visible="false"。
+ *  - divider 在此场景下被移除，避免冗余列。
  * 边界/异常：
- *  - 行为不依赖额外道具，确保视图层职责收敛。
+ *  - 折叠逻辑纯展示层处理，不依赖额外行为。
  */
-test("GivenLanguageControlsHidden_WhenRendering_ThenRenderEmptyShell", () => {
+test("GivenLanguageControlsHidden_WhenRendering_ThenCollapseLanguageSlot", () => {
   const formRef = createRef();
   const onSubmit = jest.fn();
   const { container } = render(
@@ -119,8 +120,14 @@ test("GivenLanguageControlsHidden_WhenRendering_ThenRenderEmptyShell", () => {
     />,
   );
 
-  const bottom = container.querySelector("[data-mode='language']");
-  expect(bottom).not.toBeNull();
-  const leftSlot = container.querySelector(`.${"input-bottom-left"}`);
-  expect(leftSlot?.childElementCount ?? 0).toBe(0);
+  const surface = container.querySelector(`.${"input-surface"}`);
+  expect(surface?.getAttribute("data-language-visible")).toBe("false");
+
+  const languageSlot = container.querySelector(`.${"language-slot"}`);
+  expect(languageSlot).not.toBeNull();
+  expect(languageSlot?.getAttribute("data-visible")).toBe("false");
+  expect(languageSlot?.childElementCount ?? 0).toBe(0);
+
+  const divider = container.querySelector(`.${"input-divider"}`);
+  expect(divider?.getAttribute("data-visible")).toBe("false");
 });

--- a/website/src/components/ui/ChatInput/__tests__/__snapshots__/ActionInputView.test.jsx.snap
+++ b/website/src/components/ui/ChatInput/__tests__/__snapshots__/ActionInputView.test.jsx.snap
@@ -8,11 +8,96 @@ exports[`GivenStandardProps_WhenRenderingView_ThenMatchSnapshot 1`] = `
     <div
       aria-label="dictionary search"
       class="search-box input-surface"
+      data-language-visible="true"
       data-testid="searchbar"
       role="search"
     >
       <div
-        class="input-surface-top"
+        class="language-slot"
+        data-visible="true"
+      >
+        <div
+          aria-label="源语言 → 目标语言"
+          class="language-shell"
+          role="group"
+        >
+          <div
+            class="language-select-wrapper"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-label="源语言"
+              class="language-trigger"
+              data-open="false"
+              data-variant="source"
+              title="中文"
+              type="button"
+            >
+              <span
+                class="language-trigger-content"
+              >
+                <span
+                  class="language-trigger-code"
+                >
+                  ZH
+                </span>
+                <span
+                  class="language-trigger-label"
+                  data-visible="false"
+                >
+                  中文
+                </span>
+              </span>
+            </button>
+          </div>
+          <button
+            aria-label="交换语向"
+            class="language-swap"
+            title="交换语向"
+            type="button"
+          >
+            →
+          </button>
+          <div
+            class="language-select-wrapper"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-label="目标语言"
+              class="language-trigger"
+              data-open="false"
+              data-variant="target"
+              title="英文"
+              type="button"
+            >
+              <span
+                class="language-trigger-content"
+              >
+                <span
+                  class="language-trigger-code"
+                >
+                  EN
+                </span>
+                <span
+                  class="language-trigger-label"
+                  data-visible="false"
+                >
+                  英文
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <span
+        aria-hidden="true"
+        class="input-divider"
+        data-visible="true"
+      />
+      <div
+        class="text-slot"
       >
         <div
           class="core-input"
@@ -33,103 +118,20 @@ exports[`GivenStandardProps_WhenRenderingView_ThenMatchSnapshot 1`] = `
         </div>
       </div>
       <div
-        class="input-surface-bottom"
-        data-mode="language"
+        class="action-slot"
       >
-        <div
-          class="input-bottom-left"
+        <button
+          aria-label="发送"
+          class="action-button action-button-send"
+          type="button"
         >
-          <div
-            aria-label="源语言 → 目标语言"
-            class="language-shell"
-            role="group"
-          >
-            <div
-              class="language-select-wrapper"
-            >
-              <button
-                aria-expanded="false"
-                aria-haspopup="menu"
-                aria-label="源语言"
-                class="language-trigger"
-                data-open="false"
-                data-variant="source"
-                title="中文"
-                type="button"
-              >
-                <span
-                  class="language-trigger-content"
-                >
-                  <span
-                    class="language-trigger-code"
-                  >
-                    ZH
-                  </span>
-                  <span
-                    class="language-trigger-label"
-                    data-visible="false"
-                  >
-                    中文
-                  </span>
-                </span>
-              </button>
-            </div>
-            <button
-              aria-label="交换语向"
-              class="language-swap"
-              title="交换语向"
-              type="button"
-            >
-              →
-            </button>
-            <div
-              class="language-select-wrapper"
-            >
-              <button
-                aria-expanded="false"
-                aria-haspopup="menu"
-                aria-label="目标语言"
-                class="language-trigger"
-                data-open="false"
-                data-variant="target"
-                title="英文"
-                type="button"
-              >
-                <span
-                  class="language-trigger-content"
-                >
-                  <span
-                    class="language-trigger-code"
-                  >
-                    EN
-                  </span>
-                  <span
-                    class="language-trigger-label"
-                    data-visible="false"
-                  >
-                    英文
-                  </span>
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-        <div
-          class="input-bottom-right"
-        >
-          <button
-            aria-label="发送"
-            class="action-button action-button-send"
-            type="button"
-          >
-            <span
-              aria-hidden="true"
-              class="action-button-icon"
-              data-icon-name="paper-airplane"
-              style="mask: url(file-mock) center / contain no-repeat; background-color: currentcolor;"
-            />
-          </button>
-        </div>
+          <span
+            aria-hidden="true"
+            class="action-button-icon"
+            data-icon-name="paper-airplane"
+            style="mask: url(file-mock) center / contain no-repeat; background-color: currentcolor;"
+          />
+        </button>
       </div>
     </div>
   </form>

--- a/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
+++ b/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
@@ -27,10 +27,28 @@ function ActionInputView({
   const { isVisible, props: languageProps } = languageControls;
   const shouldRenderLanguageControls = isVisible;
 
+  const languageVisibility = shouldRenderLanguageControls ? "true" : "false";
+
   return (
     <form {...formProps} className={styles["input-wrapper"]}>
-      <SearchBox className={styles["input-surface"]}>
-        <div className={styles["input-surface-top"]}>
+      <SearchBox
+        className={styles["input-surface"]}
+        data-language-visible={languageVisibility}
+      >
+        <div
+          className={styles["language-slot"]}
+          data-visible={languageVisibility}
+        >
+          {shouldRenderLanguageControls ? (
+            <LanguageControls {...languageProps} />
+          ) : null}
+        </div>
+        <span
+          className={styles["input-divider"]}
+          aria-hidden="true"
+          data-visible={languageVisibility}
+        />
+        <div className={styles["text-slot"]}>
           <div className={styles["core-input"]}>
             <textarea
               {...restTextareaProps}
@@ -46,15 +64,8 @@ function ActionInputView({
             />
           </div>
         </div>
-        <div className={styles["input-surface-bottom"]} data-mode="language">
-          <div className={styles["input-bottom-left"]}>
-            {shouldRenderLanguageControls ? (
-              <LanguageControls {...languageProps} />
-            ) : null}
-          </div>
-          <div className={styles["input-bottom-right"]}>
-            <ActionButton {...actionButtonProps} />
-          </div>
+        <div className={styles["action-slot"]}>
+          <ActionButton {...actionButtonProps} />
         </div>
       </SearchBox>
     </form>


### PR DESCRIPTION
## Summary
- restructure ActionInputView to expose dedicated language, divider, text, and action slots for SearchBox consumers
- refresh ChatInput styles to use a responsive grid/flex hybrid, providing consistent tokens and removing wrap side-effects
- update ActionInputView tests and snapshots to assert the new markup and language toggle behaviour

## Testing
- npm run lint
- npm run lint:css
- npm run test -- ActionInputView.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68dd6bfc818483328647bc15cdcb984b