### PR TITLE
Refactor preferences page to focus on account details

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -1,852 +1,241 @@
 /**
  * 背景：
- *  - 主题系统扩展到浅色时，原本写死在容器变量上的暗色值无法复用。
+ *  - 账户偏好页面收敛为单列信息卡，需重构样式以契合极简审美与新 DOM 结构。
  * 目的：
- *  - 为偏好面板提供暗/浅两套令牌映射，并沿用既有 `--sidebar-*` 设计语言。
+ *  - 提供明暗主题自适应的卡片布局，强调层次而避免干扰元素。
  * 关键决策与取舍：
- *  - 暗色分支继续锚定 night token，保持当前感知；浅色分支复用侧边栏 light token，避免重复维护颜色。
- *  - 额外抽象 `--settings-panel-surface-active` 与 `--settings-panel-press`，确保常规/激活/按压层级在两套主题中语义一致。
+ *  - 通过局部 CSS 变量抽象色板，保持与全站设计令牌的延续性。
+ *  - 使用网格与柔性排版确保字段扩展时仍能自然换行。
  * 影响范围：
- *  - 仅偏好设置面板依赖的 CSS 变量；其他页面未引用这些变量不受影响。
+ *  - 仅 `Preferences` 页面使用的样式，不影响其他模块。
  * 演进与TODO：
- *  - 若后续引入更多主题，可在此处扩展新的 :root 分支，或改由主题模块集中注入。
+ *  - 如需加入安全或账单分组，可复用 detail-grid 并按组增加分隔样式。
  */
 
