### PR TITLE
Refactor preferences page for account summary layout

### DIFF
--- a/website/src/__tests__/Preferences.test.jsx
+++ b/website/src/__tests__/Preferences.test.jsx
@@ -1,414 +1,165 @@
 /* eslint-env jest */
 import React from "react";
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { jest } from "@jest/globals";
-import { API_PATHS } from "@/config/api.js";
 
-const mockRequest = jest.fn().mockResolvedValue({});
-const mockSetTheme = jest.fn();
-const mockTtsVoices = jest.fn().mockResolvedValue([]);
-const mockT = {
-  prefTitle: "Preferences",
-  prefDescription: "Description",
-  prefInterfaceTitle: "Interface experience",
-  prefLanguage: "Source Language",
-  prefSearchLanguage: "Target Language",
-  prefVoiceEn: "English Voice",
-  prefVoiceZh: "Chinese Voice",
-  prefTheme: "Theme",
-  settingsTabGeneral: "General",
-  saveButton: "Save changes",
-  saving: "Saving...",
-  saveSuccess: "Saved",
-  fail: "Fail",
-  autoDetect: "Auto",
-  CHINESE: "CHINESE",
-  ENGLISH: "ENGLISH",
-  close: "Close",
+const mockLanguage = {
+  prefTitle: "Account preferences",
+  prefDescription: "Review and curate your Glancy identity.",
+  prefAccountTitle: "Account",
+  settingsAccountDescription: "Details that travel with your workspace.",
+  settingsAccountUsername: "Username",
+  settingsAccountEmail: "Email",
+  settingsAccountPhone: "Phone",
+  settingsAccountAge: "Age",
+  settingsAccountGender: "Gender",
+  settingsEmptyValue: "Not set",
+  settingsManageProfile: "Manage profile",
 };
+
+let mockUser;
+const fetchProfile = jest.fn();
 
 jest.unstable_mockModule("@/context", () => ({
-  // Aggregate all required context hooks for clarity
-  useLanguage: () => ({ t: mockT, lang: "en" }),
-  useTheme: () => ({ theme: "light", setTheme: mockSetTheme }),
-  useUser: () => ({ user: { id: "1", token: "t" } }),
-  useHistory: () => ({}),
-  useApiContext: () => ({}),
-  useLocale: () => ({ locale: { lang: "en" } }),
+  useLanguage: () => ({ t: mockLanguage }),
+  useUser: () => ({ user: mockUser }),
 }));
-jest.unstable_mockModule("@/hooks", () => ({
-  useEscapeKey: () => ({ on: () => {}, off: () => {} }),
-  useOutsideToggle: () => ({
-    open: false,
-    setOpen: () => {},
-    ref: { current: null },
-  }),
-  useMediaQuery: () => false,
-}));
+
 jest.unstable_mockModule("@/hooks/useApi.js", () => ({
   useApi: () => ({
-    request: mockRequest,
-    jsonRequest: mockRequest,
-    words: { streamWord: jest.fn() },
-    tts: { fetchVoices: mockTtsVoices },
+    profiles: { fetchProfile },
   }),
 }));
-jest.unstable_mockModule("@/components", () => ({
+
+jest.unstable_mockModule("@/components/ui/Avatar", () => ({
   __esModule: true,
-  VoiceSelector: ({ lang }) => <div data-testid={`voice-selector-${lang}`} />,
-  SettingsSurface: ({ title, description, actions, children }) => (
-    <section>
-      <header>
-        <h2>{title}</h2>
-        {description ? <p>{description}</p> : null}
-        {actions}
-      </header>
-      <div>{children}</div>
-    </section>
+  default: ({ className }) => (
+    <div data-testid="avatar" className={className}>
+      avatar
+    </div>
   ),
-  SETTINGS_SURFACE_VARIANTS: {
-    MODAL: "modal",
-    PAGE: "page",
-  },
-}));
-jest.unstable_mockModule("@/store", () => ({
-  useUserStore: (fn) => fn({ user: { plan: "free" } }),
-  useVoiceStore: (fn) =>
-    fn({ voices: {}, setVoice: jest.fn(), getVoice: () => undefined }),
-  useFavoritesStore: (fn) =>
-    fn({
-      favorites: [],
-      toggleFavorite: jest.fn(),
-      includes: () => false,
-    }),
-  useHistoryStore: (fn) =>
-    fn({
-      history: [],
-      loadHistory: jest.fn(),
-      addHistory: jest.fn(),
-      removeHistory: jest.fn(),
-    }),
-  useWordStore: (fn) =>
-    fn({
-      entries: new Map(),
-      setVersions: jest.fn(),
-      getEntry: jest.fn(),
-      getRecord: jest.fn(),
-    }),
-}));
-jest.unstable_mockModule("@/assets/icons.js", () => ({
-  __esModule: true,
-  default: {},
-}));
-
-const {
-  WORD_LANGUAGE_AUTO,
-  WORD_DEFAULT_TARGET_LANGUAGE,
-  normalizeWordSourceLanguage,
-  normalizeWordTargetLanguage,
-} = await import("@/utils/language.js");
-const { SYSTEM_LANGUAGE_AUTO } = await import("@/i18n/languages.js");
-
-const mockSettingsState = {
-  systemLanguage: SYSTEM_LANGUAGE_AUTO,
-  dictionarySourceLanguage: WORD_LANGUAGE_AUTO,
-  dictionaryTargetLanguage: WORD_DEFAULT_TARGET_LANGUAGE,
-};
-
-const buildSettingsSlice = () => ({
-  systemLanguage: mockSettingsState.systemLanguage,
-  setSystemLanguage: (language) => {
-    mockSettingsState.systemLanguage = language;
-  },
-  dictionarySourceLanguage: mockSettingsState.dictionarySourceLanguage,
-  setDictionarySourceLanguage: (language) => {
-    mockSettingsState.dictionarySourceLanguage =
-      normalizeWordSourceLanguage(language);
-  },
-  dictionaryTargetLanguage: mockSettingsState.dictionaryTargetLanguage,
-  setDictionaryTargetLanguage: (language) => {
-    mockSettingsState.dictionaryTargetLanguage =
-      normalizeWordTargetLanguage(language);
-  },
-});
-
-const useSettingsStoreMock = (selector) => selector(buildSettingsSlice());
-useSettingsStoreMock.getState = () => buildSettingsSlice();
-useSettingsStoreMock.setState = (updater) => {
-  const next =
-    typeof updater === "function" ? updater({ ...mockSettingsState }) : updater;
-  if (next && typeof next === "object") {
-    if (Object.prototype.hasOwnProperty.call(next, "systemLanguage")) {
-      mockSettingsState.systemLanguage = next.systemLanguage;
-    }
-    if (
-      Object.prototype.hasOwnProperty.call(next, "dictionarySourceLanguage")
-    ) {
-      mockSettingsState.dictionarySourceLanguage =
-        next.dictionarySourceLanguage;
-    }
-    if (
-      Object.prototype.hasOwnProperty.call(next, "dictionaryTargetLanguage")
-    ) {
-      mockSettingsState.dictionaryTargetLanguage =
-        next.dictionaryTargetLanguage;
-    }
-  }
-};
-useSettingsStoreMock.reset = () => {
-  mockSettingsState.systemLanguage = SYSTEM_LANGUAGE_AUTO;
-  mockSettingsState.dictionarySourceLanguage = WORD_LANGUAGE_AUTO;
-  mockSettingsState.dictionaryTargetLanguage = WORD_DEFAULT_TARGET_LANGUAGE;
-};
-
-jest.unstable_mockModule("@/store/settings", () => ({
-  useSettingsStore: useSettingsStoreMock,
-  SUPPORTED_SYSTEM_LANGUAGES: ["en"],
 }));
 
 const { default: Preferences } = await import("@/pages/preferences");
-const { default: SettingsModal } = await import(
-  "@/components/modals/SettingsModal.jsx"
-);
-const { useSettingsStore } = await import("@/store/settings");
 
 beforeEach(() => {
-  localStorage.clear();
-  mockRequest.mockReset();
-  mockRequest.mockResolvedValue({});
-  mockSetTheme.mockClear();
-  useSettingsStore.setState({
-    dictionarySourceLanguage: WORD_LANGUAGE_AUTO,
-    dictionaryTargetLanguage: WORD_DEFAULT_TARGET_LANGUAGE,
-    systemLanguage: SYSTEM_LANGUAGE_AUTO,
-  });
+  mockUser = {
+    username: "Ada",
+    email: "ada@example.com",
+    phone: "+1-111",
+    plan: "plus",
+    token: "token-123",
+  };
+  fetchProfile.mockReset();
+  fetchProfile.mockResolvedValue({ age: 28, gender: "Female" });
 });
 
 /**
- * Ensures user preference changes trigger API requests and persist through
- * the mocked backend service.
- */
-test("saves preferences via api", async () => {
-  await act(async () => {
-    render(<Preferences />);
-  });
-  await act(async () => {});
-  fireEvent.change(screen.getByLabelText("Source Language"), {
-    target: { value: "CHINESE" },
-  });
-  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
-  await waitFor(() => expect(mockRequest).toHaveBeenCalled());
-  expect(mockRequest.mock.calls[0][0]).toBe(`${API_PATHS.preferences}/user`);
-});
-
-/**
- * 防止设置页因缺失主题数据而覆盖用户的显式选择。
- */
-test("keeps user theme when server does not provide one", async () => {
-  await act(async () => {
-    render(<Preferences />);
-  });
-  await act(async () => {});
-  await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
-  expect(mockSetTheme).not.toHaveBeenCalled();
-});
-
-/**
- * 测试目标：设置弹窗应渲染自定义关闭按钮，并保证焦点留在弹窗内部且 aria 属性正确。
- * 前置条件：
- *  - SettingsModal 以 open=true 渲染，使用 jest 上下文 mock。
+ * 测试目标：渲染账户摘要表单并校验字段与翻译文案正确显示。
+ * 前置条件：提供完整的语言与用户上下文，profile 接口返回年龄与性别。
  * 步骤：
- *  1) 渲染组件并等待初次 effect。
- *  2) 查询关闭按钮与 dialog 节点。
- *  3) 校验 dialog 的 aria 属性与焦点范围。
+ *  1) 渲染 Preferences 组件。
+ *  2) 等待 profile 接口完成。
  * 断言：
- *  - 关闭按钮存在，dialog 具备 aria-modal 属性，当前焦点位于弹窗内。
+ *  - 标题、描述、各字段值与 profile 返回值匹配。
  * 边界/异常：
- *  - 若焦点跑出弹窗或 aria 属性缺失，测试失败以提示回归。
+ *  - 若接口未调用则测试失败，提示数据未拉取。
  */
-test("GivenSettingsModal_WhenOpened_ThenCustomCloseButtonRenderedWithAriaContext", async () => {
-  const handleClose = jest.fn();
+test("GivenUserContext_WhenRendered_ThenAccountFieldsReflectUserData", async () => {
+  render(<Preferences />);
 
-  await act(async () => {
-    render(<SettingsModal open onClose={handleClose} />);
-  });
+  await waitFor(() => expect(fetchProfile).toHaveBeenCalledTimes(1));
 
-  const [closeButton] = await screen.findAllByRole("button", { name: "Close" });
-  const dialog = screen.getByRole("dialog");
+  expect(
+    screen.getByRole("heading", { name: mockLanguage.prefTitle, level: 2 }),
+  ).toBeInTheDocument();
+  expect(screen.getByText(mockLanguage.prefDescription)).toBeInTheDocument();
 
-  expect(closeButton).toBeVisible();
-  expect(dialog).toHaveAttribute("aria-modal", "true");
-  await waitFor(() => {
-    expect(dialog).toContainElement(document.activeElement);
-  });
+  expect(
+    screen.getByText(mockLanguage.settingsAccountUsername),
+  ).toBeInTheDocument();
+  expect(screen.getByText(mockUser.username)).toBeInTheDocument();
+  expect(screen.getByText(mockUser.email)).toBeInTheDocument();
+  expect(screen.getByText(mockUser.phone)).toBeInTheDocument();
+  expect(await screen.findByText("28")).toBeInTheDocument();
+  expect(await screen.findByText("Female")).toBeInTheDocument();
 });
 
 /**
- * 测试目标：点击设置弹窗中的关闭按钮应触发 onClose 回调。
- * 前置条件：
- *  - SettingsModal 处于打开状态，并注入 jest.fn() 作为 onClose。
+ * 测试目标：当用户信息或 profile 数据缺失时显示占位文案。
+ * 前置条件：用户上下文缺少邮箱与电话，profile 返回空值。
  * 步骤：
- *  1) 渲染组件。
- *  2) 点击关闭按钮。
+ *  1) 更新 mockUser 与 profile 返回值为空。
+ *  2) 渲染组件并等待请求完成。
  * 断言：
- *  - onClose 被调用一次，表明事件链路畅通。
+ *  - 对应字段显示 settingsEmptyValue。
  * 边界/异常：
- *  - 若按钮缺失或点击未触发回调，测试失败以暴露回归。
+ *  - 若仍显示空字符串，表明回填逻辑未生效。
  */
-test("GivenSettingsModal_WhenCloseClicked_ThenOnCloseFires", async () => {
-  const handleClose = jest.fn();
+test("GivenMissingAccountData_WhenRendered_ThenFallbackCopyDisplayed", async () => {
+  mockUser = {
+    username: "Ada",
+    email: "",
+    phone: undefined,
+    plan: "",
+    token: "token-123",
+  };
+  fetchProfile.mockResolvedValue({ age: null, gender: "" });
 
-  await act(async () => {
-    render(<SettingsModal open onClose={handleClose} />);
-  });
+  render(<Preferences />);
 
-  const [modalCloseButton] = screen.getAllByRole("button", { name: "Close" });
-  fireEvent.click(modalCloseButton);
+  await waitFor(() => expect(fetchProfile).toHaveBeenCalledTimes(1));
 
-  expect(handleClose).toHaveBeenCalledTimes(1);
+  const fallback = mockLanguage.settingsEmptyValue;
+  expect(screen.getAllByText(fallback)).toHaveLength(4);
 });
 
 /**
- * 测试目标：
- *  - 默认页面模式不应渲染关闭按钮，确保布局纯粹。
- * 前置条件：
- *  - 渲染未提供 onClose 的 Preferences 页面。
+ * 测试目标：验证“Manage profile”按钮触发上层回调。
+ * 前置条件：传入 onOpenAccountManager 回调。
  * 步骤：
- *  1) 渲染组件并等待初次 effect。
+ *  1) 渲染组件并等待 profile 请求。
+ *  2) 点击按钮。
  * 断言：
- *  - 查询关闭按钮返回 null，避免误露出无效控件。
+ *  - 回调被调用一次。
  * 边界/异常：
- *  - 若默认模式渲染按钮则测试失败，提示可访问性回归。
+ *  - 若按钮未渲染或未触发回调则测试失败。
  */
-test("GivenPreferencesWithoutOnClose_WhenRendered_ThenCloseButtonHidden", async () => {
-  await act(async () => {
-    render(<Preferences />);
-  });
-  await act(async () => {});
+test("GivenManageProfileHandler_WhenClicked_ThenDelegateInvoked", async () => {
+  const handleOpen = jest.fn();
+  render(<Preferences onOpenAccountManager={handleOpen} />);
 
-  expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  await waitFor(() => expect(fetchProfile).toHaveBeenCalledTimes(1));
+
+  const button = screen.getByRole("button", {
+    name: mockLanguage.settingsManageProfile,
+  });
+  await userEvent.setup().click(button);
+
+  expect(handleOpen).toHaveBeenCalledTimes(1);
 });
 
 /**
- * 测试目标：
- *  - 对话框模式应渲染关闭按钮并在点击时触发回调。
- * 前置条件：
- *  - 注入 onClose 模拟函数，并以 dialog 变体渲染组件。
+ * 测试目标：在缺少用户上下文时不调用 profile 接口且隐藏管理按钮。
+ * 前置条件：mockUser 设为 undefined。
  * 步骤：
- *  1) 渲染组件并等待初次 effect。
- *  2) 获取关闭按钮并触发点击。
+ *  1) 将 mockUser 置空并渲染组件。
  * 断言：
- *  - onClose 恰好被调用一次，说明事件链路正确。
+ *  - fetchProfile 未被调用。
+ *  - 页面不包含 Manage profile 按钮。
  * 边界/异常：
- *  - 若按钮缺失或多次触发，则视为交互回归。
+ *  - 若接口被调用则说明守卫逻辑失效。
  */
-test("GivenPreferencesDialog_WhenCloseClicked_ThenOnCloseInvoked", async () => {
-  const handleClose = jest.fn();
+test("GivenNoUserContext_WhenRendered_ThenProfileRequestSkipped", () => {
+  mockUser = undefined;
 
-  await act(async () => {
-    render(<Preferences variant="dialog" onClose={handleClose} />);
-  });
-  await act(async () => {});
+  render(<Preferences onOpenAccountManager={jest.fn()} />);
 
-  const closeButton = screen.getByRole("button", { name: "Close" });
-  fireEvent.click(closeButton);
-
-  expect(handleClose).toHaveBeenCalledTimes(1);
-});
-
-/**
- * 测试目标：
- *  - 关闭按钮需支持键盘 Enter 激活，保障可访问性。
- * 前置条件：
- *  - 渲染带 onClose 的 dialog 变体并准备 userEvent。
- * 步骤：
- *  1) 渲染组件并聚焦关闭按钮。
- *  2) 通过键盘输入 Enter 激活。
- * 断言：
- *  - onClose 被调用一次，证明键盘路径生效。
- * 边界/异常：
- *  - 若键盘触发未生效，则需检查按钮语义或事件绑定。
- */
-test("GivenPreferencesDialog_WhenEnterPressedOnClose_ThenOnCloseInvoked", async () => {
-  const handleClose = jest.fn();
-  const user = userEvent.setup();
-
-  await act(async () => {
-    render(<Preferences variant="dialog" onClose={handleClose} />);
-  });
-  await act(async () => {});
-
-  const closeButton = screen.getByRole("button", { name: "Close" });
-  closeButton.focus();
-  expect(closeButton).toHaveFocus();
-
-  await user.keyboard("{Enter}");
-
-  expect(handleClose).toHaveBeenCalledTimes(1);
-});
-
-/**
- * 测试目标：确保设置页侧栏标签与主标题使用不同文案，维持信息层级清晰。
- * 前置条件：默认渲染 Preferences 页面，并提供区分的翻译文案。
- * 步骤：
- *  1) 渲染组件。
- *  2) 捕获当前激活的导航标签与内容标题。
- * 断言：
- *  - 标签文本与标题文本不相等，否则提示文案配置回退。
- * 边界/异常：
- *  - 若翻译缺失导致文本一致，应提醒补齐翻译或调整默认值。
- */
-test("renders distinct copy between navigation and heading", async () => {
-  await act(async () => {
-    render(<Preferences />);
-  });
-  await act(async () => {});
-
-  const activeTab = screen.getByRole("tab", { selected: true });
-  const heading = screen.getByRole("heading", { level: 2 });
-
-  expect(activeTab.textContent?.trim()).not.toBe(heading.textContent?.trim());
-});
-
-/**
- * 确认后端返回的主题值不会在用户未操作时触发全局主题切换。
- */
-test("ignores remote theme preference without user input", async () => {
-  mockRequest.mockReset();
-  mockRequest.mockResolvedValue({ theme: "dark" });
-  await act(async () => {
-    render(<Preferences />);
-  });
-  await act(async () => {});
-  await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
-  expect(mockSetTheme).not.toHaveBeenCalled();
-  expect(screen.getByLabelText("Theme").value).toBe("light");
-});
-
-/**
- * 确认语言选择会同步更新字典配置的全局 Store，保障即时生效。
- */
-test("updates dictionary language preferences in settings store", async () => {
-  await act(async () => {
-    render(<Preferences />);
-  });
-  await act(async () => {});
-  fireEvent.change(screen.getByLabelText("Source Language"), {
-    target: { value: "CHINESE" },
-  });
-  fireEvent.change(screen.getByLabelText("Target Language"), {
-    target: { value: "ENGLISH" },
-  });
-  await waitFor(() => {
-    const state = useSettingsStore.getState();
-    expect(state.dictionarySourceLanguage).toBe("CHINESE");
-    expect(state.dictionaryTargetLanguage).toBe("ENGLISH");
-  });
+  expect(fetchProfile).not.toHaveBeenCalled();
+  expect(
+    screen.queryByRole("button", {
+      name: mockLanguage.settingsManageProfile,
+    }),
+  ).not.toBeInTheDocument();
 });

--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -6,7 +6,7 @@ import styles from "./SettingsModal.module.css";
 import { SettingsSurface } from "@/components";
 import { useLanguage } from "@/context";
 
-function SettingsModal({ open, onClose, initialTab, onOpenAccountManager }) {
+function SettingsModal({ open, onClose, onOpenAccountManager }) {
   const { t } = useLanguage();
   const closeLabel = t.close ?? "Close";
   const surfaceTitle = t.prefTitle ?? "Preferences";
@@ -45,12 +45,7 @@ function SettingsModal({ open, onClose, initialTab, onOpenAccountManager }) {
         description={surfaceDescription}
         actions={closeAction}
       >
-        <Preferences
-          variant="dialog"
-          initialTab={initialTab}
-          onOpenAccountManager={onOpenAccountManager}
-          onClose={onClose}
-        />
+        <Preferences onOpenAccountManager={onOpenAccountManager} />
       </SettingsSurface>
     </BaseModal>
   );
@@ -59,12 +54,10 @@ function SettingsModal({ open, onClose, initialTab, onOpenAccountManager }) {
 SettingsModal.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  initialTab: PropTypes.string,
   onOpenAccountManager: PropTypes.func,
 };
 
 SettingsModal.defaultProps = {
-  initialTab: undefined,
   onOpenAccountManager: undefined,
 };
 

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -1,902 +1,246 @@
 /**
  * 背景：
- *  - 主题系统扩展到浅色时，原本写死在容器变量上的暗色值无法复用。
+ *  - 偏好设置回归账户信息展示，需要重塑单列面板的视觉节奏。
  * 目的：
- *  - 为偏好面板提供暗/浅两套令牌映射，并沿用既有 `--sidebar-*` 设计语言。
+ *  - 提供奢侈品级极简的账户摘要样式，兼容暗/浅/系统三种主题令牌。
  * 关键决策与取舍：
- *  - 暗色分支继续锚定 night token，保持当前感知；浅色分支复用侧边栏 light token，避免重复维护颜色。
- *  - 额外抽象 `--settings-panel-surface-active` 与 `--settings-panel-press`，确保常规/激活/按压层级在两套主题中语义一致。
+ *  - 沿用原有设置面板配色变量，删除多标签与语音预览遗留样式。
+ *  - 通过柔和的层次与充足留白凸显关键信息，为未来编辑态预留空间。
  * 影响范围：
- *  - 仅偏好设置面板依赖的 CSS 变量；其他页面未引用这些变量不受影响。
+ *  - 仅作用于 Preferences 页面。
  * 演进与TODO：
- *  - 若后续引入更多主题，可在此处扩展新的 :root 分支，或改由主题模块集中注入。
+ *  - TODO: 当引入更多字段或编辑态时扩展交互状态（hover/focus/disabled）。
  */
 
-.container {
-  --settings-panel-radius: 16px;
-  --settings-panel-nav-width: 280px;
-  --settings-panel-padding-x: 32px;
-  --settings-panel-padding-y: 28px;
-  --settings-panel-gap: 24px;
-  --settings-panel-row-gap: 18px;
-  --settings-panel-row-height: 56px;
-  --settings-panel-max-width: min(92vw, 960px);
-  --settings-panel-min-width: 720px;
-  --settings-panel-max-height: 86vh;
-  --settings-panel-transition: 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
-
-  position: relative;
-  display: grid;
-  grid-template-columns: var(--settings-panel-nav-width) minmax(0, 1fr);
-  gap: var(--settings-panel-gap);
-  width: 100%;
-  max-width: var(--settings-panel-max-width);
-  min-width: min(100%, var(--settings-panel-min-width));
-  max-height: var(--settings-panel-max-height);
-  padding: var(--settings-panel-padding-y) var(--settings-panel-padding-x);
-  border-radius: var(--settings-panel-radius);
-  background: var(--settings-panel-bg);
-  color: var(--settings-panel-text);
-  box-shadow: var(--settings-panel-shadow);
-  overflow: hidden;
+.content {
+  display: flex;
+  justify-content: center;
+  padding: 56px 24px 72px;
 }
 
-:global(:root[data-theme="dark"]) .container,
-:global(:root:not([data-theme])) .container {
-  --settings-panel-bg: var(--night-panel);
-  --settings-panel-surface: var(--night-active);
-  --settings-panel-surface-hover: var(--night-hover);
-  --settings-panel-surface-active: var(--night-active);
-  --settings-panel-press: var(--night-hover);
-  --settings-panel-border: var(--night-border);
-  --settings-panel-text: var(--night-text);
-  --settings-panel-muted: var(--night-muted);
-  --settings-panel-shadow: 0 24px 60px rgb(0 0 0 / 45%);
-  --settings-panel-ring: var(--night-input-ring);
-  --settings-panel-overlay: var(--color-overlay-strong);
+.form {
+  --preferences-panel-bg: var(--night-panel);
+  --preferences-panel-border: rgb(255 255 255 / 12%);
+  --preferences-panel-text: var(--night-text);
+  --preferences-panel-muted: var(--night-muted);
+  --preferences-panel-ring: var(--night-input-ring);
+  --preferences-panel-surface: rgb(255 255 255 / 6%);
+  --preferences-panel-shadow: 0 24px 60px rgb(0 0 0 / 45%);
+  --preferences-panel-accent: linear-gradient(135deg, #5a8bff, #4c6fff);
+  --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 35%);
+
+  width: min(720px, 100%);
+  padding: 44px;
+  border-radius: 20px;
+  border: 1px solid var(--preferences-panel-border);
+  background: var(--preferences-panel-bg);
+  box-shadow: var(--preferences-panel-shadow);
+  color: var(--preferences-panel-text);
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
 }
 
-:global(:root[data-theme="light"]) .container {
-  /*
-   * 主题映射：
-   *  - 所有颜色引用现有 light 面板令牌，确保与侧栏、弹层等组件风格一致。
-   */
-  --settings-panel-bg: var(--sidebar-panel, var(--neutral-0));
-  --settings-panel-surface: var(--sidebar-panel, var(--neutral-0));
-  --settings-panel-surface-hover: var(--sidebar-hover-bg, rgb(15 17 21 / 6%));
-  --settings-panel-surface-active: var(
-    --sidebar-active-bg,
-    rgb(15 17 21 / 12%)
-  );
-  --settings-panel-press: var(--sidebar-active-bg, rgb(15 17 21 / 12%));
-  --settings-panel-border: var(--sidebar-border-color, #d9dde7);
-  --settings-panel-text: var(--sidebar-text-color, var(--text-primary-light));
-  --settings-panel-muted: var(
-    --sidebar-muted-color,
-    color-mix(in srgb, var(--text-primary-light) 55%, transparent)
-  );
-  --settings-panel-shadow: var(
+:global(:root[data-theme="light"]) .form {
+  --preferences-panel-bg: var(--sidebar-panel, var(--neutral-0));
+  --preferences-panel-border: var(--sidebar-border-color, #d9dde7);
+  --preferences-panel-text: var(--sidebar-text-color, #1f232b);
+  --preferences-panel-muted: var(--sidebar-muted-color, #6f7585);
+  --preferences-panel-ring: var(--sidebar-input-ring, #cfd4e2);
+  --preferences-panel-surface: rgb(15 17 21 / 6%);
+  --preferences-panel-shadow: var(
     --sidebar-shadow-elevated,
     0 18px 42px rgb(31 35 43 / 16%)
   );
-  --settings-panel-ring: var(--sidebar-input-ring, #cfd4e2);
-  --settings-panel-overlay: var(--color-overlay);
+  --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 22%);
 }
 
-:global(:root[data-theme="system"]) .container {
-  /*
-   * 系统主题跟随：
-   *  - 变量值挂靠在 `--sidebar-*` 令牌上，让浏览器 `prefers-color-scheme` 接管明暗切换。
-   */
-  --settings-panel-bg: var(--sidebar-panel, var(--night-panel));
-  --settings-panel-surface: var(--sidebar-panel, var(--night-active));
-  --settings-panel-surface-hover: var(--sidebar-hover-bg, var(--night-hover));
-  --settings-panel-surface-active: var(
-    --sidebar-active-bg,
-    var(--night-active)
+:global(:root[data-theme="system"]) .form {
+  --preferences-panel-bg: var(--sidebar-panel, var(--night-panel));
+  --preferences-panel-border: var(--sidebar-border-color, var(--night-border));
+  --preferences-panel-text: var(--sidebar-text-color, var(--night-text));
+  --preferences-panel-muted: var(--sidebar-muted-color, var(--night-muted));
+  --preferences-panel-ring: var(--sidebar-input-ring, var(--night-input-ring));
+  --preferences-panel-surface: color-mix(
+    in srgb,
+    var(--sidebar-panel, var(--night-panel)) 92%,
+    transparent
   );
-  --settings-panel-press: var(--sidebar-active-bg, var(--night-hover));
-  --settings-panel-border: var(--sidebar-border-color, var(--night-border));
-  --settings-panel-text: var(--sidebar-text-color, var(--night-text));
-  --settings-panel-muted: var(--sidebar-muted-color, var(--night-muted));
-  --settings-panel-shadow: var(
+  --preferences-panel-shadow: var(
     --sidebar-shadow-elevated,
     0 24px 60px rgb(0 0 0 / 45%)
   );
-  --settings-panel-ring: var(--sidebar-input-ring, var(--night-input-ring));
-  --settings-panel-overlay: var(--color-overlay);
+  --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 30%);
 }
 
-.page {
-  margin: 40px auto;
-  width: min(100%, var(--settings-panel-max-width));
-}
-
-.surface {
-  position: relative;
-  display: contents;
-}
-
-.sidebar {
+.header {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  width: var(--settings-panel-nav-width);
-  min-height: 0;
+  gap: 20px;
 }
 
-/*
- * 背景：
- *  - 对话框模式需在侧边栏顶部提供关闭按钮，节奏需与导航按钮一致。
- * 设计取舍：
- *  - 沿用 nav-button 的尺寸与过渡，保证视觉韵律；按钮仅在提供 onClose 时渲染。
- */
-.sidebar-close {
-  align-self: flex-end;
-  display: inline-flex;
+.identity {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border: none;
-  border-radius: 12px;
-  background: transparent;
-  color: var(--settings-panel-muted);
-  cursor: pointer;
-  transition:
-    background var(--settings-panel-transition),
-    color var(--settings-panel-transition),
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
+  gap: 18px;
 }
 
-.sidebar-close:hover {
-  background: var(--settings-panel-surface-hover);
-  color: var(--settings-panel-text);
+.avatar {
+  width: 56px;
+  height: 56px;
 }
 
-.sidebar-close:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
+.identity-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.sidebar-close-icon {
-  width: 16px;
-  height: 16px;
-  color: inherit;
-}
-
-.nav-title {
+.plan {
   margin: 0;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
-  color: var(--settings-panel-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--preferences-panel-muted);
 }
 
-.nav-list {
+.title {
   margin: 0;
-  padding: 8px 4px 8px 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  overflow-y: auto;
-}
-
-.nav-item {
-  display: contents;
-}
-
-.nav-button {
-  position: relative;
-  display: grid;
-  grid-template-columns: 8px 20px auto;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  min-height: 48px;
-  padding: 0 16px;
-  border: none;
-  border-radius: 12px;
-  background: transparent;
-  color: var(--settings-panel-muted);
-  font-size: 14px;
-  font-weight: 500;
-  text-align: left;
-  cursor: pointer;
-  transition:
-    background var(--settings-panel-transition),
-    color var(--settings-panel-transition),
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.nav-button:hover {
-  background: var(--settings-panel-surface-hover);
-  color: var(--settings-panel-text);
-}
-
-.nav-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.nav-button-active {
-  background: var(--settings-panel-surface-active);
-  color: var(--settings-panel-text);
-}
-
-.nav-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: transparent;
-  transform: scale(0.4);
-  transition:
-    transform var(--settings-panel-transition),
-    background var(--settings-panel-transition);
-}
-
-.nav-button-active .nav-dot {
-  background: var(--settings-panel-text);
-  transform: scale(1);
-}
-
-.nav-icon {
-  width: 18px;
-  height: 18px;
-  color: inherit;
-}
-
-.nav-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.content {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  gap: 0;
-  min-width: 0;
-  min-height: 0;
-}
-
-.content-header {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding-bottom: 20px;
-}
-
-.content-title {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 700;
+  font-size: 28px;
+  font-weight: 600;
   line-height: 1.2;
+  color: var(--preferences-panel-text);
 }
 
-.content-description {
+.description {
   margin: 0;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--settings-panel-muted);
-}
-
-.section-stack {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  padding-right: 4px;
-  overflow-y: auto;
-  padding-bottom: 24px;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--preferences-panel-muted);
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 24px;
+  padding: 32px;
+  border-radius: 18px;
+  border: 1px solid var(--preferences-panel-border);
+  background: var(--preferences-panel-surface);
 }
 
 .section-header {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
 }
 
 .section-title {
   margin: 0;
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
+  color: var(--preferences-panel-text);
 }
 
 .section-description {
   margin: 0;
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-  line-height: 1.5;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--preferences-panel-muted);
 }
 
-.section-body {
-  border: 1px solid var(--settings-panel-border);
-  border-radius: 14px;
-  overflow: hidden;
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 96%,
-    transparent
-  );
-}
-
-.row {
+.details {
+  margin: 0;
+  padding: 0;
   display: grid;
-  grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
-  align-items: center;
-  gap: 16px;
-  min-height: var(--settings-panel-row-height);
-  padding: 12px 20px;
+  gap: 18px;
 }
 
-.row-top {
-  align-items: flex-start;
+.detail-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 0.35fr) minmax(0, 1fr);
+  gap: 28px;
+  align-items: baseline;
 }
 
-.row-control {
-  justify-self: end;
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.row-top .row-control {
-  align-self: stretch;
-}
-
-.row + .row {
-  border-top: 1px solid var(--settings-panel-border);
-}
-
-.row-label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.row-label-text {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--settings-panel-text);
-}
-
-.row-label-description {
+.detail-label {
+  margin: 0;
   font-size: 13px;
-  color: var(--settings-panel-muted);
-  line-height: 1.45;
-}
-
-.row-control-full {
-  width: 100%;
-  justify-content: flex-start;
-}
-
-.row-control-full > * {
-  width: 100%;
-}
-
-.pill-select {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  min-width: 180px;
-}
-
-.pill-native {
-  width: 100%;
-  min-height: 36px;
-  padding: 0 36px 0 16px;
-  border-radius: 999px;
-  border: 1px solid var(--settings-panel-border);
-  background: var(--settings-panel-surface);
-  color: var(--settings-panel-text);
-  font-size: 14px;
   font-weight: 600;
-  letter-spacing: 0.01em;
-  appearance: none;
-  cursor: pointer;
-  transition:
-    background-color var(--settings-panel-transition),
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition),
-    color var(--settings-panel-transition);
+  color: var(--preferences-panel-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.pill-native:focus-visible {
-  outline: none;
-  border-color: var(--settings-panel-ring);
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
+.detail-value {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--preferences-panel-text);
+  overflow-wrap: break-word;
 }
 
-.pill-native:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.pill-native:hover:not(:disabled) {
-  background: var(--settings-panel-surface-hover);
-}
-
-.pill-select-icon {
-  position: absolute;
-  right: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: var(--settings-panel-muted);
-}
-
-.play-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 36px;
-  padding: 0 16px;
-  border-radius: 12px;
-  border: 1px solid var(--settings-panel-border);
-  background: var(--settings-panel-surface);
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color var(--settings-panel-transition),
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition),
-    border-color var(--settings-panel-transition);
-}
-
-.play-button[data-active="true"] {
-  background: var(--settings-panel-press);
-}
-
-.play-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.play-button:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.play-button:hover:not(:disabled) {
-  background: var(--settings-panel-surface-hover);
-}
-
-.content-footer {
+.footer {
   display: flex;
   justify-content: flex-end;
-  padding-top: 20px;
-  border-top: 1px solid var(--settings-panel-border);
-  margin-top: 24px;
+  padding-top: 26px;
+  border-top: 1px solid var(--preferences-panel-border);
 }
 
-.primary-button {
+.manage-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 160px;
-  min-height: 42px;
-  padding: 0 24px;
-  border-radius: 999px;
+  min-width: 176px;
+  min-height: 44px;
+  padding: 0 28px;
   border: none;
-  background: linear-gradient(135deg, #5a8bff, #4c6fff);
+  border-radius: 999px;
+  background: var(--preferences-panel-accent);
   color: #fff;
   font-size: 15px;
   font-weight: 600;
   cursor: pointer;
   transition:
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
+    transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.primary-button:focus-visible {
+.manage-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgb(76 111 255 / 40%);
+  box-shadow: 0 0 0 3px var(--preferences-panel-ring);
 }
 
-.primary-button:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.primary-button:hover:not(:disabled) {
+.manage-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgb(76 111 255 / 35%);
+  box-shadow: var(--preferences-panel-accent-shadow);
 }
 
-.shortcut-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+.manage-button:active {
+  transform: translateY(0);
 }
 
-.shortcut-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 20px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 90%,
-    transparent
-  );
-}
-
-.shortcut-key {
-  font-family:
-    SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
-  font-size: 12px;
-  font-weight: 600;
-  padding: 6px 10px;
-  border-radius: 10px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-  color: var(--settings-panel-text);
-}
-
-.shortcut-label {
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-}
-
-.data-card {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  padding: 20px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 94%,
-    transparent
-  );
-}
-
-.data-description {
-  margin: 0;
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-  line-height: 1.6;
-}
-
-.data-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.secondary-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 36px;
-  padding: 0 18px;
-  border-radius: 999px;
-  border: 1px solid var(--settings-panel-border);
-  background: transparent;
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color var(--settings-panel-transition),
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.secondary-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.secondary-button:hover:not(:disabled) {
-  background: var(--settings-panel-surface-hover);
-}
-
-.section-columns {
-  display: grid;
-  gap: 18px;
-}
-
-.switch-row {
-  justify-content: space-between;
-}
-
-.switch {
-  position: relative;
-  width: 48px;
-  height: 26px;
-}
-
-.switch input {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-}
-
-.switch span {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--settings-panel-border) 55%, transparent);
-  transition:
-    background-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.switch span::after {
-  content: "";
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  width: 18px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--settings-panel-text);
-  box-shadow: 0 2px 4px rgb(0 0 0 / 24%);
-  transition:
-    transform var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.switch input:checked + span {
-  background: linear-gradient(135deg, #5a8bff, #4c6fff);
-}
-
-.switch input:checked + span::after {
-  transform: translateX(22px);
-}
-
-.switch input:focus-visible + span {
-  outline: none;
-  box-shadow: 0 0 0 2px rgb(76 111 255 / 45%);
-}
-
-.input-control {
-  width: 100%;
-  min-height: 44px;
-  padding: 0 18px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  font-weight: 500;
-  transition:
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition),
-    background-color var(--settings-panel-transition);
-}
-
-.input-control:focus-visible {
-  outline: none;
-  border-color: var(--settings-panel-ring);
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.input-control:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.input-area {
-  width: 100%;
-  padding: 14px 18px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-  color: var(--settings-panel-text);
-  font-size: 14px;
-  line-height: 1.6;
-  resize: vertical;
-  min-height: 120px;
-  transition:
-    border-color var(--settings-panel-transition),
-    box-shadow var(--settings-panel-transition);
-}
-
-.input-area:focus-visible {
-  outline: none;
-  border-color: var(--settings-panel-ring);
-  box-shadow: 0 0 0 2px var(--settings-panel-ring);
-}
-
-.input-area:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-}
-
-.inline-field {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.account-card {
-  display: grid;
-  gap: 18px;
-  padding: 20px;
-  border-radius: 14px;
-  border: 1px solid var(--settings-panel-border);
-  background: color-mix(
-    in srgb,
-    var(--settings-panel-surface) 92%,
-    transparent
-  );
-}
-
-.account-header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.account-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.account-name {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--settings-panel-text);
-}
-
-.account-plan {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--settings-panel-muted);
-}
-
-.account-rows dt {
-  margin: 0;
-  font-size: 13px;
-  color: var(--settings-panel-muted);
-}
-
-.account-rows dd {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.account-rows {
-  display: grid;
-  gap: 12px;
-}
-
-.account-row {
-  display: flex;
-  justify-content: space-between;
-  font-size: 14px;
-  color: var(--settings-panel-text);
-}
-
-.account-row dd {
-  margin: 0;
-  color: var(--settings-panel-muted);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .nav-button,
-  .pill-native,
-  .play-button,
-  .primary-button,
-  .secondary-button,
-  .switch span,
-  .switch span::after {
-    transition: none;
-  }
-}
-
-@media (width <= 1023px) {
-  .container {
-    grid-template-columns: 240px minmax(0, 1fr);
-
-    --settings-panel-nav-width: 240px;
-  }
-}
-
-@media (width <= 900px) {
-  .container {
-    grid-template-columns: 220px minmax(0, 1fr);
-
-    --settings-panel-nav-width: 220px;
+@media (width <= 768px) {
+  .form {
+    padding: 32px 24px;
+    gap: 32px;
   }
 
-  .nav-list {
-    max-height: 60vh;
-  }
-}
-
-@media (width <= 760px) {
-  .container {
-    grid-template-columns: 1fr;
-    min-width: auto;
-    width: 100%;
+  .section {
     padding: 24px;
   }
 
-  .sidebar {
-    width: 100%;
-    flex-direction: row;
-    overflow-x: auto;
-    gap: 8px;
-  }
-
-  .nav-list {
-    display: flex;
-    flex-direction: row;
-    gap: 8px;
-    padding-bottom: 4px;
-  }
-
-  .nav-button {
-    grid-template-columns: 8px auto;
-    padding: 0 14px;
-    min-height: 44px;
-  }
-
-  .nav-icon {
-    display: none;
-  }
-
-  .content {
-    padding-top: 12px;
-  }
-
-  .row {
+  .detail-row {
     grid-template-columns: 1fr;
-    justify-items: flex-start;
-    gap: 12px;
+    gap: 10px;
   }
 
-  .row-control {
-    justify-self: flex-start;
-  }
-
-  .content-footer {
+  .footer {
     justify-content: stretch;
   }
 
-  .primary-button {
+  .manage-button {
     width: 100%;
   }
 }

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -1,1347 +1,217 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+/**
+ * 背景：
+ *  - 历史上 Preferences 组件承载多标签与语音预览逻辑，维护成本高且难以复用。
+ * 目的：
+ *  - 收敛到账户信息的极简展示面板，构建后续可扩展的账号偏好基座。
+ * 关键决策与取舍：
+ *  - 移除与多标签、语音预览、个性化相关的状态，仅保留读取账户与档案信息的必要逻辑。
+ *  - 通过 useApi 拉取 profile 元数据，保持数据来源一致，并采用守卫避免卸载后状态更新。
+ * 影响范围：
+ *  - SettingsModal 调用接口收敛为 onOpenAccountManager，可在弹窗内复用该表单骨架。
+ * 演进与TODO：
+ *  - TODO: 当引入账户编辑功能时，在现有结构上补充输入控件与校验态。
+ */
+import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import styles from "./Preferences.module.css";
-import { useLanguage, useTheme, useUser } from "@/context";
-import { API_PATHS } from "@/config/api.js";
-import MessagePopup from "@/components/ui/MessagePopup";
+import { useLanguage, useUser } from "@/context";
 import { useApi } from "@/hooks/useApi.js";
-import { VoiceSelector } from "@/components";
-import { useSettingsStore, SUPPORTED_SYSTEM_LANGUAGES } from "@/store/settings";
-import { useVoiceStore } from "@/store";
-import { SYSTEM_LANGUAGE_AUTO } from "@/i18n/languages.js";
-import {
-  WORD_LANGUAGE_AUTO,
-  WORD_DEFAULT_TARGET_LANGUAGE,
-  normalizeWordSourceLanguage,
-  normalizeWordTargetLanguage,
-} from "@/utils/language.js";
-import ThemeIcon from "@/components/ui/Icon";
 import Avatar from "@/components/ui/Avatar";
-import { useTtsPlayer } from "@/hooks/useTtsPlayer.js";
 
-const SOURCE_LANG_STORAGE_KEY = "sourceLang";
-const TARGET_LANG_STORAGE_KEY = "targetLang";
-const PERSONALIZATION_ENABLED_STORAGE_KEY = "glancy:personalization-enabled";
+const EMPTY_PROFILE = Object.freeze({ age: "", gender: "" });
 
-const VOICE_PREVIEW_SAMPLES = Object.freeze({
-  en: "Hi, I'm Glancy.",
-  zh: "你好，我是 Glancy。",
-});
-
-const readLocalPreference = (key) => {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  try {
-    return window.localStorage.getItem(key);
-  } catch (error) {
-    console.warn(
-      `[preferences] Unable to read ${key} from localStorage`,
-      error,
-    );
-    return null;
-  }
-};
-
-const writeLocalPreference = (key, value) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-  try {
-    window.localStorage.setItem(key, value);
-  } catch (error) {
-    console.warn(`[preferences] Unable to write ${key} to localStorage`, error);
-  }
-};
-
-const VARIANTS = {
-  PAGE: "page",
-  DIALOG: "dialog",
-};
-
-const TAB_KEYS = Object.freeze({
-  GENERAL: "general",
-  PERSONALIZATION: "personalization",
-  KEYBOARD: "keyboard",
-  DATA: "data",
-  ACCOUNT: "account",
-});
-
-const TAB_ORDER = [
-  TAB_KEYS.GENERAL,
-  TAB_KEYS.PERSONALIZATION,
-  TAB_KEYS.KEYBOARD,
-  TAB_KEYS.DATA,
-  TAB_KEYS.ACCOUNT,
-];
-
-const TAB_ICONS = Object.freeze({
-  [TAB_KEYS.GENERAL]: "cog-6-tooth",
-  [TAB_KEYS.PERSONALIZATION]: "adjustments-horizontal",
-  [TAB_KEYS.KEYBOARD]: "command-line",
-  [TAB_KEYS.DATA]: "shield-check",
-  [TAB_KEYS.ACCOUNT]: "user",
-});
-
-const KEYBOARD_SHORTCUTS = [
-  { combo: "⌘ / Ctrl + K", labelKey: "shortcutSearch" },
-  { combo: "⌘ / Ctrl + Enter", labelKey: "shortcutSend" },
-  { combo: "↑", labelKey: "shortcutEdit" },
-  { combo: "Esc", labelKey: "shortcutDismiss" },
-];
-
-const buildTabLabelMap = (t) => ({
-  [TAB_KEYS.GENERAL]: t.settingsTabGeneral || "General",
-  [TAB_KEYS.PERSONALIZATION]: t.settingsTabPersonalization || "Personalization",
-  [TAB_KEYS.KEYBOARD]: t.settingsTabKeyboard || "Keyboard",
-  [TAB_KEYS.DATA]: t.settingsTabData || "Data controls",
-  [TAB_KEYS.ACCOUNT]: t.settingsTabAccount || "Account",
-});
-
-/**
- * 背景：
- *  - 之前导航标签与内容标题共用同一文案来源，导致无法表达差异化语义。
- * 目的：
- *  - 提供显式的导航标签与内容标题映射，确保信息架构的可扩展性与可维护性。
- * 关键决策与取舍：
- *  - 采用集中 Copy Registry 的方式返回 labels/titles/descriptions，避免到处散落的文案取值逻辑。
- *  - 未引入复杂状态机，原因是当前需求仅涉及静态文案分层，使用简单映射即可满足演进需求。
- */
-const buildTabCopyMap = (t) => {
-  const tabLabelMap = buildTabLabelMap(t);
-  return {
-    labels: tabLabelMap,
-    titles: {
-      [TAB_KEYS.GENERAL]: t.prefInterfaceTitle || tabLabelMap[TAB_KEYS.GENERAL],
-      [TAB_KEYS.PERSONALIZATION]:
-        t.prefPersonalizationTitle || tabLabelMap[TAB_KEYS.PERSONALIZATION],
-      [TAB_KEYS.KEYBOARD]:
-        t.prefKeyboardTitle || tabLabelMap[TAB_KEYS.KEYBOARD],
-      [TAB_KEYS.DATA]: t.prefDataTitle || tabLabelMap[TAB_KEYS.DATA],
-      [TAB_KEYS.ACCOUNT]: t.prefAccountTitle || tabLabelMap[TAB_KEYS.ACCOUNT],
-    },
-    descriptions: {
-      [TAB_KEYS.GENERAL]: t.settingsGeneralDescription || "",
-      [TAB_KEYS.PERSONALIZATION]: t.settingsPersonalizationDescription || "",
-      [TAB_KEYS.KEYBOARD]: t.settingsKeyboardDescription || "",
-      [TAB_KEYS.DATA]: t.settingsDataDescription || "",
-      [TAB_KEYS.ACCOUNT]: t.settingsAccountDescription || "",
-    },
-  };
-};
-
-const toStoreSourceLanguage = (value) => {
-  if (!value || value === WORD_LANGUAGE_AUTO) {
-    return WORD_LANGUAGE_AUTO;
-  }
-  return normalizeWordSourceLanguage(value);
-};
-
-const toUiSourceLanguage = (value) => {
-  const normalized = normalizeWordSourceLanguage(value);
-  return normalized === WORD_LANGUAGE_AUTO ? WORD_LANGUAGE_AUTO : normalized;
-};
-
-const toUiTargetLanguage = (value) =>
-  normalizeWordTargetLanguage(value ?? WORD_DEFAULT_TARGET_LANGUAGE);
-
-const toStoreTargetLanguage = (value) => normalizeWordTargetLanguage(value);
-
-const resolveInitialTab = (candidate) =>
-  TAB_ORDER.includes(candidate) ? candidate : TAB_KEYS.GENERAL;
-
-function Preferences({
-  variant = VARIANTS.PAGE,
-  initialTab = TAB_KEYS.GENERAL,
-  onOpenAccountManager,
-  onClose,
-}) {
-  const { t, lang } = useLanguage();
-  const { theme, setTheme } = useTheme();
+function Preferences({ onOpenAccountManager }) {
+  const { t } = useLanguage();
   const { user } = useUser();
   const api = useApi();
-  const {
-    systemLanguage,
-    setSystemLanguage,
-    dictionarySourceLanguage,
-    setDictionarySourceLanguage,
-    dictionaryTargetLanguage,
-    setDictionaryTargetLanguage,
-  } = useSettingsStore((state) => ({
-    systemLanguage: state.systemLanguage,
-    setSystemLanguage: state.setSystemLanguage,
-    dictionarySourceLanguage: state.dictionarySourceLanguage,
-    setDictionarySourceLanguage: state.setDictionarySourceLanguage,
-    dictionaryTargetLanguage: state.dictionaryTargetLanguage,
-    setDictionaryTargetLanguage: state.setDictionaryTargetLanguage,
-  }));
-
-  const [activeTab, setActiveTab] = useState(resolveInitialTab(initialTab));
-  const [sourceLang, setSourceLang] = useState(() =>
-    toUiSourceLanguage(
-      readLocalPreference(SOURCE_LANG_STORAGE_KEY) ?? dictionarySourceLanguage,
-    ),
-  );
-  const [targetLang, setTargetLang] = useState(() =>
-    toUiTargetLanguage(
-      readLocalPreference(TARGET_LANG_STORAGE_KEY) ?? dictionaryTargetLanguage,
-    ),
-  );
-  const [personalizationEnabled, setPersonalizationEnabled] = useState(() => {
-    const persisted = readLocalPreference(PERSONALIZATION_ENABLED_STORAGE_KEY);
-    if (persisted === "true" || persisted === "false") {
-      return persisted === "true";
-    }
-    return true;
-  });
-  const [occupation, setOccupation] = useState("");
-  const [persona, setPersona] = useState("");
-  const [learningGoal, setLearningGoal] = useState("");
-  const [profileMeta, setProfileMeta] = useState({ age: "", gender: "" });
-  const [popupOpen, setPopupOpen] = useState(false);
-  const [popupMsg, setPopupMsg] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
-  const voiceSelections = useVoiceStore((state) => state.voices || {});
-  const englishVoiceId = voiceSelections.en || "";
-  const chineseVoiceId = voiceSelections.zh || "";
-  const {
-    play: playVoicePreview,
-    stop: stopVoicePreview,
-    loading: isVoicePreviewLoading,
-    playing: isVoicePreviewPlaying,
-  } = useTtsPlayer({ scope: "sentence" });
-  const [previewLang, setPreviewLang] = useState(null);
+  const fetchProfileApi = api?.profiles?.fetchProfile;
+  const [profileMeta, setProfileMeta] = useState(EMPTY_PROFILE);
 
   useEffect(() => {
-    setActiveTab(resolveInitialTab(initialTab));
-  }, [initialTab]);
-
-  useEffect(
-    () => () => {
-      stopVoicePreview();
-      setPreviewLang(null);
-    },
-    [stopVoicePreview],
-  );
-
-  useEffect(() => {
-    if (
-      activeTab !== TAB_KEYS.GENERAL &&
-      (isVoicePreviewPlaying || isVoicePreviewLoading)
-    ) {
-      stopVoicePreview();
-      setPreviewLang(null);
-    }
-  }, [
-    activeTab,
-    isVoicePreviewLoading,
-    isVoicePreviewPlaying,
-    stopVoicePreview,
-  ]);
-
-  const systemLanguageFormatter = useMemo(() => {
-    try {
-      return new Intl.DisplayNames([lang], { type: "language" });
-    } catch (error) {
-      console.warn("[preferences] Intl.DisplayNames unsupported", error);
-      return null;
-    }
-  }, [lang]);
-
-  const {
-    labels: tabLabelMap,
-    titles: tabTitleMap,
-    descriptions: tabDescriptionMap,
-  } = useMemo(() => buildTabCopyMap(t), [t]);
-
-  const voiceSampleTextMap = useMemo(
-    () => ({
-      en: t.settingsVoicePreviewTextEn || VOICE_PREVIEW_SAMPLES.en,
-      zh: t.settingsVoicePreviewTextZh || VOICE_PREVIEW_SAMPLES.zh,
-    }),
-    [t.settingsVoicePreviewTextEn, t.settingsVoicePreviewTextZh],
-  );
-
-  const formatLanguageLabel = useCallback(
-    (code) => {
-      const label = systemLanguageFormatter?.of(code);
-      if (!label) {
-        return code.toUpperCase();
-      }
-      return label
-        .split(" ")
-        .map((segment) =>
-          segment.length > 0
-            ? segment[0].toUpperCase() + segment.slice(1)
-            : segment,
-        )
-        .join(" ");
-    },
-    [systemLanguageFormatter],
-  );
-
-  const systemLanguageOptions = useMemo(
-    () => [
-      { value: SYSTEM_LANGUAGE_AUTO, label: t.prefSystemLanguageAuto },
-      ...SUPPORTED_SYSTEM_LANGUAGES.map((code) => ({
-        value: code,
-        label: formatLanguageLabel(code),
-      })),
-    ],
-    [formatLanguageLabel, t.prefSystemLanguageAuto],
-  );
-
-  const languageOptions = useMemo(
-    () => [
-      { value: WORD_LANGUAGE_AUTO, label: t.autoDetect },
-      { value: "CHINESE", label: "CHINESE" },
-      { value: "ENGLISH", label: "ENGLISH" },
-    ],
-    [t.autoDetect],
-  );
-
-  const searchLanguageOptions = useMemo(
-    () => [
-      { value: "CHINESE", label: "CHINESE" },
-      { value: "ENGLISH", label: "ENGLISH" },
-    ],
-    [],
-  );
-
-  const themeOptions = useMemo(
-    () => [
-      { value: "light", label: "light" },
-      { value: "dark", label: "dark" },
-      { value: "system", label: "system" },
-    ],
-    [],
-  );
-
-  const persistLanguages = useCallback((source, target) => {
-    writeLocalPreference(SOURCE_LANG_STORAGE_KEY, source);
-    writeLocalPreference(TARGET_LANG_STORAGE_KEY, target);
-  }, []);
-
-  const persistPersonalization = useCallback((enabled) => {
-    writeLocalPreference(
-      PERSONALIZATION_ENABLED_STORAGE_KEY,
-      enabled ? "true" : "false",
-    );
-  }, []);
-
-  const openPopup = useCallback((message) => {
-    setPopupMsg(message);
-    setPopupOpen(true);
-  }, []);
-
-  const handleSourceLanguageChange = useCallback(
-    (value) => {
-      const candidate = value ?? WORD_LANGUAGE_AUTO;
-      const uiValue =
-        typeof candidate === "string" ? candidate : WORD_LANGUAGE_AUTO;
-      setSourceLang(uiValue);
-      setDictionarySourceLanguage(toStoreSourceLanguage(uiValue));
-    },
-    [setDictionarySourceLanguage],
-  );
-
-  const handleTargetLanguageChange = useCallback(
-    (value) => {
-      const uiValue = toUiTargetLanguage(value);
-      setTargetLang(uiValue);
-      setDictionaryTargetLanguage(toStoreTargetLanguage(uiValue));
-    },
-    [setDictionaryTargetLanguage],
-  );
-
-  const handleVoicePreview = useCallback(
-    async (langCode) => {
-      const sample = voiceSampleTextMap[langCode];
-      if (!sample) {
-        return;
-      }
-      const selectedVoice =
-        langCode === "zh"
-          ? chineseVoiceId || undefined
-          : englishVoiceId || undefined;
-      const isActivePreview =
-        previewLang === langCode &&
-        (isVoicePreviewPlaying || isVoicePreviewLoading);
-      if (isActivePreview) {
-        stopVoicePreview();
-        setPreviewLang(null);
-        return;
-      }
-      setPreviewLang(langCode);
-      try {
-        await playVoicePreview({
-          text: sample,
-          lang: langCode,
-          voice: selectedVoice,
-        });
-      } catch (error) {
-        console.error("[preferences] Voice preview failed", error);
-        setPreviewLang(null);
-      }
-    },
-    [
-      voiceSampleTextMap,
-      chineseVoiceId,
-      englishVoiceId,
-      previewLang,
-      isVoicePreviewPlaying,
-      isVoicePreviewLoading,
-      stopVoicePreview,
-      playVoicePreview,
-    ],
-  );
-
-  const applyPreferences = useCallback(
-    (data) => {
-      const nextSource = data.systemLanguage || WORD_LANGUAGE_AUTO;
-      const nextTarget = data.searchLanguage || WORD_DEFAULT_TARGET_LANGUAGE;
-      handleSourceLanguageChange(nextSource);
-      handleTargetLanguageChange(nextTarget);
-      persistLanguages(nextSource, nextTarget);
-    },
-    [handleSourceLanguageChange, handleTargetLanguageChange, persistLanguages],
-  );
-
-  useEffect(() => {
-    if (!user) {
-      return;
-    }
-    api
-      .request(`${API_PATHS.preferences}/user`)
-      .then((data) => {
-        applyPreferences(data);
-      })
-      .catch((err) => {
-        console.error(err);
-        openPopup(t.fail);
+    if (!user?.token || !fetchProfileApi) {
+      setProfileMeta((previous) => {
+        if (previous.age === "" && previous.gender === "") {
+          return previous;
+        }
+        return { age: "", gender: "" };
       });
-  }, [api, applyPreferences, openPopup, t.fail, user]);
-
-  useEffect(() => {
-    if (!user || !api?.profiles?.fetchProfile) {
-      return;
+      return undefined;
     }
-    api.profiles
-      .fetchProfile({ token: user.token })
+
+    let mounted = true;
+
+    /**
+     * 背景：
+     *  - Profile 拉取在旧版多标签流程中属于副作用，此处仅保留读取逻辑。
+     * 关键取舍：
+     *  - 采用布尔标记避免组件卸载后继续 setState，待未来接入 AbortController 时可进一步抽象。
+     */
+    fetchProfileApi({ token: user.token })
       .then((profile) => {
-        setOccupation(profile.job || "");
-        setPersona(profile.interest || "");
-        setLearningGoal(profile.goal || "");
+        if (!mounted) {
+          return;
+        }
         setProfileMeta({
-          age: profile.age ?? "",
-          gender: profile.gender ?? "",
+          age:
+            profile?.age === null ||
+            profile?.age === undefined ||
+            profile?.age === ""
+              ? ""
+              : String(profile.age),
+          gender:
+            profile?.gender === null ||
+            profile?.gender === undefined ||
+            profile?.gender === ""
+              ? ""
+              : String(profile.gender),
         });
-        if (!readLocalPreference(PERSONALIZATION_ENABLED_STORAGE_KEY)) {
-          const hasData = Boolean(
-            profile.job || profile.interest || profile.goal,
-          );
-          setPersonalizationEnabled(hasData);
-        }
       })
-      .catch((err) => {
-        console.error(err);
-      });
-  }, [api, user]);
-
-  const handleSystemLanguageChange = useCallback(
-    (value) => {
-      setSystemLanguage(value);
-    },
-    [setSystemLanguage],
-  );
-
-  const handleSave = useCallback(
-    async (event) => {
-      event.preventDefault();
-      if (!user) {
-        return;
-      }
-      setIsSaving(true);
-      try {
-        const requests = [
-          api.jsonRequest(`${API_PATHS.preferences}/user`, {
-            method: "POST",
-            body: {
-              systemLanguage: sourceLang,
-              searchLanguage: targetLang,
-              theme,
-            },
-          }),
-        ];
-
-        if (api?.profiles?.saveProfile) {
-          requests.push(
-            api.profiles.saveProfile({
-              token: user.token,
-              profile: {
-                age: profileMeta.age,
-                gender: profileMeta.gender,
-                job: personalizationEnabled ? occupation : "",
-                interest: personalizationEnabled ? persona : "",
-                goal: personalizationEnabled ? learningGoal : "",
-              },
-            }),
-          );
+      .catch((error) => {
+        console.warn("[preferences] Failed to load profile meta", error);
+        if (!mounted) {
+          return;
         }
+        setProfileMeta((previous) => {
+          if (previous.age === "" && previous.gender === "") {
+            return previous;
+          }
+          return { age: "", gender: "" };
+        });
+      });
 
-        await Promise.all(requests);
-        persistLanguages(sourceLang, targetLang);
-        persistPersonalization(personalizationEnabled);
-        openPopup(t.saveSuccess);
-      } catch (error) {
-        console.error(error);
-        openPopup(t.fail);
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [
-      api,
-      sourceLang,
-      targetLang,
-      theme,
-      user,
-      profileMeta.age,
-      profileMeta.gender,
-      occupation,
-      persona,
-      learningGoal,
-      personalizationEnabled,
-      persistLanguages,
-      persistPersonalization,
-      openPopup,
-      t.saveSuccess,
-      t.fail,
-    ],
-  );
+    return () => {
+      mounted = false;
+    };
+  }, [fetchProfileApi, user?.token]);
 
-  useEffect(() => {
-    setSourceLang((prev) =>
-      prev === dictionarySourceLanguage
-        ? prev
-        : toUiSourceLanguage(dictionarySourceLanguage),
-    );
-  }, [dictionarySourceLanguage]);
+  const headingId = "settings-heading";
+  const hasDescription = Boolean(t.prefDescription && t.prefDescription.trim());
+  const descriptionId = hasDescription ? "settings-description" : undefined;
+  const sectionHeadingId = "account-preferences-section-heading";
+  const fallbackValue = t.settingsEmptyValue ?? "—";
 
-  useEffect(() => {
-    setTargetLang((prev) =>
-      prev === dictionaryTargetLanguage
-        ? prev
-        : toUiTargetLanguage(dictionaryTargetLanguage),
-    );
-  }, [dictionaryTargetLanguage]);
-
-  const handleTabClick = useCallback((tab) => {
-    setActiveTab(resolveInitialTab(tab));
-  }, []);
-
-  const navRefs = useRef([]);
-
-  const registerNavRef = useCallback(
-    (index) => (node) => {
-      navRefs.current[index] = node ?? null;
-    },
-    [],
-  );
-
-  const focusTabByIndex = useCallback((index) => {
-    const target = navRefs.current[index];
-    if (target && typeof target.focus === "function") {
-      target.focus();
+  const planLabel = (() => {
+    if (!user) {
+      return "";
     }
-  }, []);
+    const candidate =
+      (typeof user.plan === "string" && user.plan.trim()) ||
+      (user.isPro ? "plus" : "");
+    if (!candidate) {
+      return "";
+    }
+    const normalized = candidate.trim();
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  })();
 
-  const handleNavKeyDown = useCallback(
-    (index) => (event) => {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        const nextIndex = (index + 1) % TAB_ORDER.length;
-        handleTabClick(TAB_ORDER[nextIndex]);
-        focusTabByIndex(nextIndex);
-        return;
-      }
-
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        const nextIndex = index === 0 ? TAB_ORDER.length - 1 : index - 1;
-        handleTabClick(TAB_ORDER[nextIndex]);
-        focusTabByIndex(nextIndex);
-        return;
-      }
-
-      if (event.key === "Home") {
-        event.preventDefault();
-        handleTabClick(TAB_ORDER[0]);
-        focusTabByIndex(0);
-        return;
-      }
-
-      if (event.key === "End") {
-        event.preventDefault();
-        const lastIndex = TAB_ORDER.length - 1;
-        handleTabClick(TAB_ORDER[lastIndex]);
-        focusTabByIndex(lastIndex);
-      }
-    },
-    [focusTabByIndex, handleTabClick],
-  );
-
-  const renderGeneralPanel = () => {
-    const defaultsTitle = t.prefDefaultsTitle || tabTitleMap[TAB_KEYS.GENERAL];
-    const defaultsDescription =
-      t.prefDefaultsDescription || tabDescriptionMap[TAB_KEYS.GENERAL];
-    const voicesTitle = t.prefVoicesTitle || t.prefVoiceEn;
-    const voicesDescription =
-      t.prefVoicesDescription || tabDescriptionMap[TAB_KEYS.GENERAL];
-    const englishPreviewActive =
-      previewLang === "en" && (isVoicePreviewLoading || isVoicePreviewPlaying);
-    const chinesePreviewActive =
-      previewLang === "zh" && (isVoicePreviewLoading || isVoicePreviewPlaying);
-
-    return (
-      <>
-        <SettingsSection
-          title={defaultsTitle}
-          description={defaultsDescription}
-        >
-          <SettingsRow label={t.prefTheme} htmlFor="pref-theme">
-            <PillSelect
-              id="pref-theme"
-              value={theme}
-              options={themeOptions}
-              onChange={(event) => setTheme(event.target.value)}
-            />
-          </SettingsRow>
-          <SettingsRow
-            label={t.prefSystemLanguage}
-            htmlFor="pref-system-language"
-          >
-            <PillSelect
-              id="pref-system-language"
-              value={systemLanguage}
-              options={systemLanguageOptions}
-              onChange={(event) =>
-                handleSystemLanguageChange(event.target.value)
-              }
-            />
-          </SettingsRow>
-          <SettingsRow label={t.prefLanguage} htmlFor="pref-source-language">
-            <PillSelect
-              id="pref-source-language"
-              value={sourceLang}
-              options={languageOptions}
-              onChange={(event) =>
-                handleSourceLanguageChange(event.target.value)
-              }
-            />
-          </SettingsRow>
-          <SettingsRow
-            label={t.prefSearchLanguage}
-            htmlFor="pref-target-language"
-          >
-            <PillSelect
-              id="pref-target-language"
-              value={targetLang}
-              options={searchLanguageOptions}
-              onChange={(event) =>
-                handleTargetLanguageChange(event.target.value)
-              }
-            />
-          </SettingsRow>
-        </SettingsSection>
-        <SettingsSection title={voicesTitle} description={voicesDescription}>
-          <SettingsRow label={t.prefVoiceEn} htmlFor="pref-voice-en">
-            <VoicePreviewButton
-              onClick={() => handleVoicePreview("en")}
-              active={englishPreviewActive}
-              loading={isVoicePreviewLoading && previewLang === "en"}
-              disabled={
-                !user ||
-                ((isVoicePreviewLoading || isVoicePreviewPlaying) &&
-                  previewLang !== "en")
-              }
-              playLabel={t.settingsVoicePreviewPlay}
-              stopLabel={t.settingsVoicePreviewStop}
-            />
-            <PillSelectField>
-              <VoiceSelector
-                lang="en"
-                id="pref-voice-en"
-                variant="pill"
-                className={styles["pill-native"]}
-              />
-            </PillSelectField>
-          </SettingsRow>
-          <SettingsRow label={t.prefVoiceZh} htmlFor="pref-voice-zh">
-            <VoicePreviewButton
-              onClick={() => handleVoicePreview("zh")}
-              active={chinesePreviewActive}
-              loading={isVoicePreviewLoading && previewLang === "zh"}
-              disabled={
-                !user ||
-                ((isVoicePreviewLoading || isVoicePreviewPlaying) &&
-                  previewLang !== "zh")
-              }
-              playLabel={t.settingsVoicePreviewPlay}
-              stopLabel={t.settingsVoicePreviewStop}
-            />
-            <PillSelectField>
-              <VoiceSelector
-                lang="zh"
-                id="pref-voice-zh"
-                variant="pill"
-                className={styles["pill-native"]}
-              />
-            </PillSelectField>
-          </SettingsRow>
-        </SettingsSection>
-      </>
-    );
+  const mapValue = (candidate) => {
+    if (candidate === null || candidate === undefined) {
+      return fallbackValue;
+    }
+    if (typeof candidate === "string" && candidate.trim().length === 0) {
+      return fallbackValue;
+    }
+    return String(candidate);
   };
 
-  const renderPersonalizationPanel = () => (
-    <>
-      <SettingsSection
-        title={tabTitleMap[TAB_KEYS.PERSONALIZATION]}
-        description={tabDescriptionMap[TAB_KEYS.PERSONALIZATION]}
-      >
-        <SettingsRow
-          label={t.settingsEnableCustomization || "Enable customization"}
-          htmlFor="personalization-toggle"
-        >
-          <label className={styles.switch} htmlFor="personalization-toggle">
-            <input
-              id="personalization-toggle"
-              type="checkbox"
-              role="switch"
-              aria-checked={personalizationEnabled}
-              checked={personalizationEnabled}
-              onChange={(event) =>
-                setPersonalizationEnabled(event.target.checked)
-              }
-            />
-            <span aria-hidden="true" />
-          </label>
-        </SettingsRow>
-        <SettingsRow
-          label={t.settingsOccupation}
-          htmlFor="personal-occupation"
-          controlFullWidth
-        >
-          <input
-            id="personal-occupation"
-            type="text"
-            className={styles["input-control"]}
-            value={occupation}
-            onChange={(event) => setOccupation(event.target.value)}
-            placeholder={t.settingsOccupationPlaceholder || "e.g. Student"}
-            disabled={!personalizationEnabled}
-          />
-        </SettingsRow>
-        <SettingsRow
-          label={t.settingsAboutYou}
-          htmlFor="personal-about"
-          alignTop
-          controlFullWidth
-        >
-          <textarea
-            id="personal-about"
-            rows={3}
-            className={styles["input-area"]}
-            value={persona}
-            onChange={(event) => setPersona(event.target.value)}
-            placeholder={
-              t.settingsAboutYouPlaceholder ||
-              "Share your expertise, interests, or context."
-            }
-            disabled={!personalizationEnabled}
-          />
-        </SettingsRow>
-        <SettingsRow
-          label={t.settingsLearningGoal}
-          htmlFor="personal-goal"
-          alignTop
-          controlFullWidth
-        >
-          <textarea
-            id="personal-goal"
-            rows={3}
-            className={styles["input-area"]}
-            value={learningGoal}
-            onChange={(event) => setLearningGoal(event.target.value)}
-            placeholder={
-              t.settingsLearningGoalPlaceholder ||
-              "Tell us the outcome you're aiming for."
-            }
-            disabled={!personalizationEnabled}
-          />
-        </SettingsRow>
-      </SettingsSection>
-    </>
-  );
+  const accountRows = [
+    {
+      id: "username",
+      label: t.settingsAccountUsername ?? "Username",
+      value: mapValue(user?.username),
+    },
+    {
+      id: "email",
+      label: t.settingsAccountEmail ?? "Email",
+      value: mapValue(user?.email),
+    },
+    {
+      id: "phone",
+      label: t.settingsAccountPhone ?? "Phone",
+      value: mapValue(user?.phone),
+    },
+    {
+      id: "age",
+      label: t.settingsAccountAge ?? "Age",
+      value: mapValue(profileMeta.age),
+    },
+    {
+      id: "gender",
+      label: t.settingsAccountGender ?? "Gender",
+      value: mapValue(profileMeta.gender),
+    },
+  ];
 
-  const renderKeyboardPanel = () => (
-    <>
-      <SettingsSection
-        title={tabTitleMap[TAB_KEYS.KEYBOARD]}
-        description={tabDescriptionMap[TAB_KEYS.KEYBOARD]}
-      >
-        <div className={styles["section-columns"]}>
-          <ul className={styles["shortcut-list"]}>
-            {KEYBOARD_SHORTCUTS.map((shortcut) => (
-              <li key={shortcut.labelKey} className={styles["shortcut-item"]}>
-                <span className={styles["shortcut-key"]}>{shortcut.combo}</span>
-                <span className={styles["shortcut-label"]}>
-                  {t[shortcut.labelKey] || shortcut.labelKey}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </SettingsSection>
-    </>
-  );
-
-  const renderDataPanel = () => (
-    <>
-      <SettingsSection
-        title={tabTitleMap[TAB_KEYS.DATA]}
-        description={tabDescriptionMap[TAB_KEYS.DATA]}
-      >
-        <div className={styles["data-card"]}>
-          <p className={styles["data-description"]}>
-            {t.settingsDataNotice || ""}
-          </p>
-          <div className={styles["data-actions"]}>
-            <button
-              type="button"
-              className={styles["secondary-button"]}
-              disabled
-            >
-              {t.settingsExportData}
-            </button>
-            <button
-              type="button"
-              className={styles["secondary-button"]}
-              disabled
-            >
-              {t.settingsEraseHistory}
-            </button>
-          </div>
-        </div>
-      </SettingsSection>
-    </>
-  );
-
-  const renderAccountPanel = () => {
-    const planName = user?.plan || (user?.isPro ? "plus" : "free");
-    const planLabel = planName
-      ? planName.charAt(0).toUpperCase() + planName.slice(1)
-      : "";
-    return (
-      <>
-        <SettingsSection
-          title={tabTitleMap[TAB_KEYS.ACCOUNT]}
-          description={tabDescriptionMap[TAB_KEYS.ACCOUNT]}
-        >
-          <div className={styles["account-card"]}>
-            <div className={styles["account-header"]}>
-              <Avatar width={56} height={56} />
-              <div className={styles["account-meta"]}>
-                <span className={styles["account-name"]}>
-                  {user?.username || ""}
-                </span>
-                <span className={styles["account-plan"]}>{planLabel}</span>
-              </div>
-              {typeof onOpenAccountManager === "function" ? (
-                <button
-                  type="button"
-                  className={styles["secondary-button"]}
-                  onClick={onOpenAccountManager}
-                >
-                  {t.settingsManageProfile || "Manage profile"}
-                </button>
-              ) : null}
-            </div>
-            <dl className={styles["account-rows"]}>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountUsername}</dt>
-                <dd>{user?.username || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountEmail}</dt>
-                <dd>{user?.email || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountPhone}</dt>
-                <dd>{user?.phone || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountAge}</dt>
-                <dd>{profileMeta.age || t.settingsEmptyValue || ""}</dd>
-              </div>
-              <div className={styles["account-row"]}>
-                <dt>{t.settingsAccountGender}</dt>
-                <dd>{profileMeta.gender || t.settingsEmptyValue || ""}</dd>
-              </div>
-            </dl>
-          </div>
-        </SettingsSection>
-      </>
-    );
+  const handleSubmit = (event) => {
+    event.preventDefault();
   };
-
-  const renderActivePanel = () => {
-    switch (activeTab) {
-      case TAB_KEYS.PERSONALIZATION:
-        return renderPersonalizationPanel();
-      case TAB_KEYS.KEYBOARD:
-        return renderKeyboardPanel();
-      case TAB_KEYS.DATA:
-        return renderDataPanel();
-      case TAB_KEYS.ACCOUNT:
-        return renderAccountPanel();
-      case TAB_KEYS.GENERAL:
-      default:
-        return renderGeneralPanel();
-    }
-  };
-
-  const panelId = `settings-panel-${activeTab}`;
-  const containerClassName =
-    variant === VARIANTS.PAGE
-      ? `${styles.container} ${styles.page}`
-      : styles.container;
-
-  const closeLabel = t.close ?? "Close";
-  const handleClose = useCallback(() => {
-    if (typeof onClose === "function") {
-      onClose();
-    }
-  }, [onClose]);
 
   return (
-    <>
+    <div className={styles.content}>
       <form
-        className={containerClassName}
-        onSubmit={handleSave}
-        aria-labelledby="settings-heading"
-        aria-describedby="settings-description"
+        aria-labelledby={headingId}
+        aria-describedby={descriptionId}
+        className={styles.form}
+        onSubmit={handleSubmit}
       >
-        <aside className={styles.sidebar} aria-label={t.prefTitle}>
-          {typeof onClose === "function" ? (
-            <button
-              type="button"
-              className={styles["sidebar-close"]}
-              aria-label={closeLabel}
-              onClick={handleClose}
-            >
-              {/*
-               * 背景：
-               *  - Dialog 变体需要就地关闭入口，避免用户依赖外层组件寻找关闭控件。
-               * 关键取舍：
-               *  - 通过局部 SVG 图标避免新增全局资产，同时沿用侧边栏的交互令牌，保持节奏一致。
-               */}
-              <CloseGlyph
-                className={styles["sidebar-close-icon"]}
-                aria-hidden="true"
-              />
-            </button>
+        <header className={styles.header}>
+          <div className={styles.identity}>
+            <Avatar width={56} height={56} className={styles.avatar} />
+            <div className={styles["identity-copy"]}>
+              {planLabel ? <p className={styles.plan}>{planLabel}</p> : null}
+              <h2 id={headingId} className={styles.title}>
+                {t.prefTitle ?? "Preferences"}
+              </h2>
+            </div>
+          </div>
+          {hasDescription ? (
+            <p id={descriptionId} className={styles.description}>
+              {t.prefDescription}
+            </p>
           ) : null}
-          <nav aria-label={t.prefTitle}>
-            <ul
-              className={styles["nav-list"]}
-              role="tablist"
-              aria-orientation="vertical"
-            >
-              {TAB_ORDER.map((tab, index) => {
-                const isActive = activeTab === tab;
-                const icon = TAB_ICONS[tab];
-                const tabId = `settings-tab-${tab}`;
-                const tabPanelId = `settings-panel-${tab}`;
-                const buttonClassName = isActive
-                  ? `${styles["nav-button"]} ${styles["nav-button-active"]}`
-                  : styles["nav-button"];
-                return (
-                  <li key={tab} className={styles["nav-item"]}>
-                    <button
-                      type="button"
-                      role="tab"
-                      id={tabId}
-                      className={buttonClassName}
-                      aria-selected={isActive}
-                      aria-controls={tabPanelId}
-                      tabIndex={isActive ? 0 : -1}
-                      onClick={() => handleTabClick(tab)}
-                      onKeyDown={handleNavKeyDown(index)}
-                      ref={registerNavRef(index)}
-                    >
-                      <span className={styles["nav-dot"]} aria-hidden="true" />
-                      {icon ? (
-                        <ThemeIcon
-                          name={icon}
-                          width={18}
-                          height={18}
-                          className={styles["nav-icon"]}
-                        />
-                      ) : null}
-                      <span className={styles["nav-label"]}>
-                        {tabLabelMap[tab]}
-                      </span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          </nav>
-        </aside>
-        <section
-          className={styles.content}
-          role="tabpanel"
-          id={panelId}
-          aria-labelledby={`settings-tab-${activeTab}`}
-        >
-          <header className={styles["content-header"]}>
-            <h2 id="settings-heading" className={styles["content-title"]}>
-              {tabTitleMap[activeTab]}
-            </h2>
-            {tabDescriptionMap[activeTab] ? (
-              <p className={styles["content-description"]}>
-                {tabDescriptionMap[activeTab]}
+        </header>
+        <section aria-labelledby={sectionHeadingId} className={styles.section}>
+          <div className={styles["section-header"]}>
+            <h3 id={sectionHeadingId} className={styles["section-title"]}>
+              {t.prefAccountTitle ?? t.settingsTabAccount ?? "Account"}
+            </h3>
+            {t.settingsAccountDescription ? (
+              <p className={styles["section-description"]}>
+                {t.settingsAccountDescription}
               </p>
             ) : null}
-          </header>
-          <div className={styles["section-stack"]} id="settings-description">
-            {renderActivePanel()}
           </div>
-          <footer className={styles["content-footer"]}>
+          <dl className={styles.details}>
+            {accountRows.map((field) => (
+              <div key={field.id} className={styles["detail-row"]}>
+                <dt className={styles["detail-label"]}>{field.label}</dt>
+                <dd className={styles["detail-value"]}>{field.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+        {user && typeof onOpenAccountManager === "function" ? (
+          <footer className={styles.footer}>
             <button
-              type="submit"
-              className={styles["primary-button"]}
-              disabled={isSaving}
+              type="button"
+              className={styles["manage-button"]}
+              onClick={onOpenAccountManager}
             >
-              {isSaving ? (t.saving ?? t.saveButton) : t.saveButton}
+              {t.settingsManageProfile ?? "Manage profile"}
             </button>
           </footer>
-        </section>
+        ) : null}
       </form>
-      <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
-      />
-    </>
-  );
-}
-
-function SettingsSection({ title, description, children }) {
-  return (
-    <section className={styles.section} aria-label={title}>
-      <header className={styles["section-header"]}>
-        <h3 className={styles["section-title"]}>{title}</h3>
-        {description ? (
-          <p className={styles["section-description"]}>{description}</p>
-        ) : null}
-      </header>
-      <div className={styles["section-body"]}>{children}</div>
-    </section>
-  );
-}
-
-SettingsSection.propTypes = {
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string,
-  children: PropTypes.node.isRequired,
-};
-
-SettingsSection.defaultProps = {
-  description: undefined,
-};
-
-function SettingsRow({
-  label,
-  description,
-  htmlFor,
-  children,
-  alignTop = false,
-  controlFullWidth = false,
-  className = "",
-}) {
-  const rowClassName = [
-    styles.row,
-    alignTop ? styles["row-top"] : null,
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const controlClassName = [
-    styles["row-control"],
-    controlFullWidth ? styles["row-control-full"] : null,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  return (
-    <div className={rowClassName}>
-      <div className={styles["row-label"]}>
-        {htmlFor ? (
-          <label htmlFor={htmlFor} className={styles["row-label-text"]}>
-            {label}
-          </label>
-        ) : (
-          <span className={styles["row-label-text"]}>{label}</span>
-        )}
-        {description ? (
-          <p className={styles["row-label-description"]}>{description}</p>
-        ) : null}
-      </div>
-      <div className={controlClassName}>{children}</div>
     </div>
   );
 }
-
-SettingsRow.propTypes = {
-  label: PropTypes.node.isRequired,
-  description: PropTypes.node,
-  htmlFor: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  alignTop: PropTypes.bool,
-  controlFullWidth: PropTypes.bool,
-  className: PropTypes.string,
-};
-
-SettingsRow.defaultProps = {
-  description: undefined,
-  htmlFor: undefined,
-  alignTop: false,
-  controlFullWidth: false,
-  className: "",
-};
-
-function PillSelectField({ children }) {
-  return (
-    <div className={styles["pill-select"]}>
-      {children}
-      <ChevronDownGlyph className={styles["pill-select-icon"]} />
-    </div>
-  );
-}
-
-PillSelectField.propTypes = {
-  children: PropTypes.node.isRequired,
-};
-
-function PillSelect({ id, value, options, onChange, disabled = false }) {
-  return (
-    <PillSelectField>
-      <select
-        id={id}
-        className={styles["pill-native"]}
-        value={value}
-        onChange={onChange}
-        disabled={disabled}
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </PillSelectField>
-  );
-}
-
-PillSelect.propTypes = {
-  id: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-    }).isRequired,
-  ).isRequired,
-  onChange: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
-};
-
-PillSelect.defaultProps = {
-  disabled: false,
-};
-
-function VoicePreviewButton({
-  onClick,
-  active,
-  loading,
-  disabled,
-  playLabel,
-  stopLabel,
-}) {
-  const label = active ? stopLabel || "Stop" : playLabel || "Play";
-  const isDisabled = disabled && !active;
-
-  return (
-    <button
-      type="button"
-      className={styles["play-button"]}
-      onClick={onClick}
-      data-active={active}
-      aria-pressed={active}
-      aria-busy={loading}
-      disabled={isDisabled}
-    >
-      <PlayGlyph active={active} />
-      <span>{loading && !active ? `${label}…` : label}</span>
-    </button>
-  );
-}
-
-VoicePreviewButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
-  active: PropTypes.bool,
-  loading: PropTypes.bool,
-  disabled: PropTypes.bool,
-  playLabel: PropTypes.string,
-  stopLabel: PropTypes.string,
-};
-
-VoicePreviewButton.defaultProps = {
-  active: false,
-  loading: false,
-  disabled: false,
-  playLabel: undefined,
-  stopLabel: undefined,
-};
-
-function ChevronDownGlyph({ className }) {
-  return (
-    <svg
-      className={className}
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path
-        d="M3 4.5 6 7.5 9 4.5"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-ChevronDownGlyph.propTypes = {
-  className: PropTypes.string,
-};
-
-ChevronDownGlyph.defaultProps = {
-  className: "",
-};
-
-function PlayGlyph({ active }) {
-  if (active) {
-    return (
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 12 12"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          d="M3.25 2.5h1.5a.75.75 0 0 1 .75.75v5.5a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1-.75-.75v-5.5a.75.75 0 0 1 .75-.75Zm4 0h1.5a.75.75 0 0 1 .75.75v5.5a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1-.75-.75v-5.5a.75.75 0 0 1 .75-.75Z"
-          fill="currentColor"
-        />
-      </svg>
-    );
-  }
-
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path
-        d="M3.25 2.15 9.2 5.63a.4.4 0 0 1 0 .7L3.25 9.11a.4.4 0 0 1-.6-.35v-6a.4.4 0 0 1 .6-.35Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-
-PlayGlyph.propTypes = {
-  active: PropTypes.bool,
-};
-
-PlayGlyph.defaultProps = {
-  active: false,
-};
-
-/**
- * 背景：
- *  - 设置侧边栏需提供统一的关闭图标，同时不依赖额外的资产构建。
- * 目的：
- *  - 提供语义化的乘号图标用于对话框关闭按钮，保持与导航控件一致的视觉密度。
- * 关键决策与取舍：
- *  - 采用内联 SVG 以规避新增静态资源与构建步骤；路径参数参考 16px 基线，便于未来主题复用。
- */
-function CloseGlyph({ className, ...props }) {
-  return (
-    <svg
-      className={className}
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      focusable="false"
-      {...props}
-    >
-      <path
-        d="M4.22 4.22a.75.75 0 0 1 1.06 0L8 6.94l2.72-2.72a.75.75 0 1 1 1.06 1.06L9.06 8l2.72 2.72a.75.75 0 0 1-1.06 1.06L8 9.06l-2.72 2.72a.75.75 0 1 1-1.06-1.06L6.94 8 4.22 5.28a.75.75 0 0 1 0-1.06Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-
-CloseGlyph.propTypes = {
-  className: PropTypes.string,
-};
-
-CloseGlyph.defaultProps = {
-  className: undefined,
-};
 
 Preferences.propTypes = {
-  variant: PropTypes.oneOf(Object.values(VARIANTS)),
-  initialTab: PropTypes.oneOf(TAB_ORDER),
   onOpenAccountManager: PropTypes.func,
-  onClose: PropTypes.func,
 };
 
 Preferences.defaultProps = {
-  variant: VARIANTS.PAGE,
-  initialTab: TAB_KEYS.GENERAL,
   onOpenAccountManager: undefined,
-  onClose: undefined,
 };
 
 export default Preferences;


### PR DESCRIPTION
## Summary
- simplify the preferences page into a single account summary form and drop legacy multi-tab logic
- rework the module CSS to the new minimal layout tokens and adjust SettingsModal integration
- refresh the preferences tests to validate account field hydration and manage-profile actions

## Testing
- npm test -- Preferences
- npm run lint -- --fix
- npm run lint:css -- --fix

------
https://chatgpt.com/codex/tasks/task_e_68de2047d9bc8332a49af6edf7100b38