### PR TITLE
Fix sidebar history history truncation

### DIFF
--- a/website/src/components/Sidebar/HistoryListView.jsx
+++ b/website/src/components/Sidebar/HistoryListView.jsx
@@ -35,6 +35,11 @@ function HistoryListView({ items, onSelect, onNavigate }) {
                 }
               }}
               className={styles.entryButton}
+              /*
+               * 背景：搜索记录需要完整呈现用户输入，避免记忆成本。
+               * 取舍：启用 NavItem 的多行模式，让排版与数据长度解耦，不影响其他入口。
+               */
+              allowMultilineLabel
               ref={navigationBindings.ref}
               onKeyDown={navigationBindings.onKeyDown}
             />

--- a/website/src/components/Sidebar/NavItem.jsx
+++ b/website/src/components/Sidebar/NavItem.jsx
@@ -44,6 +44,7 @@ const NavItem = forwardRef(function NavItem(
     type = "button",
     children = null,
     variant = "accent",
+    allowMultilineLabel = false,
     ...rest
   },
   ref,
@@ -52,11 +53,23 @@ const NavItem = forwardRef(function NavItem(
     INTERACTION_VARIANTS[variant] || INTERACTION_VARIANTS.accent;
   const baseVariantClass = variantStyles.baseClass;
   const activeVariantClass = variantStyles.activeClass;
+  // 通过可选的多行模式将视觉策略与业务容器解耦，避免在组件内部引入长度判断逻辑。
+  const multilineItemClass = allowMultilineLabel
+    ? styles["item-multiline"]
+    : "";
+  const labelClassName = useMemo(
+    () =>
+      joinClassNames(
+        styles.label,
+        allowMultilineLabel ? styles["label-multiline"] : "",
+      ),
+    [allowMultilineLabel],
+  );
 
   const content = (
     <>
       {renderIcon(icon, typeof label === "string" ? label : undefined)}
-      <span className={styles.label}>
+      <span className={labelClassName}>
         {label}
         {description ? (
           <span className={styles.description}>{description}</span>
@@ -71,12 +84,20 @@ const NavItem = forwardRef(function NavItem(
     () =>
       joinClassNames(
         styles.item,
+        multilineItemClass,
         toneClassName,
         baseVariantClass,
         active ? activeVariantClass : "",
         className,
       ),
-    [active, baseVariantClass, activeVariantClass, className, toneClassName],
+    [
+      active,
+      baseVariantClass,
+      activeVariantClass,
+      className,
+      multilineItemClass,
+      toneClassName,
+    ],
   );
 
   if (to) {
@@ -87,6 +108,7 @@ const NavItem = forwardRef(function NavItem(
         className={({ isActive }) =>
           joinClassNames(
             styles.item,
+            multilineItemClass,
             toneClassName,
             baseVariantClass,
             isActive || active ? activeVariantClass : "",
@@ -144,6 +166,7 @@ NavItem.propTypes = {
   children: PropTypes.node,
   tone: PropTypes.oneOf(["default", "muted"]),
   variant: PropTypes.oneOf(Object.keys(INTERACTION_VARIANTS)),
+  allowMultilineLabel: PropTypes.bool,
 };
 
 export default NavItem;

--- a/website/src/components/Sidebar/NavItem.module.css
+++ b/website/src/components/Sidebar/NavItem.module.css
@@ -4,7 +4,9 @@
   align-items: center;
   justify-content: flex-start;
   gap: var(--sidebar-item-gap, 12px);
-  height: var(--sidebar-item-h);
+
+  /* 保持默认高度基准，同时允许多行模式扩展 */
+  min-height: var(--sidebar-item-h);
   padding: 0 var(--sidebar-pad-x);
   padding-left: calc(var(--sidebar-pad-x) + 3px);
   border: 0;
@@ -88,6 +90,27 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/*
+ * 背景：
+ *  - 搜索历史存在长度不定的词条，单行截断会导致信息缺失，影响复查与复用体验。
+ * 目的：
+ *  - 在保持默认单行样式的同时提供显式的多行模式，必要时允许内容扩展且不侵扰其他入口。
+ * 关键决策与取舍：
+ *  - 通过额外类控制高度与换行，避免在组件中直接写条件样式，便于未来扩展更多布局策略。
+ */
+.item-multiline {
+  align-items: flex-start;
+  padding-top: var(--sidebar-multiline-pad-y, 8px);
+  padding-bottom: var(--sidebar-multiline-pad-y, 8px);
+}
+
+.label-multiline {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  overflow-wrap: anywhere;
 }
 
 .description {

--- a/website/src/components/Sidebar/__tests__/HistoryListView.test.jsx
+++ b/website/src/components/Sidebar/__tests__/HistoryListView.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { jest } from "@jest/globals";
 import styles from "../HistoryList.module.css";
+import navItemStyles from "../NavItem.module.css";
 
 const loadHistory = jest.fn();
 
@@ -153,5 +154,38 @@ describe("HistoryListView", () => {
     fireEvent.keyDown(firstItem, { key: "ArrowDown" });
 
     expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 测试目标：验证历史词条启用 NavItem 的多行模式以完整展示文本。
+   * 前置条件：提供包含长词条的列表，并渲染默认视图。
+   * 步骤：
+   *  1) 渲染组件并获取长词条按钮与文本节点。
+   * 断言：
+   *  - 按钮含有多行布局类，文本节点具备多行标签类。
+   * 边界/异常：
+   *  - 若未来禁用该模式应及时更新断言，避免回归缺口。
+   */
+  test("Given_long_term_When_history_rendered_Then_enables_multiline_display", () => {
+    const onNavigate = jest.fn(() => ({}));
+    const items = [
+      {
+        termKey: "term-1",
+        term: "a very very long dictionary lookup that should not be truncated",
+        latestVersionId: "v1",
+      },
+    ];
+
+    render(<HistoryListView items={items} onNavigate={onNavigate} />);
+
+    const button = screen.getByRole("button", {
+      name: "a very very long dictionary lookup that should not be truncated",
+    });
+    const label = screen.getByText(
+      "a very very long dictionary lookup that should not be truncated",
+    );
+
+    expect(button).toHaveClass(navItemStyles["item-multiline"]);
+    expect(label).toHaveClass(navItemStyles["label-multiline"]);
   });
 });


### PR DESCRIPTION
## Summary
- add an opt-in multiline mode to the shared Sidebar NavItem so long labels can expand without truncation
- enable the multiline variant for search history entries and document the intent inline
- cover the new behaviour with a focused HistoryListView test

## Testing
- npm run lint
- npm run lint:css
- npm test -- HistoryListView

------
https://chatgpt.com/codex/tasks/task_e_68e13a8ff9e88332ad7224919bff1d91