### PR TITLE
feat: realign preference sections for modal parity

### DIFF
--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -26,6 +26,18 @@ const createTranslations = (overrides = {}) => ({
   prefTablistLabel: "Preference sections",
   close: "Close",
   settingsEmptyValue: "—",
+  settingsTabGeneral: "General",
+  settingsGeneralDescription: "General summary",
+  prefDefaultsDescription: "Defaults description",
+  prefInterfaceDescription: "Interface description",
+  settingsTabPersonalization: "Personalization",
+  settingsPersonalizationDescription: "Personalization summary",
+  prefPersonalizationTitle: "Personal context",
+  settingsTabData: "Data controls",
+  settingsDataDescription: "Data summary",
+  settingsDataNotice: "Data notice",
+  settingsTabKeyboard: "Keyboard shortcuts",
+  settingsKeyboardDescription: "Keyboard summary",
   prefAccountTitle: "Account",
   settingsAccountDescription: "Account summary",
   settingsAccountUsername: "Username",
@@ -34,12 +46,7 @@ const createTranslations = (overrides = {}) => ({
   settingsAccountAge: "Age",
   settingsAccountGender: "Gender",
   settingsTabAccount: "Account",
-  prefPrivacyTitle: "Privacy",
-  prefPrivacyDescription: "Privacy summary",
-  prefPrivacyPlaceholder: "Privacy placeholder",
-  prefNotificationsTitle: "Notifications",
-  prefNotificationsDescription: "Notifications summary",
-  prefNotificationsDisabledMessage: "Notifications disabled",
+  prefKeyboardTitle: "Shortcut playbook",
   settingsManageProfile: "Manage profile",
   ...overrides,
 });
@@ -56,83 +63,118 @@ beforeEach(() => {
 });
 
 /**
- * 测试目标：默认分区下聚焦标识与模态备用标题字段保持同步。
+ * 测试目标：默认渲染时分区顺序应为 general→personalization→data→keyboard→account，且默认激活 general。
  * 前置条件：使用默认语言文案与账户信息渲染 Hook。
  * 步骤：
  *  1) 渲染 usePreferenceSections。
- *  2) 读取 panel 结构返回的属性。
+ *  2) 读取 sections 与 panel 结构。
  * 断言：
- *  - focusHeadingId 与 headingId 相同且引用 account 分区标题。
- *  - modalHeadingId 固定为备用标题 ID。
- *  - modalHeadingText 取自账户分区标题文本。
+ *  - sections 顺序符合蓝图。
+ *  - activeSectionId 为 general。
+ *  - focusHeadingId 与 headingId 指向 general 分区。
+ *  - modalHeadingText 等于 General 文案。
  * 边界/异常：
- *  - 若 future 分区缺失标题，应回退到 fallback ID。
+ *  - 若 general 被禁用，应回退到下一个可用分区（由 sanitizeActiveSectionId 覆盖）。
  */
-test("Given default sections When reading panel metadata Then heading semantics stay aligned", () => {
-  const { result } = renderHook(() =>
-    usePreferenceSections({ initialSectionId: undefined, onOpenAccountManager: jest.fn() }),
-  );
+test(
+  "Given default sections When reading blueprint Then general leads navigation",
+  () => {
+    const { result } = renderHook(() =>
+      usePreferenceSections({ initialSectionId: undefined, onOpenAccountManager: jest.fn() }),
+    );
 
-  expect(result.current.panel.headingId).toBe("account-section-heading");
-  expect(result.current.panel.focusHeadingId).toBe("account-section-heading");
-  expect(result.current.panel.modalHeadingId).toBe("settings-modal-fallback-heading");
-  expect(result.current.panel.modalHeadingText).toBe("Account");
-});
+    expect(result.current.sections.map((section) => section.id)).toEqual([
+      "general",
+      "personalization",
+      "data",
+      "keyboard",
+      "account",
+    ]);
+    expect(result.current.activeSectionId).toBe("general");
+    expect(result.current.panel.headingId).toBe("general-section-heading");
+    expect(result.current.panel.focusHeadingId).toBe("general-section-heading");
+    expect(result.current.panel.modalHeadingId).toBe("settings-modal-fallback-heading");
+    expect(result.current.panel.modalHeadingText).toBe("General");
+  },
+);
 
 /**
- * 测试目标：当分区标题文案为空白时，模态备用标题回退至 copy.title。
- * 前置条件：隐私分区标题文案仅包含空格。
+ * 测试目标：当传入历史分区 ID 时，应回退至首个可用分区以维持导航可用性。
+ * 前置条件：initialSectionId 指向已下线的 privacy 分区。
  * 步骤：
- *  1) 使用隐私分区空白标题的语言包渲染 Hook，并指定初始分区为 privacy。
+ *  1) 渲染 usePreferenceSections 并读取激活分区。
+ * 断言：
+ *  - activeSectionId 回退为 general。
+ *  - panel.headingId 对应 general 分区。
+ * 边界/异常：
+ *  - 若 general 被禁用，应回退到下一个可用分区（由 sanitizeActiveSectionId 负责）。
+ */
+test(
+  "Given legacy section id When initializing Then selection falls back to general",
+  () => {
+    const { result } = renderHook(() =>
+      usePreferenceSections({ initialSectionId: "privacy", onOpenAccountManager: jest.fn() }),
+    );
+
+    expect(result.current.activeSectionId).toBe("general");
+    expect(result.current.panel.headingId).toBe("general-section-heading");
+  },
+);
+
+/**
+ * 测试目标：当分区标题文案为空白时，模态备用标题应回退至 copy.title。
+ * 前置条件：快捷键分区标题与摘要均为空白字符串。
+ * 步骤：
+ *  1) 使用覆盖文案的语言包渲染 Hook，并指定初始分区为 keyboard。
  *  2) 读取 panel 对象中的标题字段。
  * 断言：
  *  - modalHeadingText 等于 copy.title。
- *  - focusHeadingId 指向隐私分区 heading。
+ *  - focusHeadingId 指向 keyboard 分区 heading。
  * 边界/异常：
  *  - 若 copy.title 为空，也应保持非空字符串（由 Hook 内默认值保障）。
  */
 test("Given blank section titles When resolving modal heading Then fallback title is used", () => {
   mockUseLanguage.mockReturnValue({
     t: createTranslations({
-      prefPrivacyTitle: "   ",
-      prefPrivacyDescription: "   ",
+      settingsTabKeyboard: "   ",
+      settingsKeyboardDescription: "   ",
     }),
   });
 
   const { result } = renderHook(() =>
-    usePreferenceSections({ initialSectionId: "privacy", onOpenAccountManager: jest.fn() }),
+    usePreferenceSections({ initialSectionId: "keyboard", onOpenAccountManager: jest.fn() }),
   );
 
-  expect(result.current.panel.focusHeadingId).toBe("privacy-section-heading");
+  expect(result.current.panel.focusHeadingId).toBe("keyboard-section-heading");
   expect(result.current.panel.modalHeadingText).toBe(result.current.copy.title);
   expect(result.current.panel.modalHeadingId).toBe("settings-modal-fallback-heading");
 });
 
 /**
  * 测试目标：切换分区后备用标题随激活分区更新。
- * 前置条件：默认激活 account 分区。
+ * 前置条件：默认激活 general 分区。
  * 步骤：
- *  1) 渲染 Hook 并调用 handleSectionSelect 选择 privacy 分区。
+ *  1) 渲染 Hook 并调用 handleSectionSelect 选择 data 分区。
  *  2) 读取 panel 的标题字段。
  * 断言：
- *  - modalHeadingText 更新为 Privacy 文案。
- *  - focusHeadingId 更新为 privacy-section-heading。
+ *  - modalHeadingText 更新为 Data controls 文案。
+ *  - focusHeadingId 更新为 data-section-heading。
  * 边界/异常：
  *  - 若分区被禁用，handleSectionSelect 应忽略状态变更（此处不触发）。
  */
-test("Given section switch When selecting privacy Then heading metadata updates", async () => {
+test("Given section switch When selecting data Then heading metadata updates", async () => {
   const { result } = renderHook(() =>
     usePreferenceSections({ initialSectionId: undefined, onOpenAccountManager: jest.fn() }),
   );
 
   act(() => {
-    result.current.handleSectionSelect({ id: "privacy", disabled: false });
+    result.current.handleSectionSelect({ id: "data", disabled: false });
   });
 
-  expect(result.current.activeSectionId).toBe("privacy");
+  expect(result.current.activeSectionId).toBe("data");
 
   await waitFor(() => {
-    expect(result.current.panel.focusHeadingId).toBe("privacy-section-heading");
-    expect(result.current.panel.modalHeadingText).toBe("Privacy");
+    expect(result.current.panel.focusHeadingId).toBe("data-section-heading");
+    expect(result.current.panel.modalHeadingText).toBe("Data controls");
   });
 });

--- a/website/src/pages/preferences/sections/DataSection.jsx
+++ b/website/src/pages/preferences/sections/DataSection.jsx
@@ -1,0 +1,34 @@
+/**
+ * 背景：
+ *  - 数据治理相关的导出/清除能力尚在落地，短期内需要稳定的入口与文案承诺。
+ * 目的：
+ *  - 以占位实现承载文案与后续行动按钮的语义，避免 Settings 结构因暂缺功能而破碎。
+ * 关键决策与取舍：
+ *  - 继续采用适配器封装 PlaceholderSection，但暴露 notice/cta 文案，为未来集成动作按钮留口。
+ * 影响范围：
+ *  - Preferences 与 SettingsModal 中的 "Data" 分区展示。
+ * 演进与TODO：
+ *  - TODO: 对接导出/清除 API 后在此组件内落地交互与状态反馈。
+ */
+import PropTypes from "prop-types";
+import PlaceholderSection from "./PlaceholderSection.jsx";
+
+function DataSection({ title, message, headingId, descriptionId }) {
+  return (
+    <PlaceholderSection
+      title={title}
+      message={message}
+      headingId={headingId}
+      descriptionId={descriptionId}
+    />
+  );
+}
+
+DataSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  headingId: PropTypes.string.isRequired,
+  descriptionId: PropTypes.string.isRequired,
+};
+
+export default DataSection;

--- a/website/src/pages/preferences/sections/GeneralSection.jsx
+++ b/website/src/pages/preferences/sections/GeneralSection.jsx
@@ -1,0 +1,34 @@
+/**
+ * 背景：
+ *  - 通用分区的真实交互仍在设计中，但 Settings 模态已需要稳定的分区入口。
+ * 目的：
+ *  - 以适配器模式复用 PlaceholderSection，让上层可在未来平滑替换为真正的表单实现。
+ * 关键决策与取舍：
+ *  - 采用轻量包装组件而非直接引用占位，保证语义清晰并为后续扩展保留隔离层。
+ * 影响范围：
+ *  - Preferences 页面与 SettingsModal 中的 "General" 标签内容展示。
+ * 演进与TODO：
+ *  - TODO: 当通用配置成型后，以此组件为挂载点引入真实表单与状态同步。
+ */
+import PropTypes from "prop-types";
+import PlaceholderSection from "./PlaceholderSection.jsx";
+
+function GeneralSection({ title, message, headingId, descriptionId }) {
+  return (
+    <PlaceholderSection
+      title={title}
+      message={message}
+      headingId={headingId}
+      descriptionId={descriptionId}
+    />
+  );
+}
+
+GeneralSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  headingId: PropTypes.string.isRequired,
+  descriptionId: PropTypes.string.isRequired,
+};
+
+export default GeneralSection;

--- a/website/src/pages/preferences/sections/KeyboardSection.jsx
+++ b/website/src/pages/preferences/sections/KeyboardSection.jsx
@@ -1,0 +1,34 @@
+/**
+ * 背景：
+ *  - 快捷键清单仍待与桌面端统一，目前仅能以文案承诺保留入口。
+ * 目的：
+ *  - 通过适配器转发至 PlaceholderSection，确保导航链路完整且未来更换实现零侵入。
+ * 关键决策与取舍：
+ *  - 暂不渲染快捷键表格，避免与真实设计冲突；保留 message 作为能力预告。
+ * 影响范围：
+ *  - Preferences/SettingsModal 的 "Keyboard" 分区。
+ * 演进与TODO：
+ *  - TODO: 与快捷键配置完成后，将此组件替换为 Command 列表与可编辑逻辑。
+ */
+import PropTypes from "prop-types";
+import PlaceholderSection from "./PlaceholderSection.jsx";
+
+function KeyboardSection({ title, message, headingId, descriptionId }) {
+  return (
+    <PlaceholderSection
+      title={title}
+      message={message}
+      headingId={headingId}
+      descriptionId={descriptionId}
+    />
+  );
+}
+
+KeyboardSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  headingId: PropTypes.string.isRequired,
+  descriptionId: PropTypes.string.isRequired,
+};
+
+export default KeyboardSection;

--- a/website/src/pages/preferences/sections/PersonalizationSection.jsx
+++ b/website/src/pages/preferences/sections/PersonalizationSection.jsx
@@ -1,0 +1,34 @@
+/**
+ * 背景：
+ *  - 个性化设定仍需补齐数据建模与持久化策略，但导航结构已提前暴露。
+ * 目的：
+ *  - 通过适配器封装占位组件，确保 Settings 模态与页面在等候真实能力时维持语义化分区。
+ * 关键决策与取舍：
+ *  - 保留与真实组件一致的 props 结构（标题 + 描述），避免后续更换实现时影响调用方。
+ * 影响范围：
+ *  - Preferences/SettingsModal 内的 "Personalization" 分区内容。
+ * 演进与TODO：
+ *  - TODO: 引入用户画像编辑表单后，可在本组件内替换渲染实现并串联数据层。
+ */
+import PropTypes from "prop-types";
+import PlaceholderSection from "./PlaceholderSection.jsx";
+
+function PersonalizationSection({ title, message, headingId, descriptionId }) {
+  return (
+    <PlaceholderSection
+      title={title}
+      message={message}
+      headingId={headingId}
+      descriptionId={descriptionId}
+    />
+  );
+}
+
+PersonalizationSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  headingId: PropTypes.string.isRequired,
+  descriptionId: PropTypes.string.isRequired,
+};
+
+export default PersonalizationSection;

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -14,7 +14,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLanguage, useUser } from "@/context";
 import { useApi } from "@/hooks/useApi.js";
 import AccountSection from "./sections/AccountSection.jsx";
