### PR TITLE
Add interactive theme and language controls to General preferences

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -37,6 +37,13 @@ export default {
   settingsTabGeneral: "General",
   settingsGeneralDescription:
     "Tune interface languages, theme, and pronunciation defaults.",
+  settingsGeneralThemeLabel: "Theme",
+  settingsGeneralThemeLight: "Light",
+  settingsGeneralThemeDark: "Dark",
+  settingsGeneralThemeSystem: "System",
+  settingsGeneralLanguageLabel: "Interface language",
+  settingsGeneralLanguageOption_en: "English (US)",
+  settingsGeneralLanguageOption_zh: "Chinese (Simplified)",
   settingsTabPersonalization: "Personalization",
   settingsPersonalizationDescription:
     "Describe your background so answers feel bespoke.",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -33,6 +33,13 @@ export default {
   settingsVoicePreviewTextZh: "你好，我是 Glancy。",
   settingsTabGeneral: "通用",
   settingsGeneralDescription: "协调界面语言、主题与默认发音。",
+  settingsGeneralThemeLabel: "界面主题",
+  settingsGeneralThemeLight: "浅色",
+  settingsGeneralThemeDark: "深色",
+  settingsGeneralThemeSystem: "跟随系统",
+  settingsGeneralLanguageLabel: "系统语言",
+  settingsGeneralLanguageOption_en: "英语（English）",
+  settingsGeneralLanguageOption_zh: "中文（简体）",
   settingsTabPersonalization: "个性化",
   settingsPersonalizationDescription:
     "描述你的身份与期待，生成更贴合的回答语气。",

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -106,13 +106,8 @@
   inline-size: var(--btn-action, 44px);
   block-size: var(--btn-action, 44px);
   border-radius: 999px;
-  border: 1px solid
-    color-mix(in srgb, var(--preferences-panel-border) 68%, transparent);
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 94%,
-    transparent
-  );
+  border: none;
+  background: transparent;
   color: var(--preferences-panel-text);
   cursor: pointer;
   transition:
@@ -122,11 +117,6 @@
 }
 
 .close-button:hover {
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 98%,
-    transparent
-  );
   transform: translateY(-1px);
 }
 
@@ -140,11 +130,6 @@
 .close-button:active {
   transform: translateY(0);
   box-shadow: none;
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 88%,
-    transparent
-  );
 }
 
 .tabs {
@@ -294,6 +279,135 @@
   gap: 10px;
 }
 
