### PR TITLE
Align docker width token with SearchBox

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -254,7 +254,7 @@
 }
 
 .docker-inner {
-  width: min(100%, 960px);
+  width: min(100%, var(--sb-max-width, 960px));
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- point .docker-inner width to the shared --sb-max-width token so layout aligns with SearchBox and dictionary panel constraints
- confirmed related ChatInput and DictionaryActionPanel styles already rely on the shared token and need no further changes

## Testing
- npm run lint -- --fix
- npx stylelint "src/**/*.{css,scss}" --fix
- npx prettier --write src/components/Layout/Layout.module.css

------
https://chatgpt.com/codex/tasks/task_e_68de216956888332a85262d092867d2b