### PR TITLE
Align SearchBox hover styling with default state

### DIFF
--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -22,8 +22,7 @@
 }
 
 .search-box:hover {
-  background: var(--sb-bg-hover);
-  outline-color: var(--sb-border-active);
+  box-shadow: var(--sb-shadow-hover, var(--sb-shadow));
 }
 
 .search-box:focus-within {


### PR DESCRIPTION
## Summary
- align the SearchBox hover state with its default background and outline while leaving room for subtle elevation tokens

## Testing
- npx eslint --fix .
- npx stylelint "src/**/*.{css,scss}" --fix
- npx prettier -w src/components/ui/SearchBox/SearchBox.module.css

------
https://chatgpt.com/codex/tasks/task_e_68dd7d3734808332a11c2f1fdeeb7230