### PR TITLE
Adjust SettingsModal close action styling contract

### DIFF
--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -82,9 +82,19 @@ function SettingsModal({ open, onClose, initialSection, onOpenAccountManager }) 
   const renderCloseAction = useMemo(
     () =>
       ({ className = "" } = {}) => {
-        const composedClassName = [modalStyles["close-button"], className]
-          .filter(Boolean)
-          .join(" ");
+        /**
+         * 背景：
+         *  - 偏好设置导航需要在模态中复用关闭按钮但移除描边与底色，
+         *    若继续强制追加模态局部样式会导致设计冲突。
+         * 取舍：
+         *  - 当调用方传入 className 时仅保留该类名，让调用方完全掌控视觉；
+         *    否则回落到模态默认样式，避免破坏其他场景的按钮体验。
+         */
+        const trimmedClassName = className.trim();
+        const composedClassName =
+          trimmedClassName.length > 0
+            ? trimmedClassName
+            : modalStyles["close-button"];
         return (
           <button
             type="button"


### PR DESCRIPTION
## Summary
- let SettingsModal respect caller-provided close button class names without forcing the modal defaults
- document the styling contract so navigation-close buttons can drop background and borders while other contexts retain fallbacks

## Testing
- npm test -- --runTestsByPath src/__tests__/Preferences.test.jsx *(fails: Jest expectations for seeded profile data do not pass in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deda73bd808332b351ede1da44a2b0