### PR TITLE
Refine chat input focus management

### DIFF
--- a/website/src/components/ui/ChatInput/parts/ActionButton.jsx
+++ b/website/src/components/ui/ChatInput/parts/ActionButton.jsx
@@ -28,6 +28,7 @@ function ActionButton({
   isVoiceDisabled,
   sendLabel,
   voiceLabel,
+  restoreFocus,
 }) {
   const trimmedLength = value.trim().length;
   const isSendState = trimmedLength > 0;
@@ -44,6 +45,7 @@ function ActionButton({
       event.preventDefault();
       if (isSendState) {
         onSubmit?.();
+        restoreFocus?.();
         return;
       }
       if (isVoiceDisabled) {
@@ -55,8 +57,16 @@ function ActionButton({
       }
       voiceCooldownRef.current = now;
       onVoice?.();
+      restoreFocus?.();
     },
-    [isSendState, isVoiceDisabled, onSubmit, onVoice, voiceCooldownRef],
+    [
+      isSendState,
+      isVoiceDisabled,
+      onSubmit,
+      onVoice,
+      voiceCooldownRef,
+      restoreFocus,
+    ],
   );
 
   return (
@@ -86,6 +96,7 @@ ActionButton.propTypes = {
   isVoiceDisabled: PropTypes.bool,
   sendLabel: PropTypes.string.isRequired,
   voiceLabel: PropTypes.string.isRequired,
+  restoreFocus: PropTypes.func,
 };
 
 ActionButton.defaultProps = {
@@ -93,6 +104,7 @@ ActionButton.defaultProps = {
   onVoice: undefined,
   onSubmit: undefined,
   isVoiceDisabled: false,
+  restoreFocus: undefined,
 };
 
 export default ActionButton;

--- a/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
+++ b/website/src/components/ui/ChatInput/parts/ActionInputView.jsx
@@ -124,6 +124,7 @@ ActionInputView.propTypes = {
     isVoiceDisabled: PropTypes.bool.isRequired,
     sendLabel: PropTypes.string.isRequired,
     voiceLabel: PropTypes.string.isRequired,
+    restoreFocus: PropTypes.func.isRequired,
   }).isRequired,
 };
 

--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -94,11 +94,27 @@ export default function DictionaryExperience() {
     activateSearchMode();
   };
 
-  const handleInputFocusChange = (focused) => {
-    handlePanelFocusChange(focused);
-    if (!focused) {
-      activateActionsMode();
+  /**
+   * @param {import("@/components/ui/ChatInput/hooks/useActionInputBehavior").FocusChangeContext} context
+   */
+  const handleInputFocusChange = (context) => {
+    handlePanelFocusChange(context);
+    if (context.isFocused) {
+      return;
     }
+    const { formElement, event } = context;
+    const relatedTarget = event.relatedTarget;
+    const isNodeTarget =
+      typeof Node !== "undefined" && relatedTarget instanceof Node;
+    const isWithinForm = Boolean(
+      formElement &&
+        isNodeTarget &&
+        formElement.contains(relatedTarget),
+    );
+    if (isWithinForm) {
+      return;
+    }
+    activateActionsMode();
   };
 
   const handleMainScroll = () => {


### PR DESCRIPTION
## Summary
- extend chat input behavior to expose focus context and restore-focus callback and have the action button reuse it after submissions or voice triggers
- update dictionary bottom panel state to treat in-form focus transitions as active search mode and consume the richer focus payload
- enhance unit and integration tests to cover focus retention when interacting with chat input actions

## Testing
- npm test -- useActionInputBehavior
- npm test -- useBottomPanelState
- npm test -- DictionaryExperience.focus


------
https://chatgpt.com/codex/tasks/task_e_68deb26912208332a02f1390c241a43d