### PR TITLE
Reorder preferences tab styles for specificity

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -89,6 +89,7 @@
 .tabs-region {
   position: relative;
   display: flex;
+
   --preferences-close-offset: 68px;
 }
 
@@ -138,6 +139,12 @@
   text-align: left;
 }
 
+.tab-summary {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--preferences-panel-muted);
+}
+
 .tab:focus-visible {
   outline: none;
   border-color: var(--preferences-panel-ring);
@@ -149,6 +156,10 @@
   cursor: not-allowed;
   color: color-mix(in srgb, var(--preferences-panel-muted) 65%, transparent);
   opacity: 0.6;
+}
+
+.tab:disabled .tab-summary {
+  color: color-mix(in srgb, var(--preferences-panel-muted) 55%, transparent);
 }
 
 .tab:not([disabled]):hover {
@@ -176,16 +187,6 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.tab-summary {
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--preferences-panel-muted);
-}
-
-.tab:disabled .tab-summary {
-  color: color-mix(in srgb, var(--preferences-panel-muted) 55%, transparent);
 }
 
 .tab[data-state="active"] .tab-summary {


### PR DESCRIPTION
## Summary
- reorder the preferences tab state selectors so focus and disabled variants precede the hover rule, keeping specificity ascending
- place the base tab summary styles ahead of state-specific overrides to satisfy stylelint's descending specificity check

## Testing
- npx stylelint "src/**/*.css"


------
https://chatgpt.com/codex/tasks/task_e_68de76ed61ac8332affb6d8bd7fa9807