### PR TITLE
Expose sidebar footer padding tokens

### DIFF
--- a/website/src/components/Sidebar/Sidebar.module.css
+++ b/website/src/components/Sidebar/Sidebar.module.css
@@ -79,8 +79,11 @@
 }
 
 .footer {
+  --sidebar-footer-padding-top: 12px;
+  --sidebar-footer-padding-bottom: 16px;
+
   margin-top: auto;
-  padding: 12px 0 16px;
+  padding: var(--sidebar-footer-padding-top) 0 var(--sidebar-footer-padding-bottom);
   border-top: 1px solid var(--sidebar-border-color, var(--border));
   background: var(--sidebar-bg, var(--bg));
 }

--- a/website/src/components/Sidebar/UserMenu/UserMenu.module.css
+++ b/website/src/components/Sidebar/UserMenu/UserMenu.module.css
@@ -9,7 +9,7 @@
 
 .surface {
   position: absolute;
-  bottom: calc(48px + 8px);
+  bottom: calc(48px + 8px + var(--sidebar-footer-padding-top, 0px));
   left: var(--user-menu-safe);
   width: calc(var(--sidebar-w) - 2 * var(--user-menu-safe));
   border-radius: var(--menu-radius);


### PR DESCRIPTION
## Summary
- expose CSS custom properties for sidebar footer padding to allow downstream reuse
- update user menu surface positioning to account for footer padding variable

## Testing
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68de96cb4e9483328ef24f4bf33335d9