### PR TITLE
Add spacing before comment blocks in dictionary action panel CSS

### DIFF
--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -21,6 +21,7 @@
     --sidebar-hover-bg,
     color-mix(in srgb, var(--sidebar-panel, var(--sb-surface)) 94%, white 6%)
   );
+
   /*
    * 背景：SearchBox 默认依赖 --padding-y 推导垂直留白，但词典面板需要与 ChatInput 底部壳同步。
    * 取舍：将变量重置为 0，并在组件作用域内直接消费 ChatInput 的 padding-block 令牌，
@@ -79,6 +80,7 @@
   width: 100%;
   align-items: center;
   flex-wrap: nowrap;
+
   /*
    * 背景：词典面板需与 ChatInput 搜索态共用壳层高度，防止 search/actions 切换出现高度闪烁。
    * 取舍：直接复用 ChatInput 的 padding-block 令牌，当主题覆写时可保持两端一致响应。


### PR DESCRIPTION
## Summary
- insert blank lines before comment blocks in DictionaryActionPanel.module.css to satisfy comment-empty-line-before stylelint rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deb06a1b308332afb7674cf539bd26