-import PlaceholderSection from "./sections/PlaceholderSection.jsx";
+import DataSection from "./sections/DataSection.jsx";
+import GeneralSection from "./sections/GeneralSection.jsx";
+import KeyboardSection from "./sections/KeyboardSection.jsx";
+import PersonalizationSection from "./sections/PersonalizationSection.jsx";
 
 const EMPTY_PROFILE = Object.freeze({ age: "", gender: "" });
 const FALLBACK_MODAL_HEADING_ID = "settings-modal-fallback-heading";
@@ -162,8 +165,49 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
   const manageLabel = t.settingsManageProfile ?? "Manage profile";
 
   const sections = useMemo(() => {
+    const generalLabel = t.settingsTabGeneral ?? "General";
+    const generalSummary =
+      t.settingsGeneralDescription ??
+      "Tune interface languages, theme, and pronunciation defaults.";
+    const generalMessage = pickFirstMeaningfulString(
+      [t.prefDefaultsDescription, t.prefInterfaceDescription, generalSummary],
+      generalSummary,
+    );
+
+    const personalizationLabel =
+      t.settingsTabPersonalization ?? "Personalization";
+    const personalizationSummary =
+      t.settingsPersonalizationDescription ??
+      "Describe your background so answers feel bespoke.";
+    const personalizationMessage = pickFirstMeaningfulString(
+      [t.settingsPersonalizationDescription, t.prefPersonalizationTitle],
+      personalizationSummary,
+    );
+
+    const dataLabel = t.settingsTabData ?? "Data controls";
+    const dataSummary =
+      t.settingsDataDescription ??
+      "Manage how Glancy stores and purges your historical traces.";
+    const dataMessage = pickFirstMeaningfulString(
+      [t.settingsDataNotice, t.settingsDataDescription],
+      dataSummary,
+    );
+
+    const keyboardLabel =
+      t.settingsTabKeyboard ?? "Keyboard shortcuts";
+    const keyboardSummary =
+      t.settingsKeyboardDescription ??
+      "Master Glancy with a curated set of command keys.";
+    const keyboardMessage = pickFirstMeaningfulString(
+      [t.settingsKeyboardDescription, t.prefKeyboardTitle],
+      keyboardSummary,
+    );
+
     const accountLabel = t.prefAccountTitle ?? t.settingsTabAccount ?? "Account";
-    const accountDescription = t.settingsAccountDescription ?? "";
+    const accountDescription = pickFirstMeaningfulString(
+      [t.settingsAccountDescription],
+      "Review and safeguard the basics that identify you in Glancy.",
+    );
     const accountFields = [
       {
         id: "username",
@@ -194,11 +238,53 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
 
     return [
       {
+        id: "general",
+        label: generalLabel,
+        summary: generalSummary,
+        disabled: false,
+        Component: GeneralSection,
+        componentProps: {
+          title: generalLabel,
+          message: generalMessage,
+        },
+      },
+      {
+        id: "personalization",
+        label: personalizationLabel,
+        summary: personalizationSummary,
+        disabled: false,
+        Component: PersonalizationSection,
+        componentProps: {
+          title: personalizationLabel,
+          message: personalizationMessage,
+        },
+      },
+      {
+        id: "data",
+        label: dataLabel,
+        summary: dataSummary,
+        disabled: false,
+        Component: DataSection,
+        componentProps: {
+          title: dataLabel,
+          message: dataMessage,
+        },
+      },
+      {
+        id: "keyboard",
+        label: keyboardLabel,
+        summary: keyboardSummary,
+        disabled: false,
+        Component: KeyboardSection,
+        componentProps: {
+          title: keyboardLabel,
+          message: keyboardMessage,
+        },
+      },
+      {
         id: "account",
         label: accountLabel,
-        summary:
-          accountDescription ||
-          "Details that travel with your workspace.",
+        summary: accountDescription,
         disabled: false,
         Component: AccountSection,
         componentProps: {
@@ -210,36 +296,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
           onOpenAccountManager,
         },
       },
-      {
-        id: "privacy",
-        label: t.prefPrivacyTitle ?? "Privacy",
-        summary:
-          t.prefPrivacyDescription ??
-          "Control how your presence and data are shared across Glancy.",
-        disabled: false,
-        Component: PlaceholderSection,
-        componentProps: {
-          title: t.prefPrivacyTitle ?? "Privacy",
-          message:
-            t.prefPrivacyPlaceholder ??
-            "Privacy controls are being handcrafted and will arrive soon.",
-        },
-      },
-      {
-        id: "notifications",
-        label: t.prefNotificationsTitle ?? "Notifications",
-        summary:
-          t.prefNotificationsDescription ??
-          "Tune alerts to match your creative rhythm.",
-        disabled: true,
-        Component: PlaceholderSection,
-        componentProps: {
-          title: t.prefNotificationsTitle ?? "Notifications",
-          message:
-            t.prefNotificationsDisabledMessage ??
-            "Notification preferences are managed in the mobile app for now.",
-        },
-      },
     ];
   }, [
     canManageProfile,
@@ -249,19 +305,26 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
     profileMeta.age,
     profileMeta.gender,
     t.prefAccountTitle,
-    t.prefNotificationsDescription,
-    t.prefNotificationsDisabledMessage,
-    t.prefNotificationsTitle,
-    t.prefPrivacyDescription,
-    t.prefPrivacyPlaceholder,
-    t.prefPrivacyTitle,
+    t.prefDefaultsDescription,
+    t.prefInterfaceDescription,
+    t.prefKeyboardTitle,
+    t.prefPersonalizationTitle,
     t.settingsAccountAge,
     t.settingsAccountDescription,
     t.settingsAccountEmail,
     t.settingsAccountGender,
     t.settingsAccountPhone,
     t.settingsAccountUsername,
+    t.settingsDataDescription,
+    t.settingsDataNotice,
+    t.settingsGeneralDescription,
+    t.settingsKeyboardDescription,
+    t.settingsPersonalizationDescription,
     t.settingsTabAccount,
+    t.settingsTabData,
+    t.settingsTabGeneral,
+    t.settingsTabKeyboard,
+    t.settingsTabPersonalization,
     user?.email,
     user?.phone,
     user?.username,


### PR DESCRIPTION
## Summary
- add dedicated General, Personalization, Data, and Keyboard section adapters so settings modal and page share the same blueprint
- restructure usePreferenceSections to surface the new ordering and translation-backed summaries while keeping account data intact
- refresh usePreferenceSections tests to cover ordering, legacy id fallback, and panel metadata updates

## Testing
- npm test -- --runTestsByPath src/pages/preferences/__tests__/usePreferenceSections.test.js

------
https://chatgpt.com/codex/tasks/task_e_68deb78ae0f0833295f5f52c6725b981