### PR TITLE
Align user dock background with sidebar theme

### DIFF
--- a/website/src/components/Sidebar/UserDock.module.css
+++ b/website/src/components/Sidebar/UserDock.module.css
@@ -4,6 +4,7 @@
   flex-direction: column;
   gap: 8px;
   padding: 0;
+  background: var(--sidebar-bg, var(--bg));
   isolation: isolate;
 }
 
@@ -12,4 +13,5 @@
   flex-direction: column;
   gap: 8px;
   padding: 0 var(--user-menu-safe);
+  background: inherit;
 }


### PR DESCRIPTION
## Summary
- apply the sidebar background design token to the user dock wrapper to match the sidebar surface
- let the anonymous variant inherit the wrapper background so anonymous and signed-in states stay consistent

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68dea0fdf0b48332a099933d51499a8e