### PR TITLE
Ensure Markdown renderer containers use border-box sizing

### DIFF
--- a/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
+++ b/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
@@ -1,3 +1,9 @@
+.section,
+.summary,
+.body {
+  box-sizing: border-box;
+}
+
 .section {
   margin-block: 16px;
   border-radius: var(--radius-lg, 14px);


### PR DESCRIPTION
## Summary
- ensure the Markdown renderer section, summary, and body containers opt into border-box sizing so their padding no longer causes horizontal overflow

## Testing
- npm run lint
- npm run lint:css
- npm run format *(fails: Missing script "format")*

------
https://chatgpt.com/codex/tasks/task_e_68dd78c1ad148332ab82a0626b90af02