### PR TITLE
refactor: align send button assets with reusable airplane icon

### DIFF
--- a/website/src/assets/buttons/send-button-dark.svg
+++ b/website/src/assets/buttons/send-button-dark.svg
@@ -1,11 +1,21 @@
-<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_44_27)">
-<circle cx="512" cy="512" r="512" fill="white"/>
-<circle cx="512" cy="512" r="256" fill="#121212"/>
-</g>
-<defs>
-<clipPath id="clip0_44_27">
-<rect width="1024" height="1024" fill="white"/>
-</clipPath>
-</defs>
+<!--
+  背景：
+    - ChatInput 的发送按钮在暗色主题下同样需要依赖 currentColor，以保证与亮色主题一致的符号语言。
+  目的：
+    - 提供 manifest 中 send-button/dark 令牌的矢量实现，确保暗色按钮沿用统一的纸飞机轮廓。
+  与 paper-airplane.svg 的关系：
+    - 与 icons/paper-airplane.svg 复用相同路径与填充策略。
+    - 维持独立文件是为兼容生成脚本对明暗态的拆分，后续若引入别名，可合并到通用图标资源。
+  关键决策与取舍：
+    - 移除旧版实心底色，避免主题色被固定，确保按钮颜色完全由样式控制。
+  演进与 TODO：
+    - 当 send-button 令牌迁移至单一资源时，请同步调整 icon manifest 生成逻辑以清理重复文件。
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 18 18"
+  aria-hidden="true"
+  fill="currentColor"
+>
+  <path d="M2.25 15.75 16.5 9 2.25 2.25l4.5 6-4.5 7.5Z" />
 </svg>

--- a/website/src/assets/buttons/send-button-light.svg
+++ b/website/src/assets/buttons/send-button-light.svg
@@ -1,11 +1,21 @@
-<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_44_19)">
-<circle cx="512" cy="512" r="512" fill="#121212"/>
-<circle cx="512" cy="512" r="256" fill="white"/>
-</g>
-<defs>
-<clipPath id="clip0_44_19">
-<rect width="1024" height="1024" fill="white"/>
-</clipPath>
-</defs>
+<!--
+  背景：
+    - ChatInput 的发送按钮需要与通用纸飞机图形保持一致，以继承主题配色且避免多套资源维护。
+  目的：
+    - 提供 manifest 中 send-button/light 令牌的矢量实现，确保按钮在亮色主题下仍通过 currentColor 着色。
+  与 paper-airplane.svg 的关系：
+    - 共用完全相同的几何路径与 fill="currentColor" 方案。
+    - 保留独立文件仅为兼容生成脚本对 light/dark 令牌的区分，后续可将 send-button 映射直接指向 paper-airplane.svg。
+  关键决策与取舍：
+    - 放弃原先带背景圆的版本以减少视觉噪点，并依赖主题色控制视觉对比度。
+  演进与 TODO：
+    - 若未来脚本支持别名映射，可删除该文件，改由 manifest 引用 icons/paper-airplane.svg。
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 18 18"
+  aria-hidden="true"
+  fill="currentColor"
+>
+  <path d="M2.25 15.75 16.5 9 2.25 2.25l4.5 6-4.5 7.5Z" />
 </svg>

--- a/website/src/components/ui/ChatInput/icons/SendIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/SendIcon.jsx
@@ -15,6 +15,12 @@ import PropTypes from "prop-types";
 import ICONS from "@/assets/icons.js";
 
 const SEND_ICON_TOKEN = "paper-airplane";
+/**
+ * 说明：
+ *  - send-button 资产虽已切换为相同纸飞机几何，但其 light/dark 变体仍服务于按钮蒙版，
+ *    若直接引用会让通用图标组件与按钮实现产生耦合；因此继续解析通用的 paper-airplane 令牌。
+ *  - 一旦 icon manifest 支持别名或统一引用，可在保持向后兼容的前提下退化至 send-button 令牌以减少资源冗余。
+ */
 
 const resolveSendIconResource = (registry) => {
   const entry = registry?.[SEND_ICON_TOKEN];


### PR DESCRIPTION
## Summary
- replace send-button light/dark assets with a currentColor paper airplane graphic and document their relation to the shared icon
- clarify why SendIcon continues to resolve the paper-airplane token instead of the button-specific asset

## Testing
- npm run lint
- npm run lint:css
- npm run test -- iconRegistry

------
https://chatgpt.com/codex/tasks/task_e_68de1df68cc08332881629f77377da97