### PR TITLE
Refactor settings modal content layout

### DIFF
--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -69,12 +69,7 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
       closeLabel={copy.closeLabel}
       hideDefaultCloseButton
     >
-      <form
-        aria-labelledby={header.headingId}
-        aria-describedby={header.descriptionId}
-        className={`${preferencesStyles.form} ${modalStyles["form-in-dialog"]}`}
-        onSubmit={handleSubmit}
-      >
+      <div className={modalStyles["header-region"]}>
         <SettingsHeader
           headingId={header.headingId}
           descriptionId={header.descriptionId}
@@ -95,23 +90,32 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
             description: preferencesStyles.description,
           }}
         />
-        <SettingsBody className={preferencesStyles.body}>
-          <SettingsNav
-            sections={sections}
-            activeSectionId={activeSectionId}
-            onSelect={handleSectionSelectWithFocus}
-            tablistLabel={copy.tablistLabel}
-            renderCloseAction={renderCloseAction}
-            classes={{
-              container: preferencesStyles["tabs-region"],
-              action: preferencesStyles["close-action"],
-              nav: preferencesStyles.tabs,
-              button: preferencesStyles.tab,
-              label: preferencesStyles["tab-label"],
-              summary: preferencesStyles["tab-summary"],
-              actionButton: preferencesStyles["close-button"],
-            }}
-          />
+      </div>
+      <SettingsBody
+        className={`${preferencesStyles.body} ${modalStyles["body-region"]}`}
+      >
+        <SettingsNav
+          sections={sections}
+          activeSectionId={activeSectionId}
+          onSelect={handleSectionSelectWithFocus}
+          tablistLabel={copy.tablistLabel}
+          renderCloseAction={renderCloseAction}
+          classes={{
+            container: preferencesStyles["tabs-region"],
+            action: preferencesStyles["close-action"],
+            nav: preferencesStyles.tabs,
+            button: preferencesStyles.tab,
+            label: preferencesStyles["tab-label"],
+            summary: preferencesStyles["tab-summary"],
+            actionButton: preferencesStyles["close-button"],
+          }}
+        />
+        <form
+          aria-labelledby={header.headingId}
+          aria-describedby={header.descriptionId}
+          className={modalStyles.form}
+          onSubmit={handleSubmit}
+        >
           <SettingsPanel
             panelId={panel.panelId}
             tabId={panel.tabId}
@@ -127,8 +131,8 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
               />
             ) : null}
           </SettingsPanel>
-        </SettingsBody>
-      </form>
+        </form>
+      </SettingsBody>
     </BaseModal>
   );
 }

--- a/website/src/components/modals/SettingsModal.module.css
+++ b/website/src/components/modals/SettingsModal.module.css
@@ -2,13 +2,55 @@
   --modal-max-width: min(92vw, 960px);
   --modal-max-height: 86vh;
   --modal-radius: 20px;
-  --modal-surface: transparent;
-  --modal-color: var(--settings-dialog-text);
-  --modal-shadow: none;
+  --preferences-panel-bg: var(--night-panel);
+  --preferences-panel-border: rgb(255 255 255 / 12%);
+  --preferences-panel-text: var(--night-text);
+  --preferences-panel-muted: var(--night-muted);
+  --preferences-panel-ring: var(--night-input-ring);
+  --preferences-panel-surface: rgb(255 255 255 / 6%);
+  --preferences-panel-shadow: 0 24px 60px rgb(0 0 0 / 45%);
+  --preferences-panel-accent: linear-gradient(135deg, #5a8bff, #4c6fff);
+  --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 35%);
+  --modal-surface: var(--preferences-panel-bg);
+  --modal-color: var(--preferences-panel-text);
+  --modal-shadow: var(--preferences-panel-shadow);
 
-  display: flex;
-  flex-direction: column;
-  background: transparent;
+  padding: 44px;
+  box-sizing: border-box;
+  border: 1px solid var(--preferences-panel-border);
+  color: var(--preferences-panel-text);
+}
+
+:global(:root[data-theme="light"]) .dialog {
+  --preferences-panel-bg: var(--sidebar-panel, var(--neutral-0));
+  --preferences-panel-border: var(--sidebar-border-color, #d9dde7);
+  --preferences-panel-text: var(--sidebar-text-color, #1f232b);
+  --preferences-panel-muted: var(--sidebar-muted-color, #6f7585);
+  --preferences-panel-ring: var(--sidebar-input-ring, #cfd4e2);
+  --preferences-panel-surface: rgb(15 17 21 / 6%);
+  --preferences-panel-shadow: var(
+    --sidebar-shadow-elevated,
+    0 18px 42px rgb(31 35 43 / 16%)
+  );
+  --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 22%);
+}
+
+:global(:root[data-theme="system"]) .dialog {
+  --preferences-panel-bg: var(--sidebar-panel, var(--night-panel));
+  --preferences-panel-border: var(--sidebar-border-color, var(--night-border));
+  --preferences-panel-text: var(--sidebar-text-color, var(--night-text));
+  --preferences-panel-muted: var(--sidebar-muted-color, var(--night-muted));
+  --preferences-panel-ring: var(--sidebar-input-ring, var(--night-input-ring));
+  --preferences-panel-surface: color-mix(
+    in srgb,
+    var(--sidebar-panel, var(--night-panel)) 92%,
+    transparent
+  );
+  --preferences-panel-shadow: var(
+    --sidebar-shadow-elevated,
+    0 24px 60px rgb(0 0 0 / 45%)
+  );
+  --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 30%);
 }
 
 .close-button {
@@ -51,16 +93,23 @@
   box-shadow: none;
 }
 
-.form-in-dialog {
-  /* 背景：模态内需要复用 Preferences 表单结构，但需撑满弹窗并自持留白。 */
-  width: 100%;
-  max-width: none;
-  align-self: stretch;
-  padding: 44px;
-  border-radius: var(--modal-radius, 20px);
-  box-sizing: border-box;
+.header-region {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 40px;
+}
+
+.body-region {
   flex: 1;
   min-height: 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  min-height: 100%;
 }
 
 @media (width <= 1023px) {


### PR DESCRIPTION
## Summary
- restructure SettingsModal so the SettingsBody container is rendered directly under the modal content and the form only wraps the panel inputs
- migrate modal-specific surface styling and theme tokens into SettingsModal.module.css to match the new DOM hierarchy
- ensure the modal header and body occupy dedicated regions while preserving scrolling behavior inside the settings body

## Testing
- npm run test -- SettingsNavPanel

------
https://chatgpt.com/codex/tasks/task_e_68de9d7dbdb4833295ef43cdf1fc4ad0