### PR TITLE
Remove background and border from preferences close button

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -106,13 +106,8 @@
   inline-size: var(--btn-action, 44px);
   block-size: var(--btn-action, 44px);
   border-radius: 999px;
-  border: 1px solid
-    color-mix(in srgb, var(--preferences-panel-border) 68%, transparent);
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 94%,
-    transparent
-  );
+  border: none;
+  background: transparent;
   color: var(--preferences-panel-text);
   cursor: pointer;
   transition:
@@ -122,11 +117,6 @@
 }
 
 .close-button:hover {
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 98%,
-    transparent
-  );
   transform: translateY(-1px);
 }
 
@@ -140,11 +130,6 @@
 .close-button:active {
   transform: translateY(0);
   box-shadow: none;
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 88%,
-    transparent
-  );
 }
 
 .tabs {


### PR DESCRIPTION
## Summary
- set the preferences panel close button to use a transparent surface and no border so it blends with the modal chrome
- retain motion, focus, and active affordances without reintroducing the background fill

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68ded6d78ac48332badd06bd356df8da