### PR TITLE
Align dictionary toolbar shell with SearchBox layout

### DIFF
--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.jsx
@@ -57,15 +57,27 @@ export default function DictionaryActionPanel({
   );
   const toolbarRootRenderer = useCallback(
     /**
-     * 意图：在 SearchBox 内内联 OutputToolbar 的子节点，
-     *       保持单一容器并复用上层的语义结构。
-     * 输入：来自 OutputToolbar 的根节点描述（仅取 children）。
-     * 输出：透传的子节点。
-     * 流程：直接返回 children，交由 SearchBox 负责排版。
-     * 错误处理：renderRoot 语义纯粹，无异常路径。
+     * 意图：在 SearchBox 的动作槽内托管 OutputToolbar，并补充统一的壳层样式以延续搜索态的伸展规则。
+     * 输入：来自 OutputToolbar 的根节点描述（className/role/aria/dataTestId/children 等属性）。
+     * 输出：包含 toolbar-shell 样式的包裹节点，保留原始语义属性并透传剩余字段。
+     * 流程：
+     *  1) 将 styles["toolbar-shell"] 与上游 className 合并；
+     *  2) 在包裹节点上恢复 role/aria/data-testid；
+     *  3) 透传其余属性，确保未来扩展（如 data-*）不被截断。
+     * 错误处理：renderRoot 的输入为纯粹对象，无副作用路径。
      * 复杂度：O(1)。
      */
-    ({ children }) => children,
+    ({ className, role, ariaLabel, dataTestId, children, ...restRootProps }) => (
+      <div
+        className={[styles["toolbar-shell"], className].filter(Boolean).join(" ")}
+        role={role}
+        aria-label={ariaLabel}
+        data-testid={dataTestId}
+        {...restRootProps}
+      >
+        {children}
+      </div>
+    ),
     [],
   );
   const resolvedRenderRoot = renderRoot ?? toolbarRootRenderer;

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -90,6 +90,24 @@
   box-shadow: var(--sb-shadow), var(--dictionary-panel-elevation-shadow);
 }
 
+.toolbar-shell {
+  /*
+   * 背景：OutputToolbar 默认提供独立容器，但在词典面板内需要继承 SearchBox 的伸展策略以与搜索态一致。
+   * 取舍：通过专属壳层合并 flex 规则，避免直接覆写 OutputToolbar 样式；同时清空背景与阴影以复用父级视觉。 
+   */
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  gap: var(--dictionary-panel-slot-gap, var(--sb-gap, 16px));
+  justify-content: space-between;
+  min-width: 0;
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: 0;
+  box-shadow: none;
+}
+
 .search-toggle {
   --toolbar-button-size: var(--dictionary-panel-action-size);
   --tool-button-opacity-base: 0.7;

--- a/website/src/features/dictionary-experience/components/__tests__/DictionaryActionPanel.test.jsx
+++ b/website/src/features/dictionary-experience/components/__tests__/DictionaryActionPanel.test.jsx
@@ -18,6 +18,11 @@ jest.unstable_mockModule("@/components/DictionaryEntryActionBar", () => ({
   __esModule: true,
   default: ({ renderRoot }) =>
     renderRoot({
+      className: "stubbed-toolbar",
+      role: "toolbar",
+      ariaLabel: "词条工具栏",
+      dataTestId: "output-toolbar",
+      "data-track-id": "dictionary-toolbar",
       children: <div data-testid="dictionary-entry-action-bar" />,
     }),
 }));
@@ -101,7 +106,7 @@ describe("DictionaryActionPanel", () => {
     );
 
     const searchBox = screen.getByTestId("dictionary-action-panel");
-    expect(searchBox.parentElement).toHaveClass(styles.panelShell);
+    expect(searchBox.parentElement).toHaveClass(styles["panel-shell"]);
 
     rerender(
       <DictionaryActionPanel
@@ -117,6 +122,41 @@ describe("DictionaryActionPanel", () => {
     const searchBoxAfterRerender = screen.getByTestId(
       "dictionary-action-panel",
     );
-    expect(searchBoxAfterRerender.parentElement).toHaveClass(styles.panelShell);
+    expect(searchBoxAfterRerender.parentElement).toHaveClass(
+      styles["panel-shell"],
+    );
+  });
+
+  /**
+   * 测试目标：验证自定义 toolbarRootRenderer 会为 OutputToolbar 根节点追加壳层样式并保留语义属性。
+   * 前置条件：DictionaryEntryActionBar 桩件提供 className/role/aria/data-testid 与额外 data-track-id 属性。
+   * 步骤：
+   *  1) 渲染 DictionaryActionPanel；
+   *  2) 获取 data-testid 为 output-toolbar 的节点；
+   *  3) 检查类名、语义属性与透传属性。
+   * 断言：
+   *  - 节点包含 styles["toolbar-shell"] 类；
+   *  - 仍然携带 stubbed-toolbar 类；
+   *  - role 与 aria-label 被保留；
+   *  - data-track-id 属性透传成功。
+   * 边界/异常：
+   *  - 未覆盖 renderRoot 返回 null 的路径，保持与生产一致的正向行为验证。
+   */
+  test("injects toolbar shell wrapper without losing toolbar semantics", () => {
+    render(
+      <DictionaryActionPanel
+        actionBarProps={{ className: "" }}
+        onRequestSearch={jest.fn()}
+        searchButtonLabel="返回搜索"
+      />,
+    );
+
+    const toolbarRoot = screen.getByTestId("output-toolbar");
+
+    expect(toolbarRoot).toHaveClass(styles["toolbar-shell"]);
+    expect(toolbarRoot).toHaveClass("stubbed-toolbar");
+    expect(toolbarRoot).toHaveAttribute("role", "toolbar");
+    expect(toolbarRoot).toHaveAttribute("aria-label", "词条工具栏");
+    expect(toolbarRoot).toHaveAttribute("data-track-id", "dictionary-toolbar");
   });
 });


### PR DESCRIPTION
## Summary
- wrap the dictionary action toolbar in a flex shell that preserves the output toolbar semantics
- add styling tokens for the toolbar shell to match the search layout cadence
- expand unit coverage to assert the new wrapper class and attribute forwarding

## Testing
- npm run lint
- npm run test -- DictionaryActionPanel

------
https://chatgpt.com/codex/tasks/task_e_68deda0be95c83328c41993260013c63