### PR TITLE
feat: add plain tone for empty state

### DIFF
--- a/website/src/components/ui/EmptyState/EmptyState.jsx
+++ b/website/src/components/ui/EmptyState/EmptyState.jsx
@@ -8,6 +8,12 @@ const SIZE_CLASS_MAP = {
   lg: styles["size-lg"],
 };
 
+// 通过“tone → className”映射构建轻量策略表，确保新增视觉语态时无需修改渲染分支。
+const TONE_CLASS_MAP = Object.freeze({
+  decorated: styles["tone-decorated"],
+  plain: styles["tone-plain"],
+});
+
 function EmptyState({
   iconName,
   illustration,
@@ -16,20 +22,24 @@ function EmptyState({
   actions,
   className = "",
   size = "md",
+  tone = "decorated",
 }) {
   const sizeClass = SIZE_CLASS_MAP[size] || SIZE_CLASS_MAP.md;
+  const toneClass = TONE_CLASS_MAP[tone] || TONE_CLASS_MAP.decorated;
   const hasVisual = Boolean(illustration || iconName);
+  // plain 语态要求纯信息呈现，因此即便传入图标亦跳过渲染，避免残留装饰元素。
+  const shouldRenderVisual = tone !== "plain" && hasVisual;
 
   return (
     <section
-      className={[styles.wrapper, sizeClass, className]
+      className={[styles.wrapper, sizeClass, toneClass, className]
         .filter(Boolean)
         .join(" ")}
     >
-      {hasVisual ? (
+      {shouldRenderVisual ? (
         <div className={styles.illustration} aria-hidden="true">
           {illustration || (
-            <ThemeIcon name={iconName} alt="" className={styles.icon} />
+            <ThemeIcon name={iconName} alt="" className={styles.icon} decorative />
           )}
         </div>
       ) : null}
@@ -48,6 +58,7 @@ EmptyState.propTypes = {
   actions: PropTypes.node,
   className: PropTypes.string,
   size: PropTypes.oneOf(["sm", "md", "lg"]),
+  tone: PropTypes.oneOf(["decorated", "plain"]),
 };
 
 export default EmptyState;

--- a/website/src/components/ui/EmptyState/EmptyState.module.css
+++ b/website/src/components/ui/EmptyState/EmptyState.module.css
@@ -23,10 +23,30 @@
   backdrop-filter: blur(18px);
 }
 
+.tone-decorated {
+  /* 保持默认的华丽装饰语态，预留钩子以便未来扩展主题细节。 */
+}
+
+.tone-plain {
+  /* 纯净态移除所有装饰元素，仅保留信息层级与舒展的留白节奏。 */
+  background: none;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  padding: var(--space-4, 24px) 0;
+  gap: var(--space-2, 8px);
+}
+
 @supports not (color: color-mix(in srgb, white 50%, black)) {
   .wrapper {
     background: var(--color-surface-muted);
     border: 1px solid var(--border-color);
+  }
+
+  .tone-plain {
+    background: none;
+    border: none;
+    box-shadow: none;
   }
 }
 

--- a/website/src/components/ui/EmptyState/EmptyState.test.jsx
+++ b/website/src/components/ui/EmptyState/EmptyState.test.jsx
@@ -1,0 +1,77 @@
+/**
+ * 背景：
+ *  - EmptyState 组件在产品中被多场景复用，之前仅提供单一带插画的视觉语态。
+ * 目的：
+ *  - 回归词典主视图的纯信息诉求，为组件引入 tone 策略并确保可测试。
+ * 关键决策与取舍：
+ *  - 采用 React Testing Library 校验结构，避免与样式实现细节硬编码耦合；
+ *  - 通过 CSS Modules class 查询确认插画容器显隐，从而精确断言视觉语态。
+ * 影响范围：
+ *  - EmptyState 组件的 plain/decorated 视觉策略与依赖其空态的页面。
+ * 演进与TODO：
+ *  - 后续可补充对自定义 illustration 节点与动作区交互的覆盖。
+ */
+
+import { createElement } from "react";
+import { jest } from "@jest/globals";
+import { render } from "@testing-library/react";
+import styles from "./EmptyState.module.css";
+
+// 以 unstable_mockModule 预先替换 ThemeIcon，避免触发主题 orchestrator 的副作用。
+jest.unstable_mockModule("@/components/ui/Icon", () => ({
+  __esModule: true,
+  default: ({ decorative, ...props }) => {
+    void decorative;
+    return createElement("span", { ...props, "data-testid": "theme-icon" });
+  },
+}));
+
+const { default: EmptyState } = await import("./EmptyState.jsx");
+
+describe("EmptyState", () => {
+  /**
+   * 测试目标：验证默认 tone=decorated 时，组件会渲染插画容器及对应图标。
+   * 前置条件：提供 iconName，保持 tone 默认为 decorated。
+   * 步骤：
+   *  1) 渲染组件并传入 iconName。
+   *  2) 查询插画容器节点。
+   * 断言：
+   *  - 找到插画容器，说明默认语态仍保留装饰视觉。
+   * 边界/异常：
+   *  - 若 iconName 缺失资源，ThemeIcon 将 fallback 但仍渲染容器。
+   */
+  it("GivenDecoratedTone_WhenIconProvided_ThenRendersIllustrationContainer", () => {
+    const { container } = render(
+      <EmptyState iconName="target" title="标题" description="描述" />,
+    );
+
+    expect(container.querySelector(`.${styles.illustration}`)).not.toBeNull();
+  });
+
+  /**
+   * 测试目标：验证 tone="plain" 时，组件不会渲染插画容器并正确添加纯净态类名。
+   * 前置条件：提供 iconName 但 tone 设置为 plain。
+   * 步骤：
+   *  1) 渲染组件并传入 tone="plain"。
+   *  2) 查询插画容器及包装元素。
+   * 断言：
+   *  - 插画容器不存在；
+   *  - 包装元素包含 tone-plain 类。
+   * 边界/异常：
+   *  - 若外部误传 illustration 节点，依旧应被 tone 约束。
+   */
+  it("GivenPlainTone_WhenVisualPropsProvided_ThenSkipsIllustrationAndAppliesPlainClass", () => {
+    const { container } = render(
+      <EmptyState
+        iconName="target"
+        tone="plain"
+        title="标题"
+        description="描述"
+      />,
+    );
+
+    expect(container.querySelector(`.${styles.illustration}`)).toBeNull();
+    const wrapper = container.querySelector(`.${styles.wrapper}`);
+    expect(wrapper?.classList.contains(styles["tone-plain"])).toBe(true);
+  });
+});

--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -169,7 +169,7 @@ export default function DictionaryExperience() {
             />
           ) : (
             <EmptyState
-              iconName="target"
+              tone="plain"
               title={searchEmptyState.title}
               description={searchEmptyState.description}
             />


### PR DESCRIPTION
## Summary
- add a tone prop to EmptyState so the dictionary search screen can render a plain empty view without decorative visuals
- provide tone-aware styles including a plain variant that removes illustration chrome while keeping existing wrapper behavior intact
- update DictionaryExperience to use the new plain tone and add focused unit tests covering decorated vs plain rendering

## Testing
- npm run lint
- npm run lint:css
- npm test -- EmptyState

------
https://chatgpt.com/codex/tasks/task_e_68de4516897c8332b7f7e6d86353d31d