### PR TITLE
Adjust dictionary entry layout and fix user menu dependencies

### DIFF
--- a/website/src/components/Sidebar/UserMenu/UserMenu.tsx
+++ b/website/src/components/Sidebar/UserMenu/UserMenu.tsx
@@ -106,15 +106,33 @@ function UserMenu({
     INITIAL_SUBMENU_STATE,
   );
   const [placement, setPlacement] = useState<"up" | "down">("up");
+  const {
+    help,
+    helpCenter,
+    releaseNotes,
+    reportBug,
+    shortcuts,
+    shortcutsDescription,
+    termsPolicies,
+    downloadApps,
+    settings,
+    logout,
+  } = labels;
 
   const supportItems = useMemo<SubmenuLinkItem[]>(() => {
+    const labelMap: Partial<Record<HelpLabelKey, string | undefined>> = {
+      helpCenter,
+      releaseNotes,
+      reportBug,
+      shortcuts,
+      termsPolicies,
+      downloadApps,
+    };
+
     return HELP_ITEMS.map<SubmenuLinkItem>((item) => {
-      const labelKey = item.labelKey as HelpLabelKey & keyof UserMenuProps["labels"];
-      const rawLabel = labels[labelKey];
-      const label =
-        item.key === "shortcuts"
-          ? labels.shortcuts
-          : rawLabel ?? labels.help;
+      const labelKey = item.labelKey as HelpLabelKey;
+      const rawLabel = labelMap[labelKey];
+      const label = item.key === "shortcuts" ? shortcuts : rawLabel ?? help;
       if (item.key === "shortcuts") {
         return {
           id: item.key,
@@ -132,14 +150,14 @@ function UserMenu({
       };
     });
   }, [
-    labels.help,
-    labels.helpCenter,
-    labels.releaseNotes,
-    labels.reportBug,
-    labels.shortcuts,
-    labels.termsPolicies,
-    labels.downloadApps,
+    downloadApps,
+    help,
+    helpCenter,
     onOpenShortcuts,
+    releaseNotes,
+    reportBug,
+    shortcuts,
+    termsPolicies,
   ]);
 
   const menuItems = useMemo<MenuItem[]>(() => {
@@ -148,7 +166,7 @@ function UserMenu({
         kind: "action",
         id: "settings",
         icon: "cog-6-tooth",
-        label: labels.settings,
+        label: settings,
         onSelect: () => onOpenSettings("general"),
       },
     ];
@@ -157,8 +175,8 @@ function UserMenu({
       kind: "submenu",
       id: "help",
       icon: "question-mark-circle",
-      label: labels.help,
-      description: labels.shortcutsDescription,
+      label: help,
+      description: shortcutsDescription,
       items: supportItems,
     };
 
@@ -170,18 +188,18 @@ function UserMenu({
       kind: "action",
       id: "logout",
       icon: "arrow-right-on-rectangle",
-      label: labels.logout,
+      label: logout,
       onSelect: onOpenLogout,
     });
 
     return items;
   }, [
-    labels.help,
-    labels.logout,
-    labels.settings,
-    labels.shortcutsDescription,
+    help,
+    logout,
     onOpenLogout,
     onOpenSettings,
+    settings,
+    shortcutsDescription,
     supportItems,
   ]);
 

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntry.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntry.module.css
@@ -1,7 +1,13 @@
 .dictionary-entry {
   width: auto;
-  margin: 0 2cm;
-  padding: 20px 0;
+
+  /*
+   * 保持词条内容在中心对齐，去除固定 2cm 外边距以适配 Markdown 折叠块；
+   * 通过水平内边距吸收横向留白，避免超出内容区域。
+   */
+  margin: 0 auto;
+  padding: 0 20px;
+  max-width: var(--layout-content-max, 100%);
   text-align: justify;
   text-align-last: left;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- center the dictionary entry container, switch to horizontal padding, and respect the layout content width token
- destructure user menu labels so memo dependencies stay stable while keeping shortcut handling intact

## Testing
- npm run lint
- npm run lint:css
- npm run format *(fails: Missing script "format")*


------
https://chatgpt.com/codex/tasks/task_e_68dd78c1ffe483329818052c52ba8e0f