### PR TITLE
Fix search box focus styling

### DIFF
--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -25,11 +25,6 @@
   box-shadow: var(--sb-shadow-hover, var(--sb-shadow));
 }
 
-.search-box:focus-within {
-  outline-color: var(--sb-border-active);
-  box-shadow: var(--sb-ring), var(--sb-shadow);
-}
-
 .search-box :global(button),
 .search-box :global(input),
 .search-box :global(textarea) {


### PR DESCRIPTION
## Summary
- remove the focus-within override on the search box so the focused state keeps the default outline and shadow

## Testing
- npx eslint --fix src/components/ui/SearchBox/SearchBox.module.css
- npx stylelint --fix src/components/ui/SearchBox/SearchBox.module.css
- npx prettier -w src/components/ui/SearchBox/SearchBox.module.css

------
https://chatgpt.com/codex/tasks/task_e_68de94492ad08332a42c13c0388b2c44