### PR TITLE
feat: centralize settings focus management

### DIFF
--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -10,7 +10,7 @@
  * 演进与TODO：
  *  - TODO: 后续可在此接入动画或过渡状态，并考虑拆分基础模态与业务逻辑。
  */
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 import BaseModal from "./BaseModal.jsx";
 import SettingsBody from "./SettingsBody.jsx";
@@ -20,6 +20,7 @@ import SettingsPanel from "./SettingsPanel.jsx";
 import modalStyles from "./SettingsModal.module.css";
 import preferencesStyles from "@/pages/preferences/Preferences.module.css";
 import usePreferenceSections from "@/pages/preferences/usePreferenceSections.js";
+import useSectionFocusManager from "@/hooks/useSectionFocusManager.js";
 
 function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) {
   const { copy, header, sections, activeSection, activeSectionId, handleSectionSelect, handleSubmit, panel } =
@@ -27,6 +28,19 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
       initialSectionId: initialSection,
       onOpenAccountManager,
     });
+
+  const { captureFocusOrigin, registerHeading } = useSectionFocusManager({
+    activeSectionId,
+    headingId: panel.headingId,
+  });
+
+  const handleSectionSelectWithFocus = useCallback(
+    (section) => {
+      captureFocusOrigin();
+      handleSectionSelect(section);
+    },
+    [captureFocusOrigin, handleSectionSelect],
+  );
 
   const renderCloseAction = useMemo(
     () =>
@@ -86,7 +100,7 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
             <SettingsNav
               sections={sections}
               activeSectionId={activeSectionId}
-              onSelect={handleSectionSelect}
+              onSelect={handleSectionSelectWithFocus}
               tablistLabel={copy.tablistLabel}
               renderCloseAction={renderCloseAction}
               classes={{
@@ -102,7 +116,9 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
             <SettingsPanel
               panelId={panel.panelId}
               tabId={panel.tabId}
+              headingId={panel.headingId}
               className={preferencesStyles.panel}
+              onHeadingElementChange={registerHeading}
             >
               {activeSection ? (
                 <activeSection.Component

--- a/website/src/components/modals/__tests__/SettingsNavPanel.test.jsx
+++ b/website/src/components/modals/__tests__/SettingsNavPanel.test.jsx
@@ -1,0 +1,136 @@
+/**
+ * 背景：
+ *  - SettingsNav 与 SettingsPanel 需要在无框架容器中验证焦点切换是否符合可访问性预期。
+ * 目的：
+ *  - 通过组合测试确保分区切换后标题获得焦点，并验证 Tab/Shift+Tab 焦点循环不会逃离模态。
+ * 关键决策与取舍：
+ *  - 选择真实组件 + 轻量测试容器而非模拟 Hook，确保行为贴近生产；放弃 e2e 以保持单测执行效率。
+ * 影响范围：
+ *  - 聚焦策略的回归验证，防止未来重构破坏键盘可达性。
+ * 演进与TODO：
+ *  - TODO: 后续可扩展至箭头键导航及滚动同步的断言。
+ */
+import { useCallback, useMemo, useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SettingsNav from "../SettingsNav.jsx";
+import SettingsPanel from "../SettingsPanel.jsx";
+import useSectionFocusManager from "@/hooks/useSectionFocusManager.js";
+
+function TestSection({ headingId, title, actionLabel }) {
+  return (
+    <section aria-labelledby={headingId}>
+      <h3 id={headingId} tabIndex={-1}>
+        {title}
+      </h3>
+      <button type="button">{actionLabel}</button>
+    </section>
+  );
+}
+
+function TestSettingsHarness() {
+  const sections = useMemo(
+    () => [
+      { id: "account", label: "Account", summary: "Account summary" },
+      { id: "privacy", label: "Privacy", summary: "Privacy summary" },
+    ],
+    [],
+  );
+  const [activeSectionId, setActiveSectionId] = useState(sections[0].id);
+  const activeSection = sections.find((section) => section.id === activeSectionId) ?? sections[0];
+  const headingId = `${activeSection.id}-heading`;
+
+  const { captureFocusOrigin, registerHeading } = useSectionFocusManager({
+    activeSectionId,
+    headingId,
+  });
+
+  const handleSectionSelect = useCallback(
+    (section) => {
+      captureFocusOrigin();
+      setActiveSectionId(section.id);
+    },
+    [captureFocusOrigin],
+  );
+
+  return (
+    <div role="dialog" aria-modal="true">
+      <SettingsNav
+        sections={sections}
+        activeSectionId={activeSectionId}
+        onSelect={handleSectionSelect}
+        tablistLabel="Example sections"
+      />
+      <SettingsPanel
+        panelId={`${activeSection.id}-panel`}
+        tabId={`${activeSection.id}-tab`}
+        headingId={headingId}
+        onHeadingElementChange={registerHeading}
+      >
+        <TestSection
+          headingId={headingId}
+          title={`${activeSection.label} heading`}
+          actionLabel={`${activeSection.label} action`}
+        />
+      </SettingsPanel>
+    </div>
+  );
+}
+
+/**
+ * 测试目标：切换分区后标题获得焦点并滚动至首部。
+ * 前置条件：渲染 TestSettingsHarness，激活默认 account 分区。
+ * 步骤：
+ *  1) 点击 Privacy 分区标签。
+ *  2) 等待焦点迁移。
+ * 断言：
+ *  - document.activeElement 与 Privacy 标题相同，失败信息提示当前聚焦元素。
+ * 边界/异常：
+ *  - 若 requestAnimationFrame 不可用，利用 setTimeout 回退仍应通过。
+ */
+test("Given section change When selecting new tab Then heading receives focus", async () => {
+  const user = userEvent.setup();
+  render(<TestSettingsHarness />);
+
+  await user.click(screen.getByRole("tab", { name: /^Privacy/ }));
+
+  const privacyHeading = await screen.findByRole("heading", { name: "Privacy heading" });
+
+  await waitFor(() => {
+    expect(document.activeElement).toBe(privacyHeading);
+  });
+});
+
+/**
+ * 测试目标：验证 Tab/Shift+Tab 在模态内循环且不逃逸。
+ * 前置条件：渲染 TestSettingsHarness，并切换至 Privacy 分区以触发焦点逻辑。
+ * 步骤：
+ *  1) 点击 Privacy 分区标签等待标题聚焦。
+ *  2) 依次执行 Tab、Shift+Tab。
+ * 断言：
+ *  - Tab 后焦点落在分区按钮。
+ *  - Shift+Tab 回到 Privacy 标签按钮，焦点仍位于模态内。
+ * 边界/异常：
+ *  - 若有额外聚焦元素插入，应更新断言顺序保持循环闭合。
+ */
+test("Given heading focus When tabbing Then focus remains within modal", async () => {
+  const user = userEvent.setup();
+  render(<TestSettingsHarness />);
+
+  const privacyTab = screen.getByRole("tab", { name: /^Privacy/ });
+  await user.click(privacyTab);
+
+  const privacyHeading = await screen.findByRole("heading", { name: "Privacy heading" });
+
+  await waitFor(() => {
+    expect(document.activeElement).toBe(privacyHeading);
+  });
+
+  await user.tab();
+  const privacyActionButton = await screen.findByRole("button", { name: "Privacy action" });
+  expect(document.activeElement).toBe(privacyActionButton);
+
+  await user.tab({ shift: true });
+  expect(document.activeElement).toBe(privacyTab);
+});
+

--- a/website/src/hooks/useSectionFocusManager.js
+++ b/website/src/hooks/useSectionFocusManager.js
@@ -1,0 +1,133 @@
+/**
+ * 背景：
+ *  - SettingsNav 与 SettingsPanel 在切换分区时缺乏统一的焦点管理，导致读屏器复诵与滚动跳跃问题。
+ * 目的：
+ *  - 通过集中式 Hook 复用焦点迁移策略，确保分区切换后标题获得焦点并回滚至视口起始位置。
+ * 关键决策与取舍：
+ *  - 采用组合模式：由容器负责调用 captureFocusOrigin，而面板通过 registerHeading 注入目标节点；拒绝直接在 Hook 内持有状态，避免重复渲染。
+ * 影响范围：
+ *  - SettingsModal 与 Preferences 页面在切换分区时的可访问性体验。
+ * 演进与TODO：
+ *  - TODO: 后续可扩展为自定义动画或平滑滚动策略，并在多列布局下支持自适应滚动容器。
+ */
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+
+const requestFrame = (callback) => {
+  if (isBrowser && typeof window.requestAnimationFrame === "function") {
+    return window.requestAnimationFrame(callback);
+  }
+  return setTimeout(callback, 0);
+};
+
+const cancelFrame = (handle) => {
+  if (isBrowser && typeof window.cancelAnimationFrame === "function") {
+    window.cancelAnimationFrame(handle);
+    return;
+  }
+  clearTimeout(handle);
+};
+
+const ensureHeadingTabIndex = (node) => {
+  if (!node || node.hasAttribute("tabindex")) {
+    return;
+  }
+  node.setAttribute("tabindex", "-1");
+};
+
+const isFocusable = (node) => Boolean(node && typeof node.focus === "function");
+
+/**
+ * 意图：在分区切换时聚焦指定标题，必要时回退至原始焦点来源。
+ * 输入：
+ *  - activeSectionId: 当前激活分区标识，用于侦测切换。
+ *  - headingId: 目标标题的 DOM id，辅助调试与容错。
+ * 输出：
+ *  - captureFocusOrigin: 在触发切换前调用，用于记录焦点来源。
+ *  - registerHeading: 由面板调用以注册标题 DOM 节点。
+ * 流程：
+ *  1) captureFocusOrigin 记录可聚焦元素。
+ *  2) registerHeading 注入最新标题节点并补齐 tabindex。
+ *  3) useLayoutEffect 监听 activeSectionId 变化，通过 requestAnimationFrame 聚焦标题并 scrollIntoView。
+ * 错误处理：回退到上一次焦点来源，确保焦点不逃逸至 <body>。
+ * 复杂度：时间 O(1)，空间 O(1)。
+ */
+function useSectionFocusManager({ activeSectionId, headingId }) {
+  const headingRef = useRef(null);
+  const lastFocusOriginRef = useRef(null);
+  const lastActiveSectionIdRef = useRef();
+  const hasInitializedRef = useRef(false);
+
+  const captureFocusOrigin = useCallback(() => {
+    if (!isBrowser) {
+      lastFocusOriginRef.current = null;
+      return;
+    }
+    const activeElement = document.activeElement;
+    if (isFocusable(activeElement) && activeElement !== document.body) {
+      lastFocusOriginRef.current = activeElement;
+      return;
+    }
+    lastFocusOriginRef.current = null;
+  }, []);
+
+  const registerHeading = useCallback((headingElement) => {
+    headingRef.current = headingElement ?? null;
+    if (headingElement) {
+      ensureHeadingTabIndex(headingElement);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!activeSectionId || !isBrowser) {
+      return undefined;
+    }
+
+    const previousActiveSectionId = lastActiveSectionIdRef.current;
+    lastActiveSectionIdRef.current = activeSectionId;
+
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+      return undefined;
+    }
+
+    if (previousActiveSectionId === activeSectionId && headingRef.current) {
+      return undefined;
+    }
+
+    const frameId = requestFrame(() => {
+      const headingElement = headingRef.current;
+      if (headingElement && (!headingId || headingElement.id === headingId)) {
+        ensureHeadingTabIndex(headingElement);
+        try {
+          headingElement.focus();
+          if (typeof headingElement.scrollIntoView === "function") {
+            headingElement.scrollIntoView({ block: "start" });
+          }
+          lastFocusOriginRef.current = null;
+          return;
+        } catch {
+          // ignore and fall back to origin
+        }
+      }
+
+      const fallbackTarget = lastFocusOriginRef.current;
+      if (isFocusable(fallbackTarget)) {
+        fallbackTarget.focus();
+      }
+    });
+
+    return () => {
+      cancelFrame(frameId);
+    };
+  }, [activeSectionId, headingId]);
+
+  return {
+    captureFocusOrigin,
+    registerHeading,
+  };
+}
+
+export default useSectionFocusManager;
+

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -11,6 +11,7 @@
  *  - TODO: 随着更多分区上线，可在 usePreferenceSections 内扩展蓝图并按需引入懒加载策略。
  */
 import PropTypes from "prop-types";
+import { useCallback } from "react";
 import {
   SettingsBody,
   SettingsHeader,
@@ -19,6 +20,7 @@ import {
 } from "@/components/modals";
 import styles from "./Preferences.module.css";
 import usePreferenceSections from "./usePreferenceSections.js";
+import useSectionFocusManager from "@/hooks/useSectionFocusManager.js";
 
 function Preferences({
   onOpenAccountManager,
@@ -30,6 +32,19 @@ function Preferences({
       initialSectionId: initialSection,
       onOpenAccountManager,
     });
+
+  const { captureFocusOrigin, registerHeading } = useSectionFocusManager({
+    activeSectionId,
+    headingId: panel.headingId,
+  });
+
+  const handleSectionSelectWithFocus = useCallback(
+    (section) => {
+      captureFocusOrigin();
+      handleSectionSelect(section);
+    },
+    [captureFocusOrigin, handleSectionSelect],
+  );
 
   const closeRenderer = renderCloseAction
     ? ({ className }) => renderCloseAction({ className })
@@ -63,7 +78,7 @@ function Preferences({
           <SettingsNav
             sections={sections}
             activeSectionId={activeSectionId}
-            onSelect={handleSectionSelect}
+            onSelect={handleSectionSelectWithFocus}
             tablistLabel={copy.tablistLabel}
             renderCloseAction={closeRenderer}
             classes={{
@@ -79,7 +94,9 @@ function Preferences({
           <SettingsPanel
             panelId={panel.panelId}
             tabId={panel.tabId}
+            headingId={panel.headingId}
             className={styles.panel}
+            onHeadingElementChange={registerHeading}
           >
             {activeSection ? (
               <activeSection.Component

--- a/website/src/pages/preferences/sections/AccountSection.jsx
+++ b/website/src/pages/preferences/sections/AccountSection.jsx
@@ -30,7 +30,7 @@ function AccountSection({
       className={styles.section}
     >
       <div className={styles["section-header"]}>
-        <h3 id={headingId} className={styles["section-title"]}>
+        <h3 id={headingId} className={styles["section-title"]} tabIndex={-1}>
           {title}
         </h3>
         {description ? (

--- a/website/src/pages/preferences/sections/PlaceholderSection.jsx
+++ b/website/src/pages/preferences/sections/PlaceholderSection.jsx
@@ -21,7 +21,7 @@ function PlaceholderSection({ title, message, headingId, descriptionId }) {
       className={styles.section}
     >
       <div className={styles["section-header"]}>
-        <h3 id={headingId} className={styles["section-title"]}>
+        <h3 id={headingId} className={styles["section-title"]} tabIndex={-1}>
           {title}
         </h3>
       </div>


### PR DESCRIPTION
## Summary
- add a reusable useSectionFocusManager hook to coordinate section heading focus and scroll alignment
- connect SettingsModal and Preferences to capture focus origin, register headings, and mark section titles as programmatically focusable
- add regression tests covering heading focus after tab switches and keyboard tab/shift+tab loops within the modal harness

## Testing
- npm run lint
- npm run lint:css
- npm test -- SettingsNavPanel

------
https://chatgpt.com/codex/tasks/task_e_68de8a76a1e8833292b6a1fef197d2d0