### PR TITLE
Fix Sidebar stub parameter in Layout test

### DIFF
--- a/website/src/components/__tests__/Layout.test.jsx
+++ b/website/src/components/__tests__/Layout.test.jsx
@@ -34,7 +34,7 @@ global.ResizeObserver = ResizeObserverMock;
 
 jest.unstable_mockModule("@/components/Sidebar", () => ({
   __esModule: true,
-  default: forwardRef(function SidebarStub({ isMobile: _isMobile, ...rest }, ref) {
+  default: forwardRef(function SidebarStub({ ...rest }, ref) {
     // 说明：Sidebar 的移动端与交互态在此 stub 中不参与断言，仅透传其余属性。
     return (
       <aside


### PR DESCRIPTION
## Summary
- remove the unused isMobile alias from the Sidebar stub used by the Layout tests to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de96a7d67c8332a7a14f9e5abf92ab