### PR TITLE
Align docker bottom panels to shared width

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -255,6 +255,13 @@
 
 .docker-inner {
   width: min(100%, var(--sb-max-width));
+  /*
+   * 背景：底部 docker 承载的搜索与释义区域需保持统一宽度比例，
+   *       避免在不同内容节点中重复硬编码宽度值。
+   * 取舍：通过暴露 --docker-row-width 变量，让子组件按需读取，
+   *       默认设置为父容器宽度的 90%，既满足本次需求又为未来调优保留入口。
+   */
+  --docker-row-width: 90%;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -1,5 +1,9 @@
 .container {
-  width: 100%;
+  /*
+   * 背景：需要与释义面板共享宽度比例，确保 docker 栏内组件节奏统一。
+   * 取舍：优先读取 Layout 提供的 --docker-row-width，脱离 docker 时回退为 100%。
+   */
+  width: var(--docker-row-width, 100%);
   display: flex;
   justify-content: center;
   max-width: var(--sb-max-width);

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -1,9 +1,10 @@
 .panel-shell {
   /*
    * 目的：复用 ChatInput 布局壳的宽度策略，确保词典面板在不同容器内保持一致居中表现。
-   * 关键取舍：直接引入布局类而非在父级分散样式，避免将 SearchBox 暴露给外层布局细节。
+   * 关键取舍：通过读取 Layout 注入的 --docker-row-width 变量集中控制宽度，
+   *           避免在父级分散样式并保持 SearchBox 的壳层解耦。
    */
-  width: 100%;
+  width: var(--docker-row-width, 100%);
   display: flex;
   justify-content: center;
   max-width: var(--sb-max-width);


### PR DESCRIPTION
## Summary
- expose a docker row width custom property from Layout so bottom content uses a consistent ratio
- update ChatInput and dictionary action panel shells to read the shared width variable with sensible fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec09a88a4833286902e5ba6dd283b