-.container {
-  --settings-panel-radius: 16px;
-  --settings-panel-nav-width: 280px;
-  --settings-panel-padding-x: 32px;
-  --settings-panel-padding-y: 28px;
-  --settings-panel-gap: 24px;
-  --settings-panel-row-gap: 18px;
-  --settings-panel-row-height: 56px;
-  --settings-panel-max-width: min(92vw, 960px);
-  --settings-panel-min-width: 720px;
-  --settings-panel-max-height: 86vh;
-  --settings-panel-transition: 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+.content {
+  --preferences-surface: var(--night-panel);
+  --preferences-border: var(--night-border);
+  --preferences-muted: var(--night-muted);
+  --preferences-text: var(--night-text);
+  --preferences-shadow: 0 42px 96px rgb(0 0 0 / 44%);
+  --preferences-accent: var(--night-active);
 
-  position: relative;
-  display: grid;
-  grid-template-columns: var(--settings-panel-nav-width) minmax(0, 1fr);
-  gap: var(--settings-panel-gap);
+  display: flex;
+  justify-content: center;
   width: 100%;
-  max-width: var(--settings-panel-max-width);
-  min-width: min(100%, var(--settings-panel-min-width));
-  max-height: var(--settings-panel-max-height);
-  padding: var(--settings-panel-padding-y) var(--settings-panel-padding-x);
-  border-radius: var(--settings-panel-radius);
-  background: var(--settings-panel-bg);
-  color: var(--settings-panel-text);
-  box-shadow: var(--settings-panel-shadow);
-  overflow: hidden;
+  padding: 72px 24px 96px;
+  box-sizing: border-box;
+  background: transparent;
 }
 
-:global(:root[data-theme="dark"]) .container,
-:global(:root:not([data-theme])) .container {
-  --settings-panel-bg: var(--night-panel);
-  --settings-panel-surface: var(--night-active);
-  --settings-panel-surface-hover: var(--night-hover);
-  --settings-panel-surface-active: var(--night-active);
-  --settings-panel-press: var(--night-hover);
-  --settings-panel-border: var(--night-border);
-  --settings-panel-text: var(--night-text);
-  --settings-panel-muted: var(--night-muted);
-  --settings-panel-shadow: 0 24px 60px rgb(0 0 0 / 45%);
-  --settings-panel-ring: var(--night-input-ring);
-  --settings-panel-overlay: var(--color-overlay-strong);
+:global(:root[data-theme="light"]) .content {
+  --preferences-surface: var(--neutral-0);
+  --preferences-border: color-mix(in srgb, var(--neutral-900) 12%, transparent);
+  --preferences-muted: color-mix(in srgb, var(--neutral-900) 48%, transparent);
+  --preferences-text: var(--neutral-900);
+  --preferences-shadow: 0 48px 96px rgb(15 17 21 / 14%);
+  --preferences-accent: rgb(15 17 21 / 6%);
 }
 
-:global(:root[data-theme="light"]) .container {
-  /*
-   * 主题映射：
-   *  - 所有颜色引用现有 light 面板令牌，确保与侧栏、弹层等组件风格一致。
-   */
-  --settings-panel-bg: var(--sidebar-panel, var(--neutral-0));
-  --settings-panel-surface: var(--sidebar-panel, var(--neutral-0));
-  --settings-panel-surface-hover: var(--sidebar-hover-bg, rgb(15 17 21 / 6%));
-  --settings-panel-surface-active: var(--sidebar-active-bg, rgb(15 17 21 / 12%));
-  --settings-panel-press: var(--sidebar-active-bg, rgb(15 17 21 / 12%));
-  --settings-panel-border: var(--sidebar-border-color, #d9dde7);
-  --settings-panel-text: var(--sidebar-text-color, var(--text-primary-light));
-  --settings-panel-muted: var(
-    --sidebar-muted-color,
-    color-mix(in srgb, var(--text-primary-light) 55%, transparent)
-  );
-  --settings-panel-shadow: var(
+:global(:root[data-theme="system"]) .content {
+  --preferences-surface: var(--sidebar-panel, var(--night-panel));
+  --preferences-border: var(--sidebar-border-color, var(--night-border));
+  --preferences-muted: var(--sidebar-muted-color, var(--night-muted));
+  --preferences-text: var(--sidebar-text-color, var(--night-text));
+  --preferences-shadow: var(
     --sidebar-shadow-elevated,
-    0 18px 42px rgb(31 35 43 / 16%)
+    0 42px 96px rgb(0 0 0 / 44%)
   );
-  --settings-panel-ring: var(--sidebar-input-ring, #cfd4e2);
-  --settings-panel-overlay: var(--color-overlay);
+  --preferences-accent: var(--sidebar-active-bg, var(--night-active));
 }
 
-:global(:root[data-theme="system"]) .container {
-  /*
-   * 系统主题跟随：
-   *  - 变量值挂靠在 `--sidebar-*` 令牌上，让浏览器 `prefers-color-scheme` 接管明暗切换。
-   */
-  --settings-panel-bg: var(--sidebar-panel, var(--night-panel));
-  --settings-panel-surface: var(--sidebar-panel, var(--night-active));
-  --settings-panel-surface-hover: var(--sidebar-hover-bg, var(--night-hover));
-  --settings-panel-surface-active: var(--sidebar-active-bg, var(--night-active));
-  --settings-panel-press: var(--sidebar-active-bg, var(--night-hover));
-  --settings-panel-border: var(--sidebar-border-color, var(--night-border));
-  --settings-panel-text: var(--sidebar-text-color, var(--night-text));
-  --settings-panel-muted: var(--sidebar-muted-color, var(--night-muted));
-  --settings-panel-shadow: var(--sidebar-shadow-elevated, 0 24px 60px rgb(0 0 0 / 45%));
-  --settings-panel-ring: var(--sidebar-input-ring, var(--night-input-ring));
-  --settings-panel-overlay: var(--color-overlay);
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  width: min(720px, 100%);
+  padding: 56px 56px 48px;
+  border-radius: 32px;
+  border: 1px solid var(--preferences-border);
+  background: var(--preferences-surface);
+  color: var(--preferences-text);
+  box-shadow: var(--preferences-shadow);
+  box-sizing: border-box;
 }
 
-.page {
-  margin: 40px auto;
-  width: min(100%, var(--settings-panel-max-width));
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 32px;
+  flex-wrap: wrap;
 }
 
-.surface {
-  position: relative;
-  display: contents;
+.identity {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
 }
 
-.sidebar {
+.avatar {
+  border-radius: 50%;
+}
+
+.identity-meta {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  width: var(--settings-panel-nav-width);
-  min-height: 0;
+  min-width: 0;
 }
 
-.nav-title {
+.eyebrow {
   margin: 0;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--settings-panel-muted);
-  letter-spacing: 0.08em;
+  font-size: 12px;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
+  color: var(--preferences-muted);
 }
 
-.nav-list {
+.title {
   margin: 0;
-  padding: 8px 4px 8px 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  overflow-y: auto;
+  font-size: 32px;
+  line-height: 1.2;
+  font-weight: 600;
 }
 
-.nav-item {
-  display: contents;
+.description {
+  margin: 0;
+  max-width: 520px;
+  color: var(--preferences-muted);
+  line-height: 1.6;
 }
 
-.nav-button {
-  position: relative;
-  display: grid;
-  grid-template-columns: 8px 20px auto;
+.plan-badge {
+  align-self: flex-start;
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
-  width: 100%;
-  min-height: 48px;
-  padding: 0 16px;
-  border: none;
-  border-radius: 12px;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: var(--preferences-accent);
+  color: var(--preferences-text);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.manage-button {
+  padding: 12px 22px;
+  border-radius: 999px;
+  border: 1px solid var(--preferences-border);
   background: transparent;
-  color: var(--settings-panel-muted);
+  color: inherit;
   font-size: 14px;
   font-weight: 500;
-  text-align: left;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   cursor: pointer;
   transition:
-    background var(--settings-panel-transition),
-    color var(--settings-panel-transition),
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
+    background 160ms ease,
+    color 160ms ease,
+    transform 160ms ease,
+    border-color 160ms ease;
 }
 
-.nav-button:hover {
-  background: var(--settings-panel-surface-hover);
-  color: var(--settings-panel-text);
+.manage-button:hover {
+  background: var(--preferences-accent);
+  transform: translateY(-1px);
 }
 
-.nav-button:focus-visible {
+.manage-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.nav-button-active {
-  background: var(--settings-panel-surface-active);
-  color: var(--settings-panel-text);
-}
-
-.nav-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: transparent;
-  transform: scale(0.4);
-  transition:
-    transform var(--settings-panel-transition),
-    background var(--settings-panel-transition);
-}
-
-.nav-button-active .nav-dot {
-  background: var(--settings-panel-text);
-  transform: scale(1);
-}
-
-.nav-icon {
-  width: 18px;
-  height: 18px;
-  color: inherit;
-}
-
-.nav-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.content {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  gap: 0;
-  min-width: 0;
-  min-height: 0;
-}
-
-.content-header {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding-bottom: 20px;
-}
-
-.content-title {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 700;
-  line-height: 1.2;
-}
-
-.content-description {
-  margin: 0;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--settings-panel-muted);
-}
-
-.section-stack {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  padding-right: 4px;
-  overflow-y: auto;
-  padding-bottom: 24px;
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--preferences-text) 28%, transparent);
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 24px;
 }
 
-.section-header {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.section-title {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.section-description {
-  margin: 0;
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-  line-height: 1.5;
-}
-
-.section-body {
-  border: 1px solid var(--settings-panel-border);
-  border-radius: 14px;
-  overflow: hidden;
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 96%,
-    transparent
-  );
-}
-
-.row {
-  display: grid;
-  grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
-  align-items: center;
-  gap: 16px;
-  min-height: var(--settings-panel-row-height);
-  padding: 12px 20px;
-}
-
-.row-top {
-  align-items: flex-start;
-}
-
-.row-control {
-  justify-self: end;
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.row-top .row-control {
-  align-self: stretch;
-}
-
-.row + .row {
-  border-top: 1px solid var(--settings-panel-border);
-}
-
-.row-label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.row-label-text {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--settings-panel-text);
-}
-
-.row-label-description {
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-  line-height: 1.45;
-}
-
-.row-control-full {
-  width: 100%;
-  justify-content: flex-start;
-}
-
-.row-control-full > * {
-  width: 100%;
-}
-
-.pill-select {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  min-width: 180px;
-}
-
-.pill-native {
-  width: 100%;
-  min-height: 36px;
-  padding: 0 36px 0 16px;
-  border-radius: 999px;
-  border: 1px solid var(--settings-panel-border);
-  background: var(--settings-panel-surface);
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  appearance: none;
-  cursor: pointer;
-  transition:
-    background-color var(--settings-panel-transition),
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition),
-    color var(--settings-panel-transition);
-}
-
-.pill-native:focus-visible {
-  outline: none;
-  border-color: var(--settings-panel-ring);
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.pill-native:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.pill-native:hover:not(:disabled) {
-  background: var(--settings-panel-surface-hover);
-}
-
-.pill-select-icon {
-  position: absolute;
-  right: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: var(--settings-panel-muted);
-}
-
-.play-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 36px;
-  padding: 0 16px;
-  border-radius: 12px;
-  border: 1px solid var(--settings-panel-border);
-  background: var(--settings-panel-surface);
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color var(--settings-panel-transition),
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition),
-    border-color var(--settings-panel-transition);
-}
-
-.play-button[data-active="true"] {
-  background: var(--settings-panel-press);
-}
-
-.play-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.play-button:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.play-button:hover:not(:disabled) {
-  background: var(--settings-panel-surface-hover);
-}
-
-.content-footer {
-  display: flex;
-  justify-content: flex-end;
-  padding-top: 20px;
-  border-top: 1px solid var(--settings-panel-border);
-  margin-top: 24px;
-}
-
-.primary-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 160px;
-  min-height: 42px;
-  padding: 0 24px;
-  border-radius: 999px;
-  border: none;
-  background: linear-gradient(135deg, #5a8bff, #4c6fff);
-  color: #fff;
-  font-size: 15px;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.primary-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgb(76 111 255 / 40%);
-}
-
-.primary-button:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.primary-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgb(76 111 255 / 35%);
-}
-
-.shortcut-list {
-  list-style: none;
+.detail-grid {
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  list-style: none;
 }
 
-.shortcut-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 20px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 90%,
-    transparent
-  );
+.detail-item {
+  display: grid;
+  gap: 8px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  border: 1px solid var(--preferences-border);
+  background: color-mix(in srgb, var(--preferences-surface) 78%, transparent);
 }
 
-.shortcut-key {
-  font-family:
-    SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+.detail-label {
+  margin: 0;
   font-size: 12px;
-  font-weight: 600;
-  padding: 6px 10px;
-  border-radius: 10px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-  color: var(--settings-panel-text);
-}
-
-.shortcut-label {
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-}
-
-.data-card {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  padding: 20px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 94%,
-    transparent
-  );
-}
-
-.data-description {
-  margin: 0;
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-  line-height: 1.6;
-}
-
-.data-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.secondary-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 36px;
-  padding: 0 18px;
-  border-radius: 999px;
-  border: 1px solid var(--settings-panel-border);
-  background: transparent;
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color var(--settings-panel-transition),
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.secondary-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.secondary-button:hover:not(:disabled) {
-  background: var(--settings-panel-surface-hover);
-}
-
-.section-columns {
-  display: grid;
-  gap: 18px;
-}
-
-.switch-row {
-  justify-content: space-between;
-}
-
-.switch {
-  position: relative;
-  width: 48px;
-  height: 26px;
-}
-
-.switch input {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-}
-
-.switch span {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--settings-panel-border) 55%, transparent);
-  transition:
-    background-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.switch span::after {
-  content: "";
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  width: 18px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--settings-panel-text);
-  box-shadow: 0 2px 4px rgb(0 0 0 / 24%);
-  transition:
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.switch input:checked + span {
-  background: linear-gradient(135deg, #5a8bff, #4c6fff);
-}
-
-.switch input:checked + span::after {
-  transform: translateX(22px);
-}
-
-.switch input:focus-visible + span {
-  outline: none;
-  box-shadow: 0 0 0 2px rgb(76 111 255 / 45%);
-}
-
-.input-control {
-  width: 100%;
-  min-height: 44px;
-  padding: 0 18px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  font-weight: 500;
-  transition:
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition),
-    background-color var(--settings-panel-transition);
-}
-
-.input-control:focus-visible {
-  outline: none;
-  border-color: var(--settings-panel-ring);
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.input-control:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.input-area {
-  width: 100%;
-  padding: 14px 18px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  line-height: 1.6;
-  resize: vertical;
-  min-height: 120px;
-  transition:
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.input-area:focus-visible {
-  outline: none;
-  border-color: var(--settings-panel-ring);
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.input-area:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.inline-field {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.account-card {
-  display: grid;
-  gap: 18px;
-  padding: 20px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-}
-
-.account-header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.account-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.account-name {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--settings-panel-text);
-}
-
-.account-plan {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--settings-panel-muted);
+  color: var(--preferences-muted);
 }
 
-.account-rows dt {
+.detail-value {
   margin: 0;
-  font-size: 13px;
-  color: var(--settings-panel-muted);
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--preferences-text);
+  overflow-wrap: anywhere;
 }
 
-.account-rows dd {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.account-rows {
-  display: grid;
-  gap: 12px;
-}
-
-.account-row {
+.footer {
   display: flex;
-  justify-content: space-between;
-  font-size: 14px;
-  color: var(--settings-panel-text);
+  justify-content: flex-end;
 }
 
-.account-row dd {
+.footer-note {
   margin: 0;
-  color: var(--settings-panel-muted);
+  max-width: 360px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--preferences-muted);
+  text-align: right;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .nav-button,
-  .pill-native,
-  .play-button,
-  .primary-button,
-  .secondary-button,
-  .switch span,
-  .switch span::after {
-    transition: none;
-  }
-}
-
-@media (width <= 1023px) {
-  .container {
-    grid-template-columns: 240px minmax(0, 1fr);
-
-    --settings-panel-nav-width: 240px;
-  }
-}
-
-@media (width <= 900px) {
-  .container {
-    grid-template-columns: 220px minmax(0, 1fr);
-
-    --settings-panel-nav-width: 220px;
+@media (width <= 768px) {
+  .form {
+    padding: 40px 28px 36px;
+    gap: 36px;
   }
 
-  .nav-list {
-    max-height: 60vh;
+  .identity {
+    flex-direction: column;
+    align-items: flex-start;
   }
-}
 
-@media (width <= 760px) {
-  .container {
+  .header {
+    gap: 24px;
+  }
+
+  .title {
+    font-size: 28px;
+  }
+
+  .detail-grid {
     grid-template-columns: 1fr;
-    min-width: auto;
-    width: 100%;
-    padding: 24px;
   }
 
-  .sidebar {
-    width: 100%;
-    flex-direction: row;
-    overflow-x: auto;
-    gap: 8px;
+  .footer {
+    justify-content: flex-start;
   }
 
-  .nav-list {
-    display: flex;
-    flex-direction: row;
-    gap: 8px;
-    padding-bottom: 4px;
-  }
-
-  .nav-button {
-    grid-template-columns: 8px auto;
-    padding: 0 14px;
-    min-height: 44px;
-  }
-
-  .nav-icon {
-    display: none;
-  }
-
-  .content {
-    padding-top: 12px;
-  }
-
-  .row {
-    grid-template-columns: 1fr;
-    justify-items: flex-start;
-    gap: 12px;
-  }
-
-  .row-control {
-    justify-self: flex-start;
-  }
-
-  .content-footer {
-    justify-content: stretch;
-  }
-
-  .primary-button {
-    width: 100%;
+  .footer-note {
+    text-align: left;
   }
 }

--- a/website/src/pages/preferences/__tests__/Preferences.test.jsx
+++ b/website/src/pages/preferences/__tests__/Preferences.test.jsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import Preferences from "@/pages/preferences";
+
+jest.mock("@/context", () => ({
+  useLanguage: jest.fn(),
+  useUser: jest.fn(),
+}));
+
+jest.mock("@/hooks/useApi.js", () => ({
+  useApi: jest.fn(),
+}));
+
+jest.mock("@/components/ui/Avatar", () => (props) => (
+  <div data-testid="avatar" {...props} />
+));
+
+const { useLanguage, useUser } = jest.requireMock("@/context");
+const { useApi } = jest.requireMock("@/hooks/useApi.js");
+
+const baseTranslations = {
+  prefTitle: "Preferences",
+  prefAccountTitle: "Account essentials",
+  settingsAccountDescription: "Review account facts.",
+  settingsAccountUsername: "Username",
+  settingsAccountEmail: "Email",
+  settingsAccountPhone: "Phone",
+  settingsAccountAge: "Age",
+  settingsAccountGender: "Gender",
+  settingsEmptyValue: "Not set",
+  settingsManageProfile: "Manage profile",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useLanguage.mockReturnValue({ t: baseTranslations });
+  useUser.mockReturnValue({
+    user: {
+      username: "Ava",
+      email: "ava@glancy.ai",
+      phone: "",
+      plan: "aurum",
+      token: "token",
+    },
+  });
+  useApi.mockReturnValue({
+    profiles: {
+      fetchProfile: jest.fn().mockResolvedValue({ age: 28, gender: "Female" }),
+    },
+  });
+});
+
+/**
+ * 测试目标：Preferences 表单渲染账号标题及主要字段。
+ * 前置条件：mock 用户上下文与翻译文案，mock API 返回年龄/性别。
+ * 步骤：
+ *  1) 渲染组件并等待异步资料回填。
+ *  2) 获取表单、标题与字段文案。
+ * 断言：
+ *  - 表单可通过 aria-labelledby 被获取。
+ *  - 主要字段（邮箱、年龄）展示上下文数据。
+ * 边界/异常：
+ *  - 若 fetchProfile 拒绝，应在控制台记录，但此用例聚焦成功路径。
+ */
+test("Given context When rendering preferences Then shows account essentials", async () => {
+  const onOpenAccountManager = jest.fn();
+  render(<Preferences onOpenAccountManager={onOpenAccountManager} />);
+
+  const form = await screen.findByRole("form", {
+    name: /Account essentials/i,
+  });
+  expect(form).toBeInTheDocument();
+  expect(screen.getByTestId("avatar")).toBeInTheDocument();
+  expect(screen.getByText("Manage profile")).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(screen.getByText("ava@glancy.ai")).toBeInTheDocument();
+    expect(screen.getByText("28")).toBeInTheDocument();
+  });
+});
+
+/**
+ * 测试目标：当 API 未返回字段时使用默认占位符。
+ * 前置条件：mock API 返回空字符串，mock 用户缺失手机号。
+ * 步骤：
+ *  1) 渲染组件。
+ *  2) 等待 detail 字段加载完成。
+ * 断言：
+ *  - 电话字段显示 "Not set" 占位。
+ * 边界/异常：
+ *  - 空值逻辑通过 `buildAccountFields` 统一处理。
+ */
+test("Given missing profile data When rendering Then falls back to placeholder", async () => {
+  useUser.mockReturnValueOnce({
+    user: {
+      username: "Ava",
+      email: "ava@glancy.ai",
+      phone: "",
+      isPro: true,
+      token: "token",
+    },
+  });
+  useApi.mockReturnValueOnce({
+    profiles: {
+      fetchProfile: jest.fn().mockResolvedValue({ age: "", gender: undefined }),
+    },
+  });
+
+  render(<Preferences />);
+
+  await waitFor(() => {
+    expect(screen.getAllByText("Not set").length).toBeGreaterThan(0);
+  });
+});

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -1,1284 +1,185 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import styles from "./Preferences.module.css";
-import { useLanguage, useTheme, useUser } from "@/context";
-import { API_PATHS } from "@/config/api.js";
-import MessagePopup from "@/components/ui/MessagePopup";
+import { useLanguage, useUser } from "@/context";
 import { useApi } from "@/hooks/useApi.js";
-import { VoiceSelector } from "@/components";
-import { useSettingsStore, SUPPORTED_SYSTEM_LANGUAGES } from "@/store/settings";
-import { useVoiceStore } from "@/store";
-import { SYSTEM_LANGUAGE_AUTO } from "@/i18n/languages.js";
-import {
-  WORD_LANGUAGE_AUTO,
-  WORD_DEFAULT_TARGET_LANGUAGE,
-  normalizeWordSourceLanguage,
-  normalizeWordTargetLanguage,
-} from "@/utils/language.js";
-import ThemeIcon from "@/components/ui/Icon";
 import Avatar from "@/components/ui/Avatar";
-import { useTtsPlayer } from "@/hooks/useTtsPlayer.js";
-
-const SOURCE_LANG_STORAGE_KEY = "sourceLang";
-const TARGET_LANG_STORAGE_KEY = "targetLang";
-const PERSONALIZATION_ENABLED_STORAGE_KEY = "glancy:personalization-enabled";
-
-const VOICE_PREVIEW_SAMPLES = Object.freeze({
-  en: "Hi, I'm Glancy.",
-  zh: "你好，我是 Glancy。",
-});
-
-const readLocalPreference = (key) => {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  try {
-    return window.localStorage.getItem(key);
-  } catch (error) {
-    console.warn(
-      `[preferences] Unable to read ${key} from localStorage`,
-      error,
-    );
-    return null;
-  }
-};
-
-const writeLocalPreference = (key, value) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-  try {
-    window.localStorage.setItem(key, value);
-  } catch (error) {
-    console.warn(`[preferences] Unable to write ${key} to localStorage`, error);
-  }
-};
-
-const VARIANTS = {
-  PAGE: "page",
-  DIALOG: "dialog",
-};
-
-const TAB_KEYS = Object.freeze({
-  GENERAL: "general",
-  PERSONALIZATION: "personalization",
-  KEYBOARD: "keyboard",
-  DATA: "data",
-  ACCOUNT: "account",
-});
-
-const TAB_ORDER = [
-  TAB_KEYS.GENERAL,
-  TAB_KEYS.PERSONALIZATION,
-  TAB_KEYS.KEYBOARD,
-  TAB_KEYS.DATA,
-  TAB_KEYS.ACCOUNT,
-];
-
-const TAB_ICONS = Object.freeze({
-  [TAB_KEYS.GENERAL]: "cog-6-tooth",
-  [TAB_KEYS.PERSONALIZATION]: "adjustments-horizontal",
-  [TAB_KEYS.KEYBOARD]: "command-line",
-  [TAB_KEYS.DATA]: "shield-check",
-  [TAB_KEYS.ACCOUNT]: "user",
-});
-
-const KEYBOARD_SHORTCUTS = [
-  { combo: "⌘ / Ctrl + K", labelKey: "shortcutSearch" },
-  { combo: "⌘ / Ctrl + Enter", labelKey: "shortcutSend" },
-  { combo: "↑", labelKey: "shortcutEdit" },
-  { combo: "Esc", labelKey: "shortcutDismiss" },
-];
-
-const buildTabLabelMap = (t) => ({
-  [TAB_KEYS.GENERAL]: t.settingsTabGeneral || "General",
-  [TAB_KEYS.PERSONALIZATION]:
-    t.settingsTabPersonalization || "Personalization",
-  [TAB_KEYS.KEYBOARD]: t.settingsTabKeyboard || "Keyboard",
-  [TAB_KEYS.DATA]: t.settingsTabData || "Data controls",
-  [TAB_KEYS.ACCOUNT]: t.settingsTabAccount || "Account",
-});
 
 /**
  * 背景：
- *  - 之前导航标签与内容标题共用同一文案来源，导致无法表达差异化语义。
+ *  - 多标签与语音预览功能已迁出，此页面仅承担账户信息的呈现职责。
  * 目的：
- *  - 提供显式的导航标签与内容标题映射，确保信息架构的可扩展性与可维护性。
+ *  - 以极简布局展示账户关键字段，并为未来扩展（如安全设置）保留结构化入口。
  * 关键决策与取舍：
- *  - 采用集中 Copy Registry 的方式返回 labels/titles/descriptions，避免到处散落的文案取值逻辑。
- *  - 未引入复杂状态机，原因是当前需求仅涉及静态文案分层，使用简单映射即可满足演进需求。
+ *  - 采用“蓝图 + 映射”模板方法定义字段，便于后续通过配置扩展字段集合。
+ *  - 异步资料加载维持最小状态集，避免引入全局 store 依赖。
+ * 影响范围：
+ *  - 仅偏好设置页面的账户模块；其余功能保持不变。
+ * 演进与TODO：
+ *  - 后续如需引入多分组信息，可在 `ACCOUNT_FIELD_BLUEPRINTS` 中扩展分段标识。
  */
-const buildTabCopyMap = (t) => {
-  const tabLabelMap = buildTabLabelMap(t);
-  return {
-    labels: tabLabelMap,
-    titles: {
-      [TAB_KEYS.GENERAL]:
-        t.prefInterfaceTitle || tabLabelMap[TAB_KEYS.GENERAL],
-      [TAB_KEYS.PERSONALIZATION]:
-        t.prefPersonalizationTitle || tabLabelMap[TAB_KEYS.PERSONALIZATION],
-      [TAB_KEYS.KEYBOARD]:
-        t.prefKeyboardTitle || tabLabelMap[TAB_KEYS.KEYBOARD],
-      [TAB_KEYS.DATA]: t.prefDataTitle || tabLabelMap[TAB_KEYS.DATA],
-      [TAB_KEYS.ACCOUNT]:
-        t.prefAccountTitle || tabLabelMap[TAB_KEYS.ACCOUNT],
-    },
-    descriptions: {
-      [TAB_KEYS.GENERAL]: t.settingsGeneralDescription || "",
-      [TAB_KEYS.PERSONALIZATION]: t.settingsPersonalizationDescription || "",
-      [TAB_KEYS.KEYBOARD]: t.settingsKeyboardDescription || "",
-      [TAB_KEYS.DATA]: t.settingsDataDescription || "",
-      [TAB_KEYS.ACCOUNT]: t.settingsAccountDescription || "",
-    },
-  };
-};
 
-const toStoreSourceLanguage = (value) => {
-  if (!value || value === WORD_LANGUAGE_AUTO) {
-    return WORD_LANGUAGE_AUTO;
-  }
-  return normalizeWordSourceLanguage(value);
-};
+const ACCOUNT_FIELD_BLUEPRINTS = Object.freeze([
+  {
+    id: "username",
+    labelKey: "settingsAccountUsername",
+    accessor: (user) => user?.username,
+  },
+  {
+    id: "email",
+    labelKey: "settingsAccountEmail",
+    accessor: (user) => user?.email,
+  },
+  {
+    id: "phone",
+    labelKey: "settingsAccountPhone",
+    accessor: (user) => user?.phone,
+  },
+  {
+    id: "age",
+    labelKey: "settingsAccountAge",
+    accessor: (_, profileMeta) => profileMeta.age,
+  },
+  {
+    id: "gender",
+    labelKey: "settingsAccountGender",
+    accessor: (_, profileMeta) => profileMeta.gender,
+  },
+]);
 
-const toUiSourceLanguage = (value) => {
-  const normalized = normalizeWordSourceLanguage(value);
-  return normalized === WORD_LANGUAGE_AUTO ? WORD_LANGUAGE_AUTO : normalized;
-};
+/**
+ * 意图：将账户字段蓝图转换为具备文案和值的可渲染实体。
+ * 输入：翻译对象 `t`、当前 `user`、`profileMeta` 状态、空值占位文案。
+ * 输出：带 id/label/value 的数组，供渲染使用。
+ * 流程：
+ *  1) 遍历蓝图并读取国际化 label。
+ *  2) 计算字段值，遇到缺失或空白时使用占位文案。
+ * 错误处理：统一输出占位文案，避免界面出现 `undefined`。
+ * 复杂度：O(n)，n 为字段数量。
+ */
+function buildAccountFields(t, user, profileMeta, fallbackValue) {
+  return ACCOUNT_FIELD_BLUEPRINTS.map(({ id, labelKey, accessor }) => {
+    const label = t[labelKey] || labelKey;
+    const rawValue = accessor(user, profileMeta);
+    const hasValue =
+      rawValue !== undefined && rawValue !== null && rawValue !== "";
+    return {
+      id,
+      label,
+      value: hasValue ? String(rawValue) : fallbackValue,
+    };
+  });
+}
 
-const toUiTargetLanguage = (value) =>
-  normalizeWordTargetLanguage(value ?? WORD_DEFAULT_TARGET_LANGUAGE);
-
-const toStoreTargetLanguage = (value) => normalizeWordTargetLanguage(value);
-
-const resolveInitialTab = (candidate) =>
-  TAB_ORDER.includes(candidate) ? candidate : TAB_KEYS.GENERAL;
-
-function Preferences({
-  variant = VARIANTS.PAGE,
-  initialTab = TAB_KEYS.GENERAL,
-  onOpenAccountManager,
-}) {
-  const { t, lang } = useLanguage();
-  const { theme, setTheme } = useTheme();
+function Preferences({ onOpenAccountManager }) {
+  const { t } = useLanguage();
   const { user } = useUser();
   const api = useApi();
-  const {
-    systemLanguage,
-    setSystemLanguage,
-    dictionarySourceLanguage,
-    setDictionarySourceLanguage,
-    dictionaryTargetLanguage,
-    setDictionaryTargetLanguage,
-  } = useSettingsStore((state) => ({
-    systemLanguage: state.systemLanguage,
-    setSystemLanguage: state.setSystemLanguage,
-    dictionarySourceLanguage: state.dictionarySourceLanguage,
-    setDictionarySourceLanguage: state.setDictionarySourceLanguage,
-    dictionaryTargetLanguage: state.dictionaryTargetLanguage,
-    setDictionaryTargetLanguage: state.setDictionaryTargetLanguage,
-  }));
-
-  const [activeTab, setActiveTab] = useState(resolveInitialTab(initialTab));
-  const [sourceLang, setSourceLang] = useState(() =>
-    toUiSourceLanguage(
-      readLocalPreference(SOURCE_LANG_STORAGE_KEY) ?? dictionarySourceLanguage,
-    ),
-  );
-  const [targetLang, setTargetLang] = useState(() =>
-    toUiTargetLanguage(
-      readLocalPreference(TARGET_LANG_STORAGE_KEY) ?? dictionaryTargetLanguage,
-    ),
-  );
-  const [personalizationEnabled, setPersonalizationEnabled] = useState(() => {
-    const persisted = readLocalPreference(PERSONALIZATION_ENABLED_STORAGE_KEY);
-    if (persisted === "true" || persisted === "false") {
-      return persisted === "true";
-    }
-    return true;
-  });
-  const [occupation, setOccupation] = useState("");
-  const [persona, setPersona] = useState("");
-  const [learningGoal, setLearningGoal] = useState("");
   const [profileMeta, setProfileMeta] = useState({ age: "", gender: "" });
-  const [popupOpen, setPopupOpen] = useState(false);
-  const [popupMsg, setPopupMsg] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
-  const voiceSelections = useVoiceStore((state) => state.voices || {});
-  const englishVoiceId = voiceSelections.en || "";
-  const chineseVoiceId = voiceSelections.zh || "";
-  const {
-    play: playVoicePreview,
-    stop: stopVoicePreview,
-    loading: isVoicePreviewLoading,
-    playing: isVoicePreviewPlaying,
-  } = useTtsPlayer({ scope: "sentence" });
-  const [previewLang, setPreviewLang] = useState(null);
-
-  useEffect(() => {
-    setActiveTab(resolveInitialTab(initialTab));
-  }, [initialTab]);
-
-  useEffect(
-    () => () => {
-      stopVoicePreview();
-      setPreviewLang(null);
-    },
-    [stopVoicePreview],
-  );
-
-  useEffect(() => {
-    if (
-      activeTab !== TAB_KEYS.GENERAL &&
-      (isVoicePreviewPlaying || isVoicePreviewLoading)
-    ) {
-      stopVoicePreview();
-      setPreviewLang(null);
-    }
-  }, [
-    activeTab,
-    isVoicePreviewLoading,
-    isVoicePreviewPlaying,
-    stopVoicePreview,
-  ]);
-
-  const systemLanguageFormatter = useMemo(() => {
-    try {
-      return new Intl.DisplayNames([lang], { type: "language" });
-    } catch (error) {
-      console.warn("[preferences] Intl.DisplayNames unsupported", error);
-      return null;
-    }
-  }, [lang]);
-
-  const {
-    labels: tabLabelMap,
-    titles: tabTitleMap,
-    descriptions: tabDescriptionMap,
-  } = useMemo(() => buildTabCopyMap(t), [t]);
-
-  const voiceSampleTextMap = useMemo(
-    () => ({
-      en: t.settingsVoicePreviewTextEn || VOICE_PREVIEW_SAMPLES.en,
-      zh: t.settingsVoicePreviewTextZh || VOICE_PREVIEW_SAMPLES.zh,
-    }),
-    [t.settingsVoicePreviewTextEn, t.settingsVoicePreviewTextZh],
-  );
-
-  const formatLanguageLabel = useCallback(
-    (code) => {
-      const label = systemLanguageFormatter?.of(code);
-      if (!label) {
-        return code.toUpperCase();
-      }
-      return label
-        .split(" ")
-        .map((segment) =>
-          segment.length > 0
-            ? segment[0].toUpperCase() + segment.slice(1)
-            : segment,
-        )
-        .join(" ");
-    },
-    [systemLanguageFormatter],
-  );
-
-  const systemLanguageOptions = useMemo(
-    () => [
-      { value: SYSTEM_LANGUAGE_AUTO, label: t.prefSystemLanguageAuto },
-      ...SUPPORTED_SYSTEM_LANGUAGES.map((code) => ({
-        value: code,
-        label: formatLanguageLabel(code),
-      })),
-    ],
-    [formatLanguageLabel, t.prefSystemLanguageAuto],
-  );
-
-  const languageOptions = useMemo(
-    () => [
-      { value: WORD_LANGUAGE_AUTO, label: t.autoDetect },
-      { value: "CHINESE", label: "CHINESE" },
-      { value: "ENGLISH", label: "ENGLISH" },
-    ],
-    [t.autoDetect],
-  );
-
-  const searchLanguageOptions = useMemo(
-    () => [
-      { value: "CHINESE", label: "CHINESE" },
-      { value: "ENGLISH", label: "ENGLISH" },
-    ],
-    [],
-  );
-
-  const themeOptions = useMemo(
-    () => [
-      { value: "light", label: "light" },
-      { value: "dark", label: "dark" },
-      { value: "system", label: "system" },
-    ],
-    [],
-  );
-
-  const persistLanguages = useCallback((source, target) => {
-    writeLocalPreference(SOURCE_LANG_STORAGE_KEY, source);
-    writeLocalPreference(TARGET_LANG_STORAGE_KEY, target);
-  }, []);
-
-  const persistPersonalization = useCallback((enabled) => {
-    writeLocalPreference(
-      PERSONALIZATION_ENABLED_STORAGE_KEY,
-      enabled ? "true" : "false",
-    );
-  }, []);
-
-  const openPopup = useCallback((message) => {
-    setPopupMsg(message);
-    setPopupOpen(true);
-  }, []);
-
-  const handleSourceLanguageChange = useCallback(
-    (value) => {
-      const candidate = value ?? WORD_LANGUAGE_AUTO;
-      const uiValue =
-        typeof candidate === "string" ? candidate : WORD_LANGUAGE_AUTO;
-      setSourceLang(uiValue);
-      setDictionarySourceLanguage(toStoreSourceLanguage(uiValue));
-    },
-    [setDictionarySourceLanguage],
-  );
-
-  const handleTargetLanguageChange = useCallback(
-    (value) => {
-      const uiValue = toUiTargetLanguage(value);
-      setTargetLang(uiValue);
-      setDictionaryTargetLanguage(toStoreTargetLanguage(uiValue));
-    },
-    [setDictionaryTargetLanguage],
-  );
-
-  const handleVoicePreview = useCallback(
-    async (langCode) => {
-      const sample = voiceSampleTextMap[langCode];
-      if (!sample) {
-        return;
-      }
-      const selectedVoice =
-        langCode === "zh"
-          ? chineseVoiceId || undefined
-          : englishVoiceId || undefined;
-      const isActivePreview =
-        previewLang === langCode &&
-        (isVoicePreviewPlaying || isVoicePreviewLoading);
-      if (isActivePreview) {
-        stopVoicePreview();
-        setPreviewLang(null);
-        return;
-      }
-      setPreviewLang(langCode);
-      try {
-        await playVoicePreview({
-          text: sample,
-          lang: langCode,
-          voice: selectedVoice,
-        });
-      } catch (error) {
-        console.error("[preferences] Voice preview failed", error);
-        setPreviewLang(null);
-      }
-    },
-    [
-      voiceSampleTextMap,
-      chineseVoiceId,
-      englishVoiceId,
-      previewLang,
-      isVoicePreviewPlaying,
-      isVoicePreviewLoading,
-      stopVoicePreview,
-      playVoicePreview,
-    ],
-  );
-
-  const applyPreferences = useCallback(
-    (data) => {
-      const nextSource = data.systemLanguage || WORD_LANGUAGE_AUTO;
-      const nextTarget = data.searchLanguage || WORD_DEFAULT_TARGET_LANGUAGE;
-      handleSourceLanguageChange(nextSource);
-      handleTargetLanguageChange(nextTarget);
-      persistLanguages(nextSource, nextTarget);
-    },
-    [handleSourceLanguageChange, handleTargetLanguageChange, persistLanguages],
-  );
-
-  useEffect(() => {
-    if (!user) {
-      return;
-    }
-    api
-      .request(`${API_PATHS.preferences}/user`)
-      .then((data) => {
-        applyPreferences(data);
-      })
-      .catch((err) => {
-        console.error(err);
-        openPopup(t.fail);
-      });
-  }, [api, applyPreferences, openPopup, t.fail, user]);
 
   useEffect(() => {
     if (!user || !api?.profiles?.fetchProfile) {
+      setProfileMeta({ age: "", gender: "" });
       return;
     }
+    let mounted = true;
     api.profiles
       .fetchProfile({ token: user.token })
       .then((profile) => {
-        setOccupation(profile.job || "");
-        setPersona(profile.interest || "");
-        setLearningGoal(profile.goal || "");
-        setProfileMeta({
-          age: profile.age ?? "",
-          gender: profile.gender ?? "",
-        });
-        if (!readLocalPreference(PERSONALIZATION_ENABLED_STORAGE_KEY)) {
-          const hasData = Boolean(
-            profile.job || profile.interest || profile.goal,
-          );
-          setPersonalizationEnabled(hasData);
+        if (!mounted) {
+          return;
         }
+        setProfileMeta({
+          age: profile?.age ?? "",
+          gender: profile?.gender ?? "",
+        });
       })
-      .catch((err) => {
-        console.error(err);
+      .catch((error) => {
+        console.error("[preferences] fetchProfile failed", error);
       });
+    return () => {
+      mounted = false;
+    };
   }, [api, user]);
 
-  const handleSystemLanguageChange = useCallback(
-    (value) => {
-      setSystemLanguage(value);
-    },
-    [setSystemLanguage],
+  const fallbackValue = useMemo(
+    () => t.settingsEmptyValue || "—",
+    [t.settingsEmptyValue],
+  );
+  const accountFields = useMemo(
+    () => buildAccountFields(t, user, profileMeta, fallbackValue),
+    [fallbackValue, profileMeta, t, user],
   );
 
-  const handleSave = useCallback(
-    async (event) => {
-      event.preventDefault();
-      if (!user) {
-        return;
-      }
-      setIsSaving(true);
-      try {
-        const requests = [
-          api.jsonRequest(`${API_PATHS.preferences}/user`, {
-            method: "POST",
-            body: {
-              systemLanguage: sourceLang,
-              searchLanguage: targetLang,
-              theme,
-            },
-          }),
-        ];
-
-        if (api?.profiles?.saveProfile) {
-          requests.push(
-            api.profiles.saveProfile({
-              token: user.token,
-              profile: {
-                age: profileMeta.age,
-                gender: profileMeta.gender,
-                job: personalizationEnabled ? occupation : "",
-                interest: personalizationEnabled ? persona : "",
-                goal: personalizationEnabled ? learningGoal : "",
-              },
-            }),
-          );
-        }
-
-        await Promise.all(requests);
-        persistLanguages(sourceLang, targetLang);
-        persistPersonalization(personalizationEnabled);
-        openPopup(t.saveSuccess);
-      } catch (error) {
-        console.error(error);
-        openPopup(t.fail);
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [
-      api,
-      sourceLang,
-      targetLang,
-      theme,
-      user,
-      profileMeta.age,
-      profileMeta.gender,
-      occupation,
-      persona,
-      learningGoal,
-      personalizationEnabled,
-      persistLanguages,
-      persistPersonalization,
-      openPopup,
-      t.saveSuccess,
-      t.fail,
-    ],
-  );
-
-  useEffect(() => {
-    setSourceLang((prev) =>
-      prev === dictionarySourceLanguage
-        ? prev
-        : toUiSourceLanguage(dictionarySourceLanguage),
-    );
-  }, [dictionarySourceLanguage]);
-
-  useEffect(() => {
-    setTargetLang((prev) =>
-      prev === dictionaryTargetLanguage
-        ? prev
-        : toUiTargetLanguage(dictionaryTargetLanguage),
-    );
-  }, [dictionaryTargetLanguage]);
-
-  const handleTabClick = useCallback((tab) => {
-    setActiveTab(resolveInitialTab(tab));
-  }, []);
-
-  const navRefs = useRef([]);
-
-  const registerNavRef = useCallback(
-    (index) => (node) => {
-      navRefs.current[index] = node ?? null;
-    },
-    [],
-  );
-
-  const focusTabByIndex = useCallback((index) => {
-    const target = navRefs.current[index];
-    if (target && typeof target.focus === "function") {
-      target.focus();
-    }
-  }, []);
-
-  const handleNavKeyDown = useCallback(
-    (index) => (event) => {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        const nextIndex = (index + 1) % TAB_ORDER.length;
-        handleTabClick(TAB_ORDER[nextIndex]);
-        focusTabByIndex(nextIndex);
-        return;
-      }
-
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        const nextIndex = index === 0 ? TAB_ORDER.length - 1 : index - 1;
-        handleTabClick(TAB_ORDER[nextIndex]);
-        focusTabByIndex(nextIndex);
-        return;
-      }
-
-      if (event.key === "Home") {
-        event.preventDefault();
-        handleTabClick(TAB_ORDER[0]);
-        focusTabByIndex(0);
-        return;
-      }
-
-      if (event.key === "End") {
-        event.preventDefault();
-        const lastIndex = TAB_ORDER.length - 1;
-        handleTabClick(TAB_ORDER[lastIndex]);
-        focusTabByIndex(lastIndex);
-      }
-    },
-    [focusTabByIndex, handleTabClick],
-  );
-
-  const renderGeneralPanel = () => {
-    const defaultsTitle = t.prefDefaultsTitle || tabTitleMap[TAB_KEYS.GENERAL];
-    const defaultsDescription =
-      t.prefDefaultsDescription || tabDescriptionMap[TAB_KEYS.GENERAL];
-    const voicesTitle = t.prefVoicesTitle || t.prefVoiceEn;
-    const voicesDescription =
-      t.prefVoicesDescription || tabDescriptionMap[TAB_KEYS.GENERAL];
-    const englishPreviewActive =
-      previewLang === "en" && (isVoicePreviewLoading || isVoicePreviewPlaying);
-    const chinesePreviewActive =
-      previewLang === "zh" && (isVoicePreviewLoading || isVoicePreviewPlaying);
-
-    return (
-      <>
-        <SettingsSection
-          title={defaultsTitle}
-          description={defaultsDescription}
-        >
-          <SettingsRow label={t.prefTheme} htmlFor="pref-theme">
-            <PillSelect
-              id="pref-theme"
-              value={theme}
-              options={themeOptions}
-              onChange={(event) => setTheme(event.target.value)}
-            />
-          </SettingsRow>
-          <SettingsRow
-            label={t.prefSystemLanguage}
-            htmlFor="pref-system-language"
-          >
-            <PillSelect
-              id="pref-system-language"
-              value={systemLanguage}
-              options={systemLanguageOptions}
-              onChange={(event) =>
-                handleSystemLanguageChange(event.target.value)
-              }
-            />
-          </SettingsRow>
-          <SettingsRow label={t.prefLanguage} htmlFor="pref-source-language">
-            <PillSelect
-              id="pref-source-language"
-              value={sourceLang}
-              options={languageOptions}
-              onChange={(event) =>
-                handleSourceLanguageChange(event.target.value)
-              }
-            />
-          </SettingsRow>
-          <SettingsRow
-            label={t.prefSearchLanguage}
-            htmlFor="pref-target-language"
-          >
-            <PillSelect
-              id="pref-target-language"
-              value={targetLang}
-              options={searchLanguageOptions}
-              onChange={(event) =>
-                handleTargetLanguageChange(event.target.value)
-              }
-            />
-          </SettingsRow>
-        </SettingsSection>
-        <SettingsSection title={voicesTitle} description={voicesDescription}>
-          <SettingsRow label={t.prefVoiceEn} htmlFor="pref-voice-en">
-            <VoicePreviewButton
-              onClick={() => handleVoicePreview("en")}
-              active={englishPreviewActive}
-              loading={isVoicePreviewLoading && previewLang === "en"}
-              disabled={
-                !user ||
-                ((isVoicePreviewLoading || isVoicePreviewPlaying) &&
-                  previewLang !== "en")
-              }
-              playLabel={t.settingsVoicePreviewPlay}
-              stopLabel={t.settingsVoicePreviewStop}
-            />
-            <PillSelectField>
-              <VoiceSelector
-                lang="en"
-                id="pref-voice-en"
-                variant="pill"
-                className={styles["pill-native"]}
-              />
-            </PillSelectField>
-          </SettingsRow>
-          <SettingsRow label={t.prefVoiceZh} htmlFor="pref-voice-zh">
-            <VoicePreviewButton
-              onClick={() => handleVoicePreview("zh")}
-              active={chinesePreviewActive}
-              loading={isVoicePreviewLoading && previewLang === "zh"}
-              disabled={
-                !user ||
-                ((isVoicePreviewLoading || isVoicePreviewPlaying) &&
-                  previewLang !== "zh")
-              }
-              playLabel={t.settingsVoicePreviewPlay}
-              stopLabel={t.settingsVoicePreviewStop}
-            />
-            <PillSelectField>
-              <VoiceSelector
-                lang="zh"
-                id="pref-voice-zh"
-                variant="pill"
-                className={styles["pill-native"]}
-              />
-            </PillSelectField>
-          </SettingsRow>
-        </SettingsSection>
-      </>
-    );
-  };
-
-  const renderPersonalizationPanel = () => (
-    <>
-      <SettingsSection
-        title={tabTitleMap[TAB_KEYS.PERSONALIZATION]}
-        description={tabDescriptionMap[TAB_KEYS.PERSONALIZATION]}
-      >
-        <SettingsRow
-          label={t.settingsEnableCustomization || "Enable customization"}
-          htmlFor="personalization-toggle"
-        >
-          <label className={styles.switch} htmlFor="personalization-toggle">
-            <input
-              id="personalization-toggle"
-              type="checkbox"
-              role="switch"
-              aria-checked={personalizationEnabled}
-              checked={personalizationEnabled}
-              onChange={(event) =>
-                setPersonalizationEnabled(event.target.checked)
-              }
-            />
-            <span aria-hidden="true" />
-          </label>
-        </SettingsRow>
-        <SettingsRow
-          label={t.settingsOccupation}
-          htmlFor="personal-occupation"
-          controlFullWidth
-        >
-          <input
-            id="personal-occupation"
-            type="text"
-            className={styles["input-control"]}
-            value={occupation}
-            onChange={(event) => setOccupation(event.target.value)}
-            placeholder={t.settingsOccupationPlaceholder || "e.g. Student"}
-            disabled={!personalizationEnabled}
-          />
-        </SettingsRow>
-        <SettingsRow
-          label={t.settingsAboutYou}
-          htmlFor="personal-about"
-          alignTop
-          controlFullWidth
-        >
-          <textarea
-            id="personal-about"
-            rows={3}
-            className={styles["input-area"]}
-            value={persona}
-            onChange={(event) => setPersona(event.target.value)}
-            placeholder={
-              t.settingsAboutYouPlaceholder ||
-              "Share your expertise, interests, or context."
-            }
-            disabled={!personalizationEnabled}
-          />
-        </SettingsRow>
-        <SettingsRow
-          label={t.settingsLearningGoal}
-          htmlFor="personal-goal"
-          alignTop
-          controlFullWidth
-        >
-          <textarea
-            id="personal-goal"
-            rows={3}
-            className={styles["input-area"]}
-            value={learningGoal}
-            onChange={(event) => setLearningGoal(event.target.value)}
-            placeholder={
-              t.settingsLearningGoalPlaceholder ||
-              "Tell us the outcome you're aiming for."
-            }
-            disabled={!personalizationEnabled}
-          />
-        </SettingsRow>
-      </SettingsSection>
-    </>
-  );
-
-  const renderKeyboardPanel = () => (
-    <>
-      <SettingsSection
-        title={tabTitleMap[TAB_KEYS.KEYBOARD]}
-        description={tabDescriptionMap[TAB_KEYS.KEYBOARD]}
-      >
-        <div className={styles["section-columns"]}>
-          <ul className={styles["shortcut-list"]}>
-            {KEYBOARD_SHORTCUTS.map((shortcut) => (
-              <li key={shortcut.labelKey} className={styles["shortcut-item"]}>
-                <span className={styles["shortcut-key"]}>{shortcut.combo}</span>
-                <span className={styles["shortcut-label"]}>
-                  {t[shortcut.labelKey] || shortcut.labelKey}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </SettingsSection>
-    </>
-  );
-
-  const renderDataPanel = () => (
-    <>
-      <SettingsSection
-        title={tabTitleMap[TAB_KEYS.DATA]}
-        description={tabDescriptionMap[TAB_KEYS.DATA]}
-      >
-        <div className={styles["data-card"]}>
-          <p className={styles["data-description"]}>
-            {t.settingsDataNotice || ""}
-          </p>
-          <div className={styles["data-actions"]}>
-            <button
-              type="button"
-              className={styles["secondary-button"]}
-              disabled
-            >
-              {t.settingsExportData}
-            </button>
-            <button
-              type="button"
-              className={styles["secondary-button"]}
-              disabled
-            >
-              {t.settingsEraseHistory}
-            </button>
-          </div>
-        </div>
-      </SettingsSection>
-    </>
-  );
-
-  const renderAccountPanel = () => {
-    const planName = user?.plan || (user?.isPro ? "plus" : "free");
-    const planLabel = planName
-      ? planName.charAt(0).toUpperCase() + planName.slice(1)
-      : "";
-    return (
-      <>
-        <SettingsSection
-          title={tabTitleMap[TAB_KEYS.ACCOUNT]}
-          description={tabDescriptionMap[TAB_KEYS.ACCOUNT]}
-        >
-          <div className={styles["account-card"]}>
-            <div className={styles["account-header"]}>
-              <Avatar width={56} height={56} />
-              <div className={styles["account-meta"]}>
-                <span className={styles["account-name"]}>
-                  {user?.username || ""}
-                </span>
-                <span className={styles["account-plan"]}>{planLabel}</span>
-              </div>
-              {typeof onOpenAccountManager === "function" ? (
-                <button
-                  type="button"
-                  className={styles["secondary-button"]}
-                  onClick={onOpenAccountManager}
-                >
-                  {t.settingsManageProfile || "Manage profile"}
-                </button>
-              ) : null}
-            </div>
-            <dl className={styles["account-rows"]}>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountUsername}</dt>
-                <dd>{user?.username || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountEmail}</dt>
-                <dd>{user?.email || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountPhone}</dt>
-                <dd>{user?.phone || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountAge}</dt>
-                <dd>{profileMeta.age || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountGender}</dt>
-                <dd>{profileMeta.gender || t.settingsEmptyValue || ""}</dd>
-              </div>
-            </dl>
-          </div>
-        </SettingsSection>
-      </>
-    );
-  };
-
-  const renderActivePanel = () => {
-    switch (activeTab) {
-      case TAB_KEYS.PERSONALIZATION:
-        return renderPersonalizationPanel();
-      case TAB_KEYS.KEYBOARD:
-        return renderKeyboardPanel();
-      case TAB_KEYS.DATA:
-        return renderDataPanel();
-      case TAB_KEYS.ACCOUNT:
-        return renderAccountPanel();
-      case TAB_KEYS.GENERAL:
-      default:
-        return renderGeneralPanel();
-    }
-  };
-
-  const panelId = `settings-panel-${activeTab}`;
-  const containerClassName =
-    variant === VARIANTS.PAGE
-      ? `${styles.container} ${styles.page}`
-      : styles.container;
+  const planName = user?.plan || (user?.isPro ? "plus" : "free");
+  const planLabel = planName
+    ? planName.charAt(0).toUpperCase() + planName.slice(1)
+    : fallbackValue;
+  const preferencesTitle = t.prefTitle || t.prefAccountTitle || "Preferences";
+  const accountTitle = t.prefAccountTitle || preferencesTitle;
+  const accountDescription = t.settingsAccountDescription || "";
+  const manageProfileLabel = t.settingsManageProfile || "Manage profile";
 
   return (
-    <>
+    <div className={styles.content}>
       <form
-        className={containerClassName}
-        onSubmit={handleSave}
-        aria-labelledby="settings-heading"
-        aria-describedby="settings-description"
+        className={styles.form}
+        aria-labelledby="preferences-heading"
+        aria-describedby="preferences-description"
+        onSubmit={(event) => event.preventDefault()}
       >
-        <aside className={styles.sidebar} aria-label={t.prefTitle}>
-          <nav aria-label={t.prefTitle}>
-            <ul
-              className={styles["nav-list"]}
-              role="tablist"
-              aria-orientation="vertical"
-            >
-              {TAB_ORDER.map((tab, index) => {
-                const isActive = activeTab === tab;
-                const icon = TAB_ICONS[tab];
-                const tabId = `settings-tab-${tab}`;
-                const tabPanelId = `settings-panel-${tab}`;
-                const buttonClassName = isActive
-                  ? `${styles["nav-button"]} ${styles["nav-button-active"]}`
-                  : styles["nav-button"];
-                return (
-                  <li key={tab} className={styles["nav-item"]}>
-                    <button
-                      type="button"
-                      role="tab"
-                      id={tabId}
-                      className={buttonClassName}
-                      aria-selected={isActive}
-                      aria-controls={tabPanelId}
-                      tabIndex={isActive ? 0 : -1}
-                      onClick={() => handleTabClick(tab)}
-                      onKeyDown={handleNavKeyDown(index)}
-                      ref={registerNavRef(index)}
-                    >
-                      <span className={styles["nav-dot"]} aria-hidden="true" />
-                      {icon ? (
-                        <ThemeIcon
-                          name={icon}
-                          width={18}
-                          height={18}
-                          className={styles["nav-icon"]}
-                        />
-                      ) : null}
-                      <span className={styles["nav-label"]}>
-                        {tabLabelMap[tab]}
-                      </span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          </nav>
-        </aside>
-        <section
-          className={styles.content}
-          role="tabpanel"
-          id={panelId}
-          aria-labelledby={`settings-tab-${activeTab}`}
-        >
-          <header className={styles["content-header"]}>
-            <h2 id="settings-heading" className={styles["content-title"]}>
-              {tabTitleMap[activeTab]}
-            </h2>
-            {tabDescriptionMap[activeTab] ? (
-              <p className={styles["content-description"]}>
-                {tabDescriptionMap[activeTab]}
+        <header className={styles.header}>
+          <div className={styles.identity}>
+            <Avatar
+              width={72}
+              height={72}
+              className={styles.avatar}
+              alt={user?.username || accountTitle}
+            />
+            <div className={styles["identity-meta"]}>
+              <span className={styles.eyebrow}>{preferencesTitle}</span>
+              <h1 id="preferences-heading" className={styles.title}>
+                {accountTitle}
+              </h1>
+              <p id="preferences-description" className={styles.description}>
+                {accountDescription}
               </p>
-            ) : null}
-          </header>
-          <div className={styles["section-stack"]} id="settings-description">
-            {renderActivePanel()}
+              <span className={styles["plan-badge"]}>{planLabel}</span>
+            </div>
           </div>
-          <footer className={styles["content-footer"]}>
+          {typeof onOpenAccountManager === "function" ? (
             <button
-              type="submit"
-              className={styles["primary-button"]}
-              disabled={isSaving}
+              type="button"
+              className={styles["manage-button"]}
+              onClick={onOpenAccountManager}
             >
-              {isSaving ? (t.saving ?? t.saveButton) : t.saveButton}
+              {manageProfileLabel}
             </button>
-          </footer>
+          ) : null}
+        </header>
+        <section className={styles.section} aria-label={accountTitle}>
+          <dl className={styles["detail-grid"]}>
+            {accountFields.map((field) => (
+              <div key={field.id} className={styles["detail-item"]}>
+                <dt className={styles["detail-label"]}>{field.label}</dt>
+                <dd className={styles["detail-value"]}>{field.value}</dd>
+              </div>
+            ))}
+          </dl>
         </section>
+        <footer className={styles.footer}>
+          <span className={styles["footer-note"]}>{accountDescription}</span>
+        </footer>
       </form>
-      <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
-      />
-    </>
-  );
-}
-
-function SettingsSection({ title, description, children }) {
-  return (
-    <section className={styles.section} aria-label={title}>
-      <header className={styles["section-header"]}>
-        <h3 className={styles["section-title"]}>{title}</h3>
-        {description ? (
-          <p className={styles["section-description"]}>{description}</p>
-        ) : null}
-      </header>
-      <div className={styles["section-body"]}>{children}</div>
-    </section>
-  );
-}
-
-SettingsSection.propTypes = {
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string,
-  children: PropTypes.node.isRequired,
-};
-
-SettingsSection.defaultProps = {
-  description: undefined,
-};
-
-function SettingsRow({
-  label,
-  description,
-  htmlFor,
-  children,
-  alignTop = false,
-  controlFullWidth = false,
-  className = "",
-}) {
-  const rowClassName = [
-    styles.row,
-    alignTop ? styles["row-top"] : null,
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const controlClassName = [
-    styles["row-control"],
-    controlFullWidth ? styles["row-control-full"] : null,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  return (
-    <div className={rowClassName}>
-      <div className={styles["row-label"]}>
-        {htmlFor ? (
-          <label htmlFor={htmlFor} className={styles["row-label-text"]}>
-            {label}
-          </label>
-        ) : (
-          <span className={styles["row-label-text"]}>{label}</span>
-        )}
-        {description ? (
-          <p className={styles["row-label-description"]}>{description}</p>
-        ) : null}
-      </div>
-      <div className={controlClassName}>{children}</div>
     </div>
   );
 }
-
-SettingsRow.propTypes = {
-  label: PropTypes.node.isRequired,
-  description: PropTypes.node,
-  htmlFor: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  alignTop: PropTypes.bool,
-  controlFullWidth: PropTypes.bool,
-  className: PropTypes.string,
-};
-
-SettingsRow.defaultProps = {
-  description: undefined,
-  htmlFor: undefined,
-  alignTop: false,
-  controlFullWidth: false,
-  className: "",
-};
-
-function PillSelectField({ children }) {
-  return (
-    <div className={styles["pill-select"]}>
-      {children}
-      <ChevronDownGlyph className={styles["pill-select-icon"]} />
-    </div>
-  );
-}
-
-PillSelectField.propTypes = {
-  children: PropTypes.node.isRequired,
-};
-
-function PillSelect({ id, value, options, onChange, disabled = false }) {
-  return (
-    <PillSelectField>
-      <select
-        id={id}
-        className={styles["pill-native"]}
-        value={value}
-        onChange={onChange}
-        disabled={disabled}
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </PillSelectField>
-  );
-}
-
-PillSelect.propTypes = {
-  id: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-    }).isRequired,
-  ).isRequired,
-  onChange: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
-};
-
-PillSelect.defaultProps = {
-  disabled: false,
-};
-
-function VoicePreviewButton({
-  onClick,
-  active,
-  loading,
-  disabled,
-  playLabel,
-  stopLabel,
-}) {
-  const label = active ? stopLabel || "Stop" : playLabel || "Play";
-  const isDisabled = disabled && !active;
-
-  return (
-    <button
-      type="button"
-      className={styles["play-button"]}
-      onClick={onClick}
-      data-active={active}
-      aria-pressed={active}
-      aria-busy={loading}
-      disabled={isDisabled}
-    >
-      <PlayGlyph active={active} />
-      <span>{loading && !active ? `${label}…` : label}</span>
-    </button>
-  );
-}
-
-VoicePreviewButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
-  active: PropTypes.bool,
-  loading: PropTypes.bool,
-  disabled: PropTypes.bool,
-  playLabel: PropTypes.string,
-  stopLabel: PropTypes.string,
-};
-
-VoicePreviewButton.defaultProps = {
-  active: false,
-  loading: false,
-  disabled: false,
-  playLabel: undefined,
-  stopLabel: undefined,
-};
-
-function ChevronDownGlyph({ className }) {
-  return (
-    <svg
-      className={className}
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path
-        d="M3 4.5 6 7.5 9 4.5"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-ChevronDownGlyph.propTypes = {
-  className: PropTypes.string,
-};
-
-ChevronDownGlyph.defaultProps = {
-  className: "",
-};
-
-function PlayGlyph({ active }) {
-  if (active) {
-    return (
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 12 12"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          d="M3.25 2.5h1.5a.75.75 0 0 1 .75.75v5.5a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1-.75-.75v-5.5a.75.75 0 0 1 .75-.75Zm4 0h1.5a.75.75 0 0 1 .75.75v5.5a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1-.75-.75v-5.5a.75.75 0 0 1 .75-.75Z"
-          fill="currentColor"
-        />
-      </svg>
-    );
-  }
-
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path
-        d="M3.25 2.15 9.2 5.63a.4.4 0 0 1 0 .7L3.25 9.11a.4.4 0 0 1-.6-.35v-6a.4.4 0 0 1 .6-.35Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-
-PlayGlyph.propTypes = {
-  active: PropTypes.bool,
-};
-
-PlayGlyph.defaultProps = {
-  active: false,
-};
 
 Preferences.propTypes = {
-  variant: PropTypes.oneOf(Object.values(VARIANTS)),
-  initialTab: PropTypes.oneOf(TAB_ORDER),
   onOpenAccountManager: PropTypes.func,
 };
 
 Preferences.defaultProps = {
-  variant: VARIANTS.PAGE,
-  initialTab: TAB_KEYS.GENERAL,
   onOpenAccountManager: undefined,
 };
 


### PR DESCRIPTION
## Summary
- replace the preferences screen with a single account-focused layout backed by a field blueprint
- refresh the module stylesheet for the simplified structure and theme-aware tokens
- add focused tests to verify account data rendering and placeholder handling

## Testing
- npm test -- --runTestsByPath src/pages/preferences/__tests__/Preferences.test.jsx --runInBand --verbose *(fails: Jest environment teardown import error)*


------
https://chatgpt.com/codex/tasks/task_e_68de1d83abe88332889ed8144089521b