### PR TITLE
feat: refresh chat input voice icon

### DIFF
--- a/website/src/assets/buttons/voice-button-dark.svg
+++ b/website/src/assets/buttons/voice-button-dark.svg
@@ -1,13 +1,6 @@
 <svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_44_30)">
-<circle cx="512" cy="512" r="512" fill="white"/>
-<rect x="576" y="192" width="640" height="128" rx="20" transform="rotate(90 576 192)" fill="#121212"/>
-<rect x="768" y="384" width="256" height="128" rx="20" transform="rotate(90 768 384)" fill="#121212"/>
-<rect x="384" y="320" width="384" height="128" rx="20" transform="rotate(90 384 320)" fill="#121212"/>
-</g>
-<defs>
-<clipPath id="clip0_44_30">
-<rect width="1024" height="1024" fill="white"/>
-</clipPath>
-</defs>
+  <path
+    fill="currentColor"
+    d="M512 128C417.707 128 341.333 204.373 341.333 298.667v256c0 94.293 76.373 170.667 170.667 170.667s170.667-76.373 170.667-170.667V298.667c0-94.293-76.373-170.667-170.667-170.667zm213.333 298.667v85.333c0 117.76-95.573 213.333-213.333 213.333s-213.333-95.573-213.333-213.333v-85.333H213.333v85.333c0 150.613 111.36 274.347 256 295.253V896h85.333v-88.747c144.64-20.907 256-144.64 256-295.253v-85.333h-85.333z"
+  />
 </svg>

--- a/website/src/assets/buttons/voice-button-light.svg
+++ b/website/src/assets/buttons/voice-button-light.svg
@@ -1,13 +1,6 @@
 <svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_44_22)">
-<circle cx="512" cy="512" r="512" fill="#121212"/>
-<rect x="576" y="192" width="640" height="128" rx="20" transform="rotate(90 576 192)" fill="white"/>
-<rect x="768" y="384" width="256" height="128" rx="20" transform="rotate(90 768 384)" fill="white"/>
-<rect x="384" y="320" width="384" height="128" rx="20" transform="rotate(90 384 320)" fill="white"/>
-</g>
-<defs>
-<clipPath id="clip0_44_22">
-<rect width="1024" height="1024" fill="white"/>
-</clipPath>
-</defs>
+  <path
+    fill="currentColor"
+    d="M512 128C417.707 128 341.333 204.373 341.333 298.667v256c0 94.293 76.373 170.667 170.667 170.667s170.667-76.373 170.667-170.667V298.667c0-94.293-76.373-170.667-170.667-170.667zm213.333 298.667v85.333c0 117.76-95.573 213.333-213.333 213.333s-213.333-95.573-213.333-213.333v-85.333H213.333v85.333c0 150.613 111.36 274.347 256 295.253V896h85.333v-88.747c144.64-20.907 256-144.64 256-295.253v-85.333h-85.333z"
+  />
 </svg>

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -318,14 +318,6 @@
   background: color-mix(in srgb, var(--sb-cta) 85%, black 15%);
 }
 
-.action-button-dot {
-  display: block;
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: var(--sb-cta-icon);
-}
-
 .action-button-icon {
   width: 18px;
   height: 18px;

--- a/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
@@ -76,10 +76,12 @@ test("GivenStandardProps_WhenRenderingView_ThenMatchSnapshot", () => {
  * 步骤：
  *  1) 渲染组件并读取 data-language-visible 属性。
  *  2) 断言语言槽位与分隔符均被折叠。
+ *  3) 捕获动作按钮，确认语音图标结构与语义标识。
  * 断言：
  *  - data-language-visible === "false"。
  *  - language-slot 不包含子节点并具有 data-visible="false"。
  *  - divider 在此场景下被移除，避免冗余列。
+ *  - 语音态按钮包含标记为 voice-button 的图标。
  * 边界/异常：
  *  - 折叠逻辑纯展示层处理，不依赖额外行为。
  */
@@ -130,4 +132,11 @@ test("GivenLanguageControlsHidden_WhenRendering_ThenCollapseLanguageSlot", () =>
 
   const divider = container.querySelector(`.${"input-divider"}`);
   expect(divider?.getAttribute("data-visible")).toBe("false");
+
+  const voiceIcon = container.querySelector('[data-icon-name="voice-button"]');
+  expect(voiceIcon).not.toBeNull();
+  expect(voiceIcon?.classList.contains("action-button-icon")).toBe(true);
+
+  const actionButton = container.querySelector(`.${"action-slot"} button`);
+  expect(actionButton).toMatchSnapshot("VoiceActionButtonMarkup");
 });

