### PR TITLE
refactor: simplify preferences tabs padding

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -154,8 +154,7 @@
   width: 100%;
   flex: 1;
   min-height: 0;
-  padding: calc(var(--space-2) + var(--space-1))
-    calc(var(--space-2) + var(--space-1)) calc(var(--space-2) + var(--space-1));
+  padding: calc(var(--space-2) + var(--space-1));
 }
 
 .tab {


### PR DESCRIPTION
## Summary
- simplify the tabs container padding declaration in the preferences page CSS module to rely on the existing spacing token

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e137f6b5048332a1a17bf2097f5b5f