### PR TITLE
refactor: unify chat input action icon rendering

### DIFF
--- a/website/src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
+++ b/website/src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
@@ -4,16 +4,15 @@ import { jest } from "@jest/globals";
 
 /**
  * 背景：
- *  - VoiceIcon 需根据主题动态切换遮罩资源，过去使用模块级常量导致主题切换后样式无法更新。
+ *  - VoiceIcon 通过 createMaskedIconRenderer 共享遮罩模板，需要验证策略函数在不同主题与降级场景下仍然生效。
  * 目的：
- *  - 通过对 useTheme 与图标注册表的桩件，验证在不同主题下能解析正确的遮罩，并在缺失资源时触发降级渲染。
+ *  - 通过桩件控制主题、遮罩能力与图标注册表，确保新模板对语音图标的渲染路径完整覆盖。
  * 关键决策与取舍：
- *  - 采用策略模式：通过 mockUseTheme 控制 resolvedTheme 以驱动遮罩选择，同时模拟图标注册表确保不依赖真实资源路径。
- *  - 舍弃直接引用真实 SVG，避免 Jest 文件桩导致的同值干扰，确保断言具备区分度。
+ *  - 延续策略模式测试：mock useTheme、useMaskSupport 与 icon registry，聚焦资源解析与降级行为；避免依赖真实资源文件导致测试脆弱。
  * 影响范围：
- *  - 覆盖 VoiceIcon 主题分支与兜底逻辑，间接保障 ChatInput 动作按钮图标渲染稳定。
+ *  - 覆盖 VoiceIcon 的主题分支、遮罩降级与 fallback 调用逻辑，间接验证 createMaskedIconRenderer 的稳定性。
  * 演进与TODO：
- *  - 后续若新增高对比主题，应扩充此处的注册表桩件与断言以覆盖新增变体。
+ *  - 若未来引入录音态动画，应扩展测试验证 buildStyle 返回的额外样式字段。
  */
 
 let currentResolvedTheme = "light";
@@ -22,7 +21,7 @@ const mockUseTheme = jest.fn(() => ({
 }));
 const mockUseMaskSupport = jest.fn(() => true);
 
