### PR TITLE
Remove box shadow from preferences sections

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -284,8 +284,11 @@
   gap: var(--space-4);
   padding: var(--space-5);
   border-radius: 18px;
-  box-shadow: 0 1px 0
-    color-mix(in srgb, var(--preferences-panel-border) 55%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface) 94%,
+    transparent
+  );
 }
 
 .section-header {


### PR DESCRIPTION
## Summary
- replace the preferences section box shadow with a subtle surface background token to eliminate the hard outline

## Testing
- prettier -w website/src/pages/preferences/Preferences.module.css
- npx stylelint --fix website/src/pages/preferences/Preferences.module.css

------
https://chatgpt.com/codex/tasks/task_e_68deb68ad6708332a872021f59261bcd