### PR TITLE
fix: normalize preferences tabs padding shorthand

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -154,8 +154,7 @@
   width: 100%;
   flex: 1;
   min-height: 0;
-  padding: calc(var(--space-2) + var(--space-1))
-    calc(var(--space-2) + var(--space-1)) calc(var(--space-2) + var(--space-1));
+  padding: calc(var(--space-2) + var(--space-1));
 }
 
 .tab {


### PR DESCRIPTION
## Summary
- collapse the preferences tabs padding declaration to a single value to satisfy stylelint's redundant shorthand rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ded4514a748332ad7ff0337c1bbb55