### PR TITLE
Fix sidebar flat nav highlight states

### DIFF
--- a/website/src/components/Sidebar/NavItem.module.css
+++ b/website/src/components/Sidebar/NavItem.module.css
@@ -111,6 +111,11 @@
   background: transparent;
 }
 
+.flat:hover,
+.flat:focus-visible {
+  background: var(--sidebar-hover-bg, var(--hover));
+}
+
 .flat::before {
   display: none;
 }
@@ -118,6 +123,11 @@
 .flat-active {
   background: transparent;
   color: var(--sidebar-color, var(--text));
+}
+
+.flat-active:hover,
+.flat-active:focus-visible {
+  background: var(--sidebar-active-bg, var(--active));
 }
 
 .flat-active::before {
@@ -129,6 +139,13 @@
 .flat-active.item[aria-current="page"] {
   background: transparent;
   color: var(--sidebar-color, var(--text));
+}
+
+.flat.item[aria-current="page"]:hover,
+.flat.item[aria-current="page"]:focus-visible,
+.flat-active.item[aria-current="page"]:hover,
+.flat-active.item[aria-current="page"]:focus-visible {
+  background: var(--sidebar-active-bg, var(--active));
 }
 
 .flat.item[aria-current="page"]::before,


### PR DESCRIPTION
## Summary
- allow flat sidebar navigation items to reuse the standard hover and focus background tokens
- keep flat active entries transparent at rest while matching the accent variant during interaction states

## Testing
- npm run lint
- npm run lint:css
- prettier -w website/src/components/Sidebar/NavItem.module.css

------
https://chatgpt.com/codex/tasks/task_e_68de87b2d8388332abdac85d7c7628d1