### PR TITLE
feat(dictionary): restore focus after returning to search

### DIFF
--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import MessagePopup from "@/components/ui/MessagePopup";
 import Layout from "@/components/Layout";
 import FavoritesView from "@/pages/App/FavoritesView.jsx";
@@ -11,7 +12,9 @@ import {
   normalizeWordTargetLanguage,
 } from "@/utils";
 import { useDictionaryExperience } from "./hooks/useDictionaryExperience";
-import useBottomPanelState from "./hooks/useBottomPanelState";
+import useBottomPanelState, {
+  PANEL_MODE_SEARCH,
+} from "./hooks/useBottomPanelState";
 import BottomPanelSwitcher from "./components/BottomPanelSwitcher.jsx";
 import DictionaryActionPanel from "./components/DictionaryActionPanel.jsx";
 import "@/pages/App/App.css";
@@ -70,9 +73,19 @@ export default function DictionaryExperience() {
     handleScrollEscape,
   } = useBottomPanelState({ hasDefinition, text });
 
+  useEffect(() => {
+    // 当面板切回搜索模式时再聚焦输入框，确保 ChatInput 完成重新挂载。
+    if (bottomPanelMode !== PANEL_MODE_SEARCH) {
+      return;
+    }
+    if (!inputRef.current) {
+      return;
+    }
+    focusInput();
+  }, [bottomPanelMode, focusInput, inputRef]);
+
   const handleSearchButtonClick = () => {
     activateSearchMode();
-    focusInput();
   };
 
   const handleInputFocusChange = (focused) => {

--- a/website/src/features/dictionary-experience/__tests__/DictionaryExperience.focus.test.jsx
+++ b/website/src/features/dictionary-experience/__tests__/DictionaryExperience.focus.test.jsx
@@ -1,0 +1,209 @@
+/**
+ * 背景：
+ *  - 词典体验在释义操作与搜索输入间切换时，存在输入框未及时聚焦的问题。
+ * 目的：
+ *  - 通过针对 DictionaryExperience 的集成测试，验证搜索模式复位后聚焦逻辑的异步保证。
+ * 关键决策与取舍：
+ *  - 采用 React Testing Library 渲染实际组件骨架，通过桩件稳定底部面板状态；
+ *  - 放弃直接调用内部 Hook，避免对实现细节形成脆弱耦合。
+ * 影响范围：
+ *  - DictionaryExperience 聚焦行为的回归保障。
+ * 演进与TODO：
+ *  - 若后续增加更多底部模式，可拓展此文件覆盖多模式切换的聚焦策略。
+ */
+/* eslint-env jest */
+import React, { useEffect, useRef } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+const focusInputMock = jest.fn();
+const inputRef = { current: null };
+
+jest.unstable_mockModule("../hooks/useDictionaryExperience.js", () => ({
+  __esModule: true,
+  useDictionaryExperience: jest.fn(() => ({
+    inputRef,
+    t: { returnToSearch: "返回搜索" },
+    text: "",
+    setText: jest.fn(),
+    dictionarySourceLanguage: "en",
+    setDictionarySourceLanguage: jest.fn(),
+    dictionaryTargetLanguage: "zh",
+    setDictionaryTargetLanguage: jest.fn(),
+    sourceLanguageOptions: [],
+    targetLanguageOptions: [],
+    handleSwapLanguages: jest.fn(),
+    handleSend: jest.fn(),
+    handleVoice: jest.fn(),
+    showFavorites: false,
+    showHistory: false,
+    handleShowDictionary: jest.fn(),
+    handleShowFavorites: jest.fn(),
+    handleSelectHistory: jest.fn(),
+    handleSelectFavorite: jest.fn(),
+    handleUnfavorite: jest.fn(),
+    favorites: [],
+    focusInput: focusInputMock,
+    entry: { term: "mock" },
+    finalText: "",
+    streamText: "",
+    loading: false,
+    dictionaryActionBarProps: {},
+    displayClassName: "dictionary-experience",
+    popupOpen: false,
+    popupMsg: "",
+    closePopup: jest.fn(),
+    dictionaryTargetLanguageLabel: "目标语言",
+    dictionarySourceLanguageLabel: "源语言",
+    dictionarySwapLanguagesLabel: "切换",
+    favoritesEmptyState: {
+      title: "",
+      description: "",
+      actionLabel: "",
+      removeLabel: "",
+    },
+    searchEmptyState: { title: "", description: "" },
+    chatInputPlaceholder: "",
+    activeSidebarView: "dictionary",
+  })),
+}));
+
+jest.unstable_mockModule("../hooks/useBottomPanelState.ts", async () => {
+  const ReactModule = await import("react");
+  const useBottomPanelStateMock = jest.fn(() => {
+    const [mode, setMode] = ReactModule.useState("actions");
+
+    return {
+      mode,
+      activateSearchMode: () => setMode("search"),
+      activateActionsMode: () => setMode("actions"),
+      handleFocusChange: jest.fn(),
+      handleScrollEscape: jest.fn(),
+    };
+  });
+
+  return {
+    __esModule: true,
+    PANEL_MODE_SEARCH: "search",
+    default: useBottomPanelStateMock,
+  };
+});
+
+jest.unstable_mockModule("@/components/Layout", () => ({
+  __esModule: true,
+  default: ({ bottomContent, children }) => (
+    <div>
+      <div data-testid="layout-bottom-content">{bottomContent}</div>
+      <div>{children}</div>
+    </div>
+  ),
+}));
+
+jest.unstable_mockModule("@/pages/App/FavoritesView.jsx", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.unstable_mockModule("@/components/ui/HistoryDisplay", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.unstable_mockModule("@/components/ui/DictionaryEntry", () => ({
+  __esModule: true,
+  DictionaryEntryView: () => <div data-testid="dictionary-entry" />,
+}));
+
+jest.unstable_mockModule("@/components/ui/ChatInput", () => {
+  const MockChatInput = ({ inputRef: forwardedRef }) => {
+    const innerRef = useRef(null);
+
+    useEffect(() => {
+      if (innerRef.current) {
+        forwardedRef.current = innerRef.current;
+      }
+      return () => {
+        forwardedRef.current = null;
+      };
+    }, [forwardedRef]);
+
+    return <input ref={innerRef} data-testid="dictionary-chat-input" />;
+  };
+
+  MockChatInput.displayName = "MockChatInput";
+
+  return {
+    __esModule: true,
+    default: MockChatInput,
+  };
+});
+
+jest.unstable_mockModule("@/components/ui/ICP", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.unstable_mockModule("@/components/ui/EmptyState", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.unstable_mockModule("@/components/ui/MessagePopup", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.unstable_mockModule("../components/BottomPanelSwitcher.jsx", () => ({
+  __esModule: true,
+  default: ({ mode, searchContent, actionsContent }) => (
+    <div data-testid="bottom-panel">
+      {mode === "search" ? searchContent : actionsContent}
+    </div>
+  ),
+}));
+
+jest.unstable_mockModule("../components/DictionaryActionPanel.jsx", () => ({
+  __esModule: true,
+  default: ({ onRequestSearch, searchButtonLabel }) => (
+    <button type="button" onClick={onRequestSearch}>
+      {searchButtonLabel}
+    </button>
+  ),
+}));
+
+const DictionaryExperience = (await import("../DictionaryExperience.jsx")).default;
+
+describe("DictionaryExperience focus management", () => {
+  beforeEach(() => {
+    focusInputMock.mockClear();
+    inputRef.current = null;
+  });
+
+  /**
+   * 测试目标：验证从操作面板切换回搜索模式时，底部输入框在重新挂载后被聚焦。
+   * 前置条件：useDictionaryExperience 与 useBottomPanelState 被桩件固定为“存在词条且初始模式为 actions”。
+   * 步骤：
+   *  1) 渲染 DictionaryExperience；
+   *  2) 确认初始渲染展示操作面板且未触发 focusInput；
+   *  3) 点击“返回搜索”按钮切换到底部搜索模式；
+   *  4) 等待 ChatInput 重新挂载并触发聚焦副作用。
+   * 断言：
+   *  - 初始阶段 focusInput 未被调用；
+   *  - 点击按钮后最终调用一次 focusInput。
+   * 边界/异常：
+   *  - 当输入框 ref 尚未建立时不会触发聚焦，避免空引用异常。
+   */
+  test("Given_actionsPanel_When_switchBackToSearch_Then_focusesChatInputAfterRemount", async () => {
+    render(<DictionaryExperience />);
+
+    const searchButton = screen.getByRole("button", { name: "返回搜索" });
+    expect(focusInputMock).not.toHaveBeenCalled();
+
+    fireEvent.click(searchButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dictionary-chat-input")).toBeInTheDocument();
+      expect(focusInputMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- focus the dictionary chat input whenever the bottom panel switches back to search mode
- reuse the PANEL_MODE_SEARCH constant to keep mode semantics aligned across the experience
- add a regression test that verifies focusInput runs after the panel returns from the actions view

## Testing
- npm run lint
- node --max-old-space-size=4096 --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand src/features/dictionary-experience/__tests__/DictionaryExperience.focus.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68de7be21b288332ab50bc9b0481bfda