+.controls {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.control-field {
+  margin: 0;
+  padding: 0;
+  border: none;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.control-label {
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--preferences-panel-text);
+  line-height: 1.6;
+}
+
+.segments {
+  display: inline-flex;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 16px;
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface) 82%,
+    transparent
+  );
+}
+
+.segment {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 96px;
+  padding: 10px 18px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--preferences-panel-muted);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.segment:hover {
+  transform: translateY(-1px);
+}
+
+.segment:focus-visible {
+  outline: none;
+  border-color: var(--preferences-panel-ring);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--preferences-panel-ring) 45%, transparent);
+}
+
+.segment-active {
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface) 96%,
+    transparent
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-border) 60%,
+    transparent
+  );
+  color: var(--preferences-panel-text);
+  transform: translateY(-1px);
+}
+
+.segment-active:focus-visible {
+  transform: translateY(-1px);
+}
+
+.select-wrapper {
+  position: relative;
+}
+
+.select-wrapper::after {
+  content: "";
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-end: 16px;
+  width: 10px;
+  height: 10px;
+  border-inline-start: 2px solid var(--preferences-panel-muted);
+  border-block-end: 2px solid var(--preferences-panel-muted);
+  transform: translateY(-60%) rotate(-45deg);
+  pointer-events: none;
+}
+
+.select {
+  appearance: none;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 44px 0 18px;
+  border-radius: 14px;
+  border: 1px solid
+    color-mix(in srgb, var(--preferences-panel-border) 68%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface) 94%,
+    transparent
+  );
+  color: var(--preferences-panel-text);
+  font-size: 15px;
+  font-weight: 500;
+  transition:
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.select:focus-visible {
+  outline: none;
+  border-color: var(--preferences-panel-ring);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--preferences-panel-ring) 45%, transparent);
+}
+
 .section-title {
   margin: 0;
   font-size: 18px;
@@ -423,6 +537,14 @@
 
   .section {
     padding: var(--space-4);
+  }
+
+  .controls {
+    gap: var(--space-4);
+  }
+
+  .segments {
+    flex-wrap: wrap;
   }
 
   .detail-row {

--- a/website/src/pages/preferences/sections/GeneralSection.jsx
+++ b/website/src/pages/preferences/sections/GeneralSection.jsx
@@ -1,34 +1,163 @@
 /**
  * 背景：
- *  - 通用分区的真实交互仍在设计中，但 Settings 模态已需要稳定的分区入口。
+ *  - 通用分区需要承载界面主题与系统语言的核心偏好，原占位组件无法满足实时配置需求。
  * 目的：
- *  - 以适配器模式复用 PlaceholderSection，让上层可在未来平滑替换为真正的表单实现。
+ *  - 以组合模式编排字段控件，串联主题上下文与设置 Store，确保模态与页面共享一致行为。
  * 关键决策与取舍：
- *  - 采用轻量包装组件而非直接引用占位，保证语义清晰并为后续扩展保留隔离层。
+ *  - 选用“组合 + 策略”架构：字段容器负责排版，具体控件通过回调策略写入 Theme/Language，上层未来可追加新策略；
+ *  - 放弃继续沿用 PlaceholderSection，避免一次性补丁阻塞真实表单的演进。
  * 影响范围：
- *  - Preferences 页面与 SettingsModal 中的 "General" 标签内容展示。
+ *  - Preferences 页面与 SettingsModal 的“通用”分区将即时呈现主题与语言配置。
  * 演进与TODO：
- *  - TODO: 当通用配置成型后，以此组件为挂载点引入真实表单与状态同步。
+ *  - TODO: 待接入更多通用偏好（如语音预览、字号）时，可在 controls 数组中扩展新的策略项。
  */
+import { useCallback, useId, useMemo } from "react";
 import PropTypes from "prop-types";
-import PlaceholderSection from "./PlaceholderSection.jsx";
+import { useLanguage, useTheme } from "@/context";
+import { SYSTEM_LANGUAGE_AUTO } from "@/i18n/languages.js";
+import { SUPPORTED_SYSTEM_LANGUAGES } from "@/store/settings";
+import styles from "../Preferences.module.css";
 
-function GeneralSection({ title, message, headingId, descriptionId }) {
+const THEME_ORDER = Object.freeze(["light", "dark", "system"]);
+
+const composeClassName = (...tokens) => tokens.filter(Boolean).join(" ");
+
+const mapLanguageLabel = (translations, code) => {
+  const key = `settingsGeneralLanguageOption_${code}`;
+  const fallback = code === "zh" ? "Chinese" : code === "en" ? "English" : code;
+  return translations[key] ?? fallback;
+};
+
+function GeneralSection({ title, headingId }) {
+  const { theme, setTheme } = useTheme();
+  const { t, systemLanguage, setSystemLanguage } = useLanguage();
+
+  const themeFieldId = useId();
+  const languageSelectId = useId();
+
+  const themeLabel = t.settingsGeneralThemeLabel ?? t.prefTheme ?? "Theme";
+  const themeOptions = useMemo(
+    () =>
+      THEME_ORDER.map((value) => ({
+        value,
+        label:
+          (value === "light" && (t.settingsGeneralThemeLight ?? "Light")) ||
+          (value === "dark" && (t.settingsGeneralThemeDark ?? "Dark")) ||
+          (value === "system" && (t.settingsGeneralThemeSystem ?? "System")) ||
+          value,
+      })),
+    [
+      t.settingsGeneralThemeDark,
+      t.settingsGeneralThemeLight,
+      t.settingsGeneralThemeSystem,
+    ],
+  );
+
+  const languageLabel =
+    t.settingsGeneralLanguageLabel ?? t.prefSystemLanguage ?? "System language";
+  const languageOptions = useMemo(() => {
+    const base = [
+      {
+        value: SYSTEM_LANGUAGE_AUTO,
+        label: t.prefSystemLanguageAuto ?? "Match device language",
+      },
+    ];
+    return base.concat(
+      SUPPORTED_SYSTEM_LANGUAGES.map((code) => ({
+        value: code,
+        label: mapLanguageLabel(t, code),
+      })),
+    );
+  }, [t]);
+
+  const handleThemeSelect = useCallback(
+    (nextTheme) => {
+      if (!nextTheme || nextTheme === theme) {
+        return;
+      }
+      setTheme(nextTheme);
+    },
+    [setTheme, theme],
+  );
+
+  const handleLanguageChange = useCallback(
+    (event) => {
+      const value = event?.target?.value ?? SYSTEM_LANGUAGE_AUTO;
+      if (value === systemLanguage) {
+        return;
+      }
+      setSystemLanguage(value);
+    },
+    [setSystemLanguage, systemLanguage],
+  );
+
   return (
-    <PlaceholderSection
-      title={title}
-      message={message}
-      headingId={headingId}
-      descriptionId={descriptionId}
-    />
+    <section aria-labelledby={headingId} className={styles.section}>
+      <div className={styles["section-header"]}>
+        <h3 id={headingId} className={styles["section-title"]} tabIndex={-1}>
+          {title}
+        </h3>
+      </div>
+      <div className={styles.controls}>
+        <fieldset
+          className={styles["control-field"]}
+          aria-labelledby={themeFieldId}
+        >
+          <legend id={themeFieldId} className={styles["control-label"]}>
+            {themeLabel}
+          </legend>
+          <div
+            role="radiogroup"
+            aria-labelledby={themeFieldId}
+            className={styles.segments}
+          >
+            {themeOptions.map((option) => {
+              const active = theme === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  className={composeClassName(
+                    styles.segment,
+                    active ? styles["segment-active"] : "",
+                  )}
+                  onClick={() => handleThemeSelect(option.value)}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+        <div className={styles["control-field"]}>
+          <label htmlFor={languageSelectId} className={styles["control-label"]}>
+            {languageLabel}
+          </label>
+          <div className={styles["select-wrapper"]}>
+            <select
+              id={languageSelectId}
+              className={styles.select}
+              value={systemLanguage ?? SYSTEM_LANGUAGE_AUTO}
+              onChange={handleLanguageChange}
+            >
+              {languageOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 
 GeneralSection.propTypes = {
   title: PropTypes.string.isRequired,
-  message: PropTypes.string.isRequired,
   headingId: PropTypes.string.isRequired,
-  descriptionId: PropTypes.string.isRequired,
 };
 
 export default GeneralSection;

--- a/website/src/pages/preferences/sections/__tests__/GeneralSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/GeneralSection.test.jsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockSetTheme = jest.fn();
+const mockSetSystemLanguage = jest.fn();
+const themeState = { theme: "light" };
+const languageState = { value: "auto" };
+
+const createTranslations = () => ({
+  prefTheme: "Theme",
+  prefSystemLanguage: "System language",
+  prefSystemLanguageAuto: "Match device language",
+  settingsGeneralThemeLabel: "Theme",
+  settingsGeneralThemeLight: "Light",
+  settingsGeneralThemeDark: "Dark",
+  settingsGeneralThemeSystem: "System",
+  settingsGeneralLanguageLabel: "Interface language",
+  settingsGeneralLanguageOption_en: "English (US)",
+  settingsGeneralLanguageOption_zh: "Chinese (Simplified)",
+});
+
+jest.unstable_mockModule("@/context", () => ({
+  useTheme: () => ({ theme: themeState.theme, setTheme: mockSetTheme }),
+  useLanguage: () => ({
+    t: createTranslations(),
+    systemLanguage: languageState.value,
+    setSystemLanguage: mockSetSystemLanguage,
+  }),
+}));
+
+jest.unstable_mockModule("@/store/settings", () => ({
+  SUPPORTED_SYSTEM_LANGUAGES: ["en", "zh"],
+}));
+
+let GeneralSection;
+
+beforeAll(async () => {
+  ({ default: GeneralSection } = await import("../GeneralSection.jsx"));
+});
+
+beforeEach(() => {
+  mockSetTheme.mockClear();
+  mockSetSystemLanguage.mockClear();
+  themeState.theme = "light";
+  languageState.value = "auto";
+});
+
+/**
+ * 测试目标：默认渲染时展示当前主题与语言的选中态。
+ * 前置条件：主题设为 light，系统语言为 auto。
+ * 步骤：
+ *  1) 渲染 GeneralSection。
+ * 断言：
+ *  - Light 选项 aria-checked 为 true。
+ *  - 语言下拉框选中 Match device language。
+ * 边界/异常：
+ *  - 若 aria-checked 未正确反映状态则提示绑定失败。
+ */
+test("Given initial preferences When rendered Then current selection highlighted", () => {
+  render(
+    <GeneralSection title="General" headingId="general-section-heading" />,
+  );
+
+  expect(screen.getByRole("radio", { name: "Light" })).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+  expect(screen.getByLabelText("Interface language")).toHaveValue("auto");
+});
+
+/**
+ * 测试目标：点击主题选项会调用 setTheme 更新偏好。
+ * 前置条件：主题初始为 light。
+ * 步骤：
+ *  1) 渲染组件。
+ *  2) 点击 Dark 选项。
+ * 断言：
+ *  - setTheme 被以 "dark" 调用一次。
+ * 边界/异常：
+ *  - 若重复点击当前主题不应触发额外调用。
+ */
+test("Given theme options When selecting another theme Then delegate invoked", async () => {
+  const user = userEvent.setup();
+  render(
+    <GeneralSection title="General" headingId="general-section-heading" />,
+  );
+
+  await user.click(screen.getByRole("radio", { name: "Dark" }));
+
+  expect(mockSetTheme).toHaveBeenCalledTimes(1);
+  expect(mockSetTheme).toHaveBeenCalledWith("dark");
+});
+
+/**
+ * 测试目标：切换语言下拉框触发 setSystemLanguage。
+ * 前置条件：系统语言初始为 auto。
+ * 步骤：
+ *  1) 渲染组件。
+ *  2) 选择 English (US)。
+ * 断言：
+ *  - setSystemLanguage 收到 "en"。
+ * 边界/异常：
+ *  - 重复选择当前值不应重复触发。
+ */
+test("Given language select When choosing locale Then system language updated", async () => {
+  const user = userEvent.setup();
+  render(
+    <GeneralSection title="General" headingId="general-section-heading" />,
+  );
+
+  await user.selectOptions(screen.getByLabelText("Interface language"), "en");
+
+  expect(mockSetSystemLanguage).toHaveBeenCalledTimes(1);
+  expect(mockSetSystemLanguage).toHaveBeenCalledWith("en");
+});

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -166,13 +166,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
 
   const sections = useMemo(() => {
     const generalLabel = t.settingsTabGeneral ?? "General";
-    const generalSummary =
-      t.settingsGeneralDescription ??
-      "Tune interface languages, theme, and pronunciation defaults.";
-    const generalMessage = pickFirstMeaningfulString(
-      [t.prefDefaultsDescription, t.prefInterfaceDescription, generalSummary],
-      generalSummary,
-    );
 
     const personalizationLabel =
       t.settingsTabPersonalization ?? "Personalization";
@@ -193,8 +186,7 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
       dataSummary,
     );
 
-    const keyboardLabel =
-      t.settingsTabKeyboard ?? "Keyboard shortcuts";
+    const keyboardLabel = t.settingsTabKeyboard ?? "Keyboard shortcuts";
     const keyboardSummary =
       t.settingsKeyboardDescription ??
       "Master Glancy with a curated set of command keys.";
@@ -203,7 +195,8 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
       keyboardSummary,
     );
 
-    const accountLabel = t.prefAccountTitle ?? t.settingsTabAccount ?? "Account";
+    const accountLabel =
+      t.prefAccountTitle ?? t.settingsTabAccount ?? "Account";
     const accountDescription = pickFirstMeaningfulString(
       [t.settingsAccountDescription],
       "Review and safeguard the basics that identify you in Glancy.",
@@ -246,7 +239,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
         Component: GeneralSection,
         componentProps: {
           title: generalLabel,
-          message: generalMessage,
         },
       },
       {
@@ -302,8 +294,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
     profileMeta.age,
     profileMeta.gender,
     t.prefAccountTitle,
-    t.prefDefaultsDescription,
-    t.prefInterfaceDescription,
     t.prefKeyboardTitle,
     t.prefPersonalizationTitle,
     t.settingsAccountAge,
@@ -314,7 +304,6 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
     t.settingsAccountUsername,
     t.settingsDataDescription,
     t.settingsDataNotice,
-    t.settingsGeneralDescription,
     t.settingsKeyboardDescription,
     t.settingsPersonalizationDescription,
     t.settingsTabAccount,
@@ -346,7 +335,8 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
   useEffect(() => {
     const nextInitial = sanitizeActiveSectionId(initialSectionId, sections);
     const initialChanged = previousInitialRef.current !== initialSectionId;
-    const sanitizedChanged = previousSanitizedInitialRef.current !== nextInitial;
+    const sanitizedChanged =
+      previousSanitizedInitialRef.current !== nextInitial;
     const shouldSync =
       !hasAppliedInitialRef.current || initialChanged || sanitizedChanged;
 
@@ -366,7 +356,8 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
   }, [initialSectionId, sections]);
 
   const activeSection = useMemo(
-    () => sections.find((section) => section.id === activeSectionId) ?? sections[0],
+    () =>
+      sections.find((section) => section.id === activeSectionId) ?? sections[0],
     [activeSectionId, sections],
   );
 
@@ -374,7 +365,9 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
     if (!section || section.disabled) {
       return;
     }
-    setActiveSectionId((current) => (current === section.id ? current : section.id));
+    setActiveSectionId((current) =>
+      current === section.id ? current : section.id,
+    );
   }, []);
 
   const handleSubmit = useCallback((event) => {
@@ -428,4 +421,3 @@ function usePreferenceSections({ initialSectionId, onOpenAccountManager }) {
 }
 
 export default usePreferenceSections;
-


### PR DESCRIPTION
## Summary
- replace the General section placeholder with theme and system language controls wired to the theme context and settings store
- extend the preferences styling and translations to support the new controls and remove the close button chrome
- add coverage for the General section interactions and ensure existing hooks work without placeholder props

## Testing
- npm test -- GeneralSection

------
https://chatgpt.com/codex/tasks/task_e_68e13b4ee120833291b8648da718d1d7