### PR TITLE
style: add spacing before dictionary panel comment

### DIFF
--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -16,6 +16,7 @@
   --dictionary-panel-action-size: var(--chat-input-action-size, 40px);
   --dictionary-panel-icon-size: 18px;
   --dictionary-panel-icon-color: var(--sb-text);
+
   /*
    * 背景：原先通过 ::before 伪元素绘制顶部 1px 分隔线，但在深色背景下造成强对比。
    * 取舍：引入可配置的阴影层，沿用现有阴影令牌，既保持层级又能按需复用旧变量。


### PR DESCRIPTION
## Summary
- insert an empty line between the dictionary panel icon color variable and the subsequent comment block to satisfy comment-empty-line-before stylelint rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd7dabfdac8332884f73ad5a4c8ac6