### PR TITLE
fix: stabilize language trigger width in chat input

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -199,6 +199,16 @@
 }
 
 .language-trigger-code {
+  /*
+   * 背景：语言切换按钮会展示缩写（如 EN、ZH），若宽度随字符波动会导致两端控件抖动。
+   * 取舍：统一以 4ch 作为默认宽度对齐所有语言，利用等宽数字排版避免视觉偏差；
+   *      通过 --seg-code-width 暴露自定义能力，后续可根据品牌或排版策略调整。
+   */
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  inline-size: var(--seg-code-width, 4ch);
+  letter-spacing: normal;
   font-variant-numeric: tabular-nums;
 }
 

--- a/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
@@ -24,8 +24,10 @@ afterEach(() => {
  * 步骤：
  *  1) 构造 props 并渲染组件。
  *  2) 捕获渲染输出进行快照。
+ *  3) 抽取语言代码标识，确认挂载宽度约束类名。
  * 断言：
  *  - 快照与基准一致，证明视图未引入额外逻辑。
+ *  - language-trigger-code 类名存在，以保障 4ch 的宽度策略。
  * 边界/异常：
  *  - 语言区隐藏与否由 snapshot 体现，确保布尔条件生效。
  */
@@ -83,6 +85,14 @@ test("GivenStandardProps_WhenRenderingView_ThenMatchSnapshot", () => {
 
   const sendIcon = container.querySelector('[data-icon-name="send-button"]');
   expect(sendIcon).not.toBeNull();
+
+  const languageCodeBadges = Array.from(
+    container.querySelectorAll(`.${"language-trigger-code"}`),
+  );
+  expect(languageCodeBadges.length).toBeGreaterThan(0);
+  languageCodeBadges.forEach((badge) => {
+    expect(badge.classList.contains("language-trigger-code")).toBe(true);
+  });
 
   expect(container).toMatchSnapshot();
 });

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -115,6 +115,12 @@
   text-align: left;
 }
 
+.tab-summary {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--preferences-panel-muted);
+}
+
 .tab[data-state="active"] {
   border-color: var(--preferences-panel-border);
   background: var(--preferences-panel-surface);
@@ -123,12 +129,6 @@
 
 .tab[data-state="active"] .tab-summary {
   color: var(--preferences-panel-muted);
-}
-
-.tab:not([disabled]):hover {
-  border-color: color-mix(in srgb, var(--preferences-panel-ring) 65%, transparent);
-  background: color-mix(in srgb, var(--preferences-panel-surface) 96%, transparent);
-  color: var(--preferences-panel-text);
 }
 
 .tab:focus-visible {
@@ -147,17 +147,26 @@
   color: color-mix(in srgb, var(--preferences-panel-muted) 55%, transparent);
 }
 
+.tab:not([disabled]):hover {
+  border-color: color-mix(in srgb, var(--preferences-panel-ring) 65%, transparent);
+  background: color-mix(in srgb, var(--preferences-panel-surface) 96%, transparent);
+  color: var(--preferences-panel-text);
+}
+
+.tab:not([disabled]):hover:focus-visible {
+  /*
+   * 组合状态：保持 hover 提供的前景高亮，同时沿用 focus-visible 的描边用于键盘可达性。
+   * 若未来需要不同的交互优先级，可通过拆分变量调整两者的视觉权重。
+   */
+  border-color: var(--preferences-panel-ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--preferences-panel-ring) 45%, transparent);
+}
+
 .tab-label {
   font-size: 15px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.tab-summary {
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--preferences-panel-muted);
 }
 
 .panel {


### PR DESCRIPTION
## Summary
- center and fix the language trigger badge width while documenting the new 4ch slot token
- extend the ActionInputView snapshot test to assert the presence of the width constraint class
- reorder preference tab pseudo-classes to satisfy stylelint while preserving hover and focus feedback

## Testing
- npm run lint
- npm run lint:css
- npm run test -- ActionInputView.test.jsx *(fails: Jest raises `Syntax error reading regular expression` while loading the suite even before our assertions run)*

------
https://chatgpt.com/codex/tasks/task_e_68de4bb26a748332a4470083fecb7cd4