### PR TITLE
refactor: streamline preference navigation labels

### DIFF
--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -125,7 +125,6 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
             nav: preferencesStyles.tabs,
             button: preferencesStyles.tab,
             label: preferencesStyles["tab-label"],
-            summary: preferencesStyles["tab-summary"],
             actionButton: preferencesStyles["close-button"],
           }}
         />

--- a/website/src/components/modals/SettingsNav.jsx
+++ b/website/src/components/modals/SettingsNav.jsx
@@ -26,7 +26,6 @@ function SettingsNav({
   const navClassName = classes?.nav ?? "";
   const buttonClassName = classes?.button ?? "";
   const labelClassName = classes?.label ?? "";
-  const summaryClassName = classes?.summary ?? "";
   const actionButtonClassName = classes?.actionButton ?? "";
 
   const closeActionNode = useMemo(() => {
@@ -71,10 +70,11 @@ function SettingsNav({
                 }
               }}
             >
+              {/*
+               * 偏好设置导航仅展示主标签文本，避免双列信息导致键盘导航朗读冗余。
+               * 如需补充副标题，应改由 tab 内容区域呈现而非按钮内部。
+               */}
               <span className={labelClassName}>{section.label}</span>
-              {section.summary ? (
-                <span className={summaryClassName}>{section.summary}</span>
-              ) : null}
             </button>
           );
         })}
@@ -88,7 +88,6 @@ SettingsNav.propTypes = {
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
-      summary: PropTypes.string,
       disabled: PropTypes.bool,
     }).isRequired,
   ).isRequired,
@@ -102,7 +101,6 @@ SettingsNav.propTypes = {
     nav: PropTypes.string,
     button: PropTypes.string,
     label: PropTypes.string,
-    summary: PropTypes.string,
     actionButton: PropTypes.string,
   }),
 };

--- a/website/src/components/modals/__tests__/SettingsNavPanel.test.jsx
+++ b/website/src/components/modals/__tests__/SettingsNavPanel.test.jsx
@@ -31,8 +31,8 @@ function TestSection({ headingId, title, actionLabel }) {
 function TestSettingsHarness({ withCloseAction = false }) {
   const sections = useMemo(
     () => [
-      { id: "account", label: "Account", summary: "Account summary" },
-      { id: "privacy", label: "Privacy", summary: "Privacy summary" },
+      { id: "account", label: "Account" },
+      { id: "privacy", label: "Privacy" },
     ],
     [],
   );
@@ -92,6 +92,26 @@ function TestSettingsHarness({ withCloseAction = false }) {
     </div>
   );
 }
+
+/**
+ * 测试目标：标签可访问名称仅包含主标签文本，不暴露冗余摘要。
+ * 前置条件：渲染 TestSettingsHarness 并聚焦 account 标签。
+ * 步骤：
+ *  1) 查询 account 标签元素。
+ *  2) 检查文案与摘要是否存在。
+ * 断言：
+ *  - 标签可访问名称为 Account。
+ *  - DOM 内不存在 Account summary 文本节点。
+ * 边界/异常：
+ *  - 若未来重新引入摘要，应更新设计并同步调整断言。
+ */
+test("Given navigation sections When rendering Then only primary label is exposed", () => {
+  render(<TestSettingsHarness />);
+
+  const accountTab = screen.getByRole("tab", { name: "Account" });
+  expect(accountTab).toHaveAccessibleName("Account");
+  expect(screen.queryByText("Account summary")).not.toBeInTheDocument();
+});
 
 /**
  * 测试目标：切换分区后标题获得焦点并滚动至首部。

--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -90,6 +90,11 @@ test(
       "keyboard",
       "account",
     ]);
+    expect(
+      result.current.sections.every(
+        (section) => !Object.prototype.hasOwnProperty.call(section, "summary"),
+      ),
+    ).toBe(true);
     expect(result.current.activeSectionId).toBe("general");
     expect(result.current.panel.headingId).toBe("general-section-heading");
     expect(result.current.panel.focusHeadingId).toBe("general-section-heading");

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -87,7 +87,6 @@ function Preferences({
               nav: styles.tabs,
               button: styles.tab,
               label: styles["tab-label"],
-              summary: styles["tab-summary"],
               actionButton: styles["close-button"],
             }}
           />

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -236,11 +236,12 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
       },
     ];
 
+    //
+    // 导航标签仅展示主标题，摘要内容由具体面板负责渲染，避免屏幕阅读器重复朗读。
     return [
       {
         id: "general",
         label: generalLabel,
-        summary: generalSummary,
         disabled: false,
         Component: GeneralSection,
         componentProps: {
@@ -251,7 +252,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
       {
         id: "personalization",
         label: personalizationLabel,
-        summary: personalizationSummary,
         disabled: false,
         Component: PersonalizationSection,
         componentProps: {
@@ -262,7 +262,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
       {
         id: "data",
         label: dataLabel,
-        summary: dataSummary,
         disabled: false,
         Component: DataSection,
         componentProps: {
@@ -273,7 +272,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
       {
         id: "keyboard",
         label: keyboardLabel,
-        summary: keyboardSummary,
         disabled: false,
         Component: KeyboardSection,
         componentProps: {
@@ -284,7 +282,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
       {
         id: "account",
         label: accountLabel,
-        summary: accountDescription,
         disabled: false,
         Component: AccountSection,
         componentProps: {


### PR DESCRIPTION
## Summary
- stop rendering navigation summaries in SettingsNav and drop unused class wiring
- remove summary payloads from usePreferenceSections while documenting the single-label decision
- extend SettingsNavPanel and hook tests to guard the simplified accessibility surface

## Testing
- npm test -- SettingsNavPanel
- npm test -- usePreferenceSections

------
https://chatgpt.com/codex/tasks/task_e_68deb92be31c8332809cb3f9f09085b2