--- a/website/src/components/ui/ChatInput/__tests__/__snapshots__/ActionInputView.test.jsx.snap
+++ b/website/src/components/ui/ChatInput/__tests__/__snapshots__/ActionInputView.test.jsx.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`GivenLanguageControlsHidden_WhenRendering_ThenCollapseLanguageSlot: VoiceActionButtonMarkup 1`] = `
+<button
+  aria-label="语音"
+  aria-pressed="false"
+  class="action-button action-button-voice"
+  disabled=""
+  type="button"
+>
+  <span
+    aria-hidden="true"
+    class="action-button-icon"
+    data-icon-name="voice-button"
+    style="mask: url(file-mock) center / contain no-repeat; background-color: currentcolor;"
+  />
+</button>
+`;
+
 exports[`GivenStandardProps_WhenRenderingView_ThenMatchSnapshot 1`] = `
 <div>
   <form

--- a/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
@@ -1,0 +1,89 @@
+/**
+ * 背景：
+ *  - 语音触发入口此前以纯色圆点占位，缺乏语义化表达且在无障碍设备上难以理解。
+ * 目的：
+ *  - 将麦克风图形封装为可复用的 UI 原子，统一资源解析、遮罩样式与降级策略。
+ * 关键决策与取舍：
+ *  - 延续 SendIcon 的资源解析与遮罩构造模板，复用既有策略以降低维护成本。
+ *  - 放弃继续使用圆点样式，而以麦克风图形呈现，换取更强的语义与后续动画扩展空间。
+ * 影响范围：
+ *  - ChatInput 下所有语音相关按钮与未来潜在的语音入口组件。
+ * 演进与TODO：
+ *  - 若需针对录音态展示波形动画，可扩展 props 注入不同的遮罩资源或动画类名。
+ */
+import PropTypes from "prop-types";
+
+import ICONS from "@/assets/icons.js";
+
+const VOICE_ICON_TOKEN = "voice-button";
+
+const resolveVoiceIconResource = (registry) => {
+  const entry = registry?.[VOICE_ICON_TOKEN];
+  if (!entry) {
+    return null;
+  }
+  return entry.single ?? entry.light ?? entry.dark ?? null;
+};
+
+const buildVoiceIconMaskStyle = (resource) => {
+  if (!resource) {
+    return null;
+  }
+  const maskFragment = `url(${resource}) center / contain no-repeat`;
+  return Object.freeze({
+    mask: maskFragment,
+    WebkitMask: maskFragment,
+  });
+};
+
+const VOICE_ICON_MASK_STYLE = buildVoiceIconMaskStyle(
+  resolveVoiceIconResource(ICONS),
+);
+
+const VOICE_ICON_INLINE_STYLE =
+  VOICE_ICON_MASK_STYLE === null
+    ? null
+    : Object.freeze({
+        ...VOICE_ICON_MASK_STYLE,
+        backgroundColor: "currentColor",
+      });
+
+// 注：选用麦克风轮廓而非圆点，可直接传达语音含义并避免在暗色主题下失真。
+const defaultFallback = ({ className }) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    viewBox="0 0 1024 1024"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    data-icon-name={VOICE_ICON_TOKEN}
+  >
+    <path d="M512 128C417.707 128 341.333 204.373 341.333 298.667v256c0 94.293 76.373 170.667 170.667 170.667s170.667-76.373 170.667-170.667V298.667c0-94.293-76.373-170.667-170.667-170.667zm213.333 298.667v85.333c0 117.76-95.573 213.333-213.333 213.333s-213.333-95.573-213.333-213.333v-85.333H213.333v85.333c0 150.613 111.36 274.347 256 295.253V896h85.333v-88.747c144.64-20.907 256-144.64 256-295.253v-85.333h-85.333z" />
+  </svg>
+);
+
+function VoiceIcon({ className, fallback }) {
+  if (!VOICE_ICON_INLINE_STYLE) {
+    return fallback({ className, iconName: VOICE_ICON_TOKEN });
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={className}
+      data-icon-name={VOICE_ICON_TOKEN}
+      style={VOICE_ICON_INLINE_STYLE}
+    />
+  );
+}
+
+VoiceIcon.propTypes = {
+  className: PropTypes.string.isRequired,
+  fallback: PropTypes.func,
+};
+
+VoiceIcon.defaultProps = {
+  fallback: defaultFallback,
+};
+
+export default VoiceIcon;

--- a/website/src/components/ui/ChatInput/icons/index.js
+++ b/website/src/components/ui/ChatInput/icons/index.js
@@ -11,3 +11,4 @@
  *  - 后续若新增多图标，可考虑生成脚本自动维护出口。
  */
 export { default as SendIcon } from "./SendIcon.jsx";
+export { default as VoiceIcon } from "./VoiceIcon.jsx";

--- a/website/src/components/ui/ChatInput/parts/ActionButton.jsx
+++ b/website/src/components/ui/ChatInput/parts/ActionButton.jsx
@@ -15,7 +15,7 @@ import { useCallback } from "react";
 import PropTypes from "prop-types";
 
 import styles from "../ChatInput.module.css";
-import { SendIcon } from "../icons";
+import { SendIcon, VoiceIcon } from "../icons";
 
 const ACTION_BUTTON_COOLDOWN_MS = 500;
 
@@ -71,7 +71,7 @@ function ActionButton({
       {isSendState ? (
         <SendIcon className={styles["action-button-icon"]} />
       ) : (
-        <span className={styles["action-button-dot"]} />
+        <VoiceIcon className={styles["action-button-icon"]} />
       )}
     </button>
   );


### PR DESCRIPTION
## Summary
- replace the voice button SVG assets with a microphone glyph that respects currentColor and the 1024 view box
- add a reusable VoiceIcon component and render it from the chat action button while pruning the obsolete dot styling
- extend the ChatInput view test coverage and snapshots to assert the new voice icon structure

## Testing
- npm run lint
- npm run lint:css
- npm run test -- ChatInput

------
https://chatgpt.com/codex/tasks/task_e_68de1df6280883329bac9aa8fea1d396