-jest.unstable_mockModule("@/context/ThemeContext", () => ({
+jest.unstable_mockModule("@/context", () => ({
   useTheme: mockUseTheme,
 }));
 
@@ -158,4 +157,3 @@ describe("VoiceIcon", () => {
     expect(container.querySelector("svg")).not.toBeNull();
   });
 });
-

--- a/website/src/components/ui/ChatInput/icons/createMaskedIconRenderer.jsx
+++ b/website/src/components/ui/ChatInput/icons/createMaskedIconRenderer.jsx
@@ -1,0 +1,125 @@
+/**
+ * 背景：
+ *  - ChatInput 的图标体系逐渐扩展，SendIcon 与 VoiceIcon 等组件都需要重复处理遮罩能力探测、主题资源解析与降级渲染，易出现实现漂移。
+ * 目的：
+ *  - 提供可配置的模板方法骨架，将“探测 → 解析 → 构造样式 → 回退”流程抽离到统一工厂，通过策略函数注入差异化逻辑。
+ * 关键决策与取舍：
+ *  - 选用模板方法（Template Method）结合策略函数：模板负责控制流程顺序，resolve/build 回调负责扩展，既保持一致性又便于未来新增图标策略。
+ *  - 暂不引入类继承，保持函数式工厂，符合 React 函数组件范式并降低测试开销。
+ * 影响范围：
+ *  - ChatInput/icons 目录下所有基于遮罩的按钮图标组件；后续如需新增图标只需注入策略即可重用流程。
+ * 演进与TODO：
+ *  - 若未来有非遮罩类按钮，可扩展参数以允许跳过遮罩探测或注入更多上下文（如尺寸、动画类名）。
+ */
+import { useMemo } from "react";
+import PropTypes from "prop-types";
+
+import ICONS from "@/assets/icons.js";
+import { useTheme } from "@/context";
+import useMaskSupport from "./useMaskSupport.js";
+
+const hasMaskDeclaration = (styleObject) =>
+  Boolean(
+    styleObject?.mask ||
+      styleObject?.WebkitMask ||
+      styleObject?.maskImage ||
+      styleObject?.WebkitMaskImage,
+  );
+
+/**
+ * 意图：根据传入的策略创建带遮罩能力的图标组件。
+ * 输入：
+ *  - token：注册表中的图标标识。
+ *  - resolveResource：策略函数，负责基于主题等上下文解析资源。
+ *  - buildStyle：策略函数，接收解析到的资源并生成行内样式。
+ *  - defaultFallback：当遮罩不可用或解析失败时使用的降级渲染函数。
+ * 输出：
+ *  - React 组件，接受 className 与 fallback，可直接用于按钮图标渲染。
+ * 流程：
+ *  1) 通过 useMaskSupport 判定能力。
+ *  2) 使用 resolveResource 按策略获取资源。
+ *  3) 交给 buildStyle 生成遮罩样式。
+ *  4) 若任一步骤失败则回退到 fallback。
+ * 错误处理：
+ *  - resolveResource / buildStyle 内部由调用方负责兜底，组件仅在返回 null 或缺失遮罩声明时触发 fallback。
+ * 复杂度：
+ *  - 常数级，所有重计算均通过 useMemo 缓存在依赖变更时触发。
+ */
+export function createMaskedIconRenderer({
+  token,
+  resolveResource,
+  buildStyle,
+  defaultFallback,
+}) {
+  if (!token) {
+    throw new Error("createMaskedIconRenderer: token is required");
+  }
+  if (typeof resolveResource !== "function") {
+    throw new Error(
+      "createMaskedIconRenderer: resolveResource must be a function",
+    );
+  }
+  if (typeof buildStyle !== "function") {
+    throw new Error("createMaskedIconRenderer: buildStyle must be a function");
+  }
+  if (typeof defaultFallback !== "function") {
+    throw new Error(
+      "createMaskedIconRenderer: defaultFallback must be a function",
+    );
+  }
+
+  const MaskedIcon = ({ className, fallback }) => {
+    const themeContext = useTheme?.() ?? {};
+    const resolvedTheme = themeContext?.resolvedTheme ?? "light";
+    const isMaskSupported = useMaskSupport();
+    const effectiveFallback = fallback ?? defaultFallback;
+
+    const maskResource = useMemo(() => {
+      if (!isMaskSupported) {
+        return null;
+      }
+
+      return resolveResource({
+        registry: ICONS,
+        resolvedTheme,
+      });
+    }, [isMaskSupported, resolvedTheme]);
+
+    const inlineStyle = useMemo(() => {
+      if (!maskResource) {
+        return null;
+      }
+
+      return buildStyle({
+        resource: maskResource,
+        resolvedTheme,
+      });
+    }, [maskResource, resolvedTheme]);
+
+    if (!hasMaskDeclaration(inlineStyle)) {
+      return effectiveFallback({ className, iconName: token });
+    }
+
+    return (
+      <span
+        aria-hidden="true"
+        className={className}
+        data-icon-name={token}
+        style={inlineStyle}
+      />
+    );
+  };
+
+  MaskedIcon.propTypes = {
+    className: PropTypes.string.isRequired,
+    fallback: PropTypes.func,
+  };
+
+  MaskedIcon.defaultProps = {
+    fallback: undefined,
+  };
+
+  return MaskedIcon;
+}
+
+export default createMaskedIconRenderer;


### PR DESCRIPTION
## Summary
- add a createMaskedIconRenderer template to centralize mask detection, resource selection, and fallbacks for chat action icons
- refactor SendIcon and VoiceIcon to use the shared renderer while keeping explicit prop contracts and default SVG fallbacks
- extend icon unit tests with theme/fallback scenarios and add dedicated coverage for the SendIcon strategies

## Testing
- npm test -- --runTestsByPath src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68debf96ea488332ad0f05bdc8f5f15a