### PR TITLE
fix: satisfy stylelint formatting in layout module

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -255,12 +255,14 @@
 
 .docker-inner {
   width: min(100%, var(--sb-max-width));
+
   /*
    * 背景：底部 docker 承载的搜索与释义区域需保持统一宽度比例，
    *       避免在不同内容节点中重复硬编码宽度值。
    * 取舍：通过暴露 --docker-row-width 变量，让子组件按需读取，
    *       默认设置为父容器宽度的 90%，既满足本次需求又为未来调优保留入口。
    */
+
   --docker-row-width: 90%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- insert required empty lines around the docker layout comment to comply with the stylelint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dec3208a2c8332a9caca79c6a2c0b4