### PR TITLE
fix: stabilize ChatInput language badge layout

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -198,7 +198,17 @@
   gap: 0;
 }
 
+/*
+ * 背景说明：语言缩写需要固定容积以保持箭头与动作按钮对齐。
+ *  - 选用 4ch 结合 tabular-nums 提供稳定的等宽节奏，避免切换语言时触发抖动。
+ *  - 暴露 --seg-code-width 便于未来适配更长徽标，无需改动组件结构。
+ */
 .language-trigger-code {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  inline-size: var(--seg-code-width, 4ch);
+  letter-spacing: normal;
   font-variant-numeric: tabular-nums;
 }
 

--- a/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ActionInputView.test.jsx
@@ -88,6 +88,77 @@ test("GivenStandardProps_WhenRenderingView_ThenMatchSnapshot", () => {
 });
 
 /**
+ * 测试目标：语言触发器应绑定等宽徽标样式以稳定布局。
+ * 前置条件：提供可见的语言控件与中英选项。
+ * 步骤：
+ *  1) 渲染组件并定位语言触发按钮的徽标节点。
+ *  2) 读取类名与文本内容验证宽度约束钩子。
+ * 断言：
+ *  - 徽标节点存在且包含 language-trigger-code 类，证明宽度约束生效。
+ *  - 徽标文本与源语言缩写一致，便于自定义属性适配不同宽度。
+ * 边界/异常：
+ *  - 若类名缺失或徽标为空，将无法维持 4ch 节奏，应提示设计联动。
+ */
+test("GivenLanguageControlsVisible_WhenRendering_ThenApplyFixedCodeWidth", () => {
+  const formRef = createRef();
+  const { container } = render(
+    <ActionInputView
+      formProps={{ ref: formRef, onSubmit: jest.fn() }}
+      textareaProps={{
+        ref: jest.fn(),
+        rows: 2,
+        placeholder: "Say something",
+        value: "example",
+        onChange: jest.fn(),
+        onKeyDown: jest.fn(),
+        onFocus: jest.fn(),
+        onBlur: jest.fn(),
+      }}
+      languageControls={{
+        isVisible: true,
+        props: {
+          sourceLanguage: "ZH",
+          sourceLanguageOptions: [
+            { value: "ZH", label: "中文" },
+            { value: "EN", label: "英文" },
+          ],
+          sourceLanguageLabel: "源语言",
+          onSourceLanguageChange: jest.fn(),
+          targetLanguage: "EN",
+          targetLanguageOptions: [
+            { value: "EN", label: "英文" },
+            { value: "ZH", label: "中文" },
+          ],
+          targetLanguageLabel: "目标语言",
+          onTargetLanguageChange: jest.fn(),
+          onSwapLanguages: jest.fn(),
+          swapLabel: "交换语向",
+          normalizeSourceLanguage: jest.fn((value) => value),
+          normalizeTargetLanguage: jest.fn((value) => value),
+          onMenuOpen: jest.fn(),
+        },
+      }}
+      actionButtonProps={{
+        value: "example",
+        isRecording: false,
+        voiceCooldownRef: { current: 0 },
+        onVoice: jest.fn(),
+        onSubmit: jest.fn(),
+        isVoiceDisabled: false,
+        sendLabel: "发送",
+        voiceLabel: "语音",
+      }}
+    />,
+  );
+
+  const triggerBadge = container.querySelector(".language-trigger-code");
+
+  expect(triggerBadge).not.toBeNull();
+  expect(triggerBadge?.classList.contains("language-trigger-code")).toBe(true);
+  expect(triggerBadge?.textContent).toBe("ZH");
+});
+
+/**
  * 测试目标：当语言区隐藏时，网格属性与语义标记应正确折叠。
  * 前置条件：languageControls.isVisible=false。
  * 步骤：

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -89,6 +89,7 @@
 .tabs-region {
   position: relative;
   display: flex;
+
   --preferences-close-offset: 68px;
 }
 


### PR DESCRIPTION
## Summary
- fix the ChatInput language badge layout by centering the code label, normalising letter spacing, and exposing a configurable 4ch width token
- add a regression test that asserts the language trigger renders the code badge with the expected class hook
- resolve the outstanding stylelint violation in the preferences tabs region by restoring the spacing before the custom property

## Testing
- npm run lint
- npm run lint:css
- npm run test -- ActionInputView.test.jsx *(fails: Jest exits early with “Syntax error reading regular expression” even on the pre-change baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68de76e78cc88332be153d13795a19f7