### PR TITLE
Add vertical divider to settings modal content column

### DIFF
--- a/website/src/components/modals/SettingsBody.module.css
+++ b/website/src/components/modals/SettingsBody.module.css
@@ -56,6 +56,12 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  border-inline-start: var(--settings-body-divider-width, 1px)
+    solid
+    var(
+      --settings-body-divider-color,
+      var(--sb-divider, color-mix(in srgb, var(--border-color, #1f2937) 70%, transparent 30%))
+    );
 }
 
 .content-scroller {
@@ -91,6 +97,10 @@
 
   .nav-scroller > * {
     min-width: max-content;
+  }
+
+  .content-column {
+    border-inline-start: none;
   }
 
   .content-scroller {


### PR DESCRIPTION
## Summary
- introduce a theme-aware vertical divider for the settings content column
- ensure the divider disappears under the single-column mobile breakpoint to preserve layout

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68deb27d382483329d7982993d775ccc