### PR TITLE
Fix ThemeIcon tone mapping for dark mode contrast

### DIFF
--- a/website/src/components/ui/Icon/__tests__/ThemeIcon.test.jsx
+++ b/website/src/components/ui/Icon/__tests__/ThemeIcon.test.jsx
@@ -56,12 +56,12 @@ describe("ThemeIcon", () => {
   });
 
   /**
-   * 测试目标：在 resolvedTheme=light 时优先渲染 light 变体。 
-   * 前置条件：iconRegistry.apple 同时提供 light/dark 资源。 
+   * 测试目标：在 resolvedTheme=light 时优先渲染 light 变体。
+   * 前置条件：iconRegistry.apple 同时提供 light/dark 资源。
    * 步骤：
    *  1) 设置 currentTheme=light；
    *  2) 渲染 ThemeIcon name="apple"；
-   *  3) 捕获 img 元素并检查 src。 
+   *  3) 捕获 img 元素并检查 src。
    * 断言：
    *  - src 指向 light 变体。
    * 边界/异常：
@@ -75,12 +75,12 @@ describe("ThemeIcon", () => {
   });
 
   /**
-   * 测试目标：在 resolvedTheme=dark 时切换到暗色背景专用资源。 
-   * 前置条件：iconRegistry.apple 提供 dark 资源；currentTheme=dark。 
+   * 测试目标：在 resolvedTheme=dark 时切换到暗色背景专用资源。
+   * 前置条件：iconRegistry.apple 提供 dark 资源；currentTheme=dark。
    * 步骤：
    *  1) 设置 currentTheme=dark；
    *  2) 渲染 ThemeIcon name="apple"；
-   *  3) 捕获 img 并校验 src。 
+   *  3) 捕获 img 并校验 src。
    * 断言：
    *  - src 指向 dark 变体。
    * 边界/异常：
@@ -94,21 +94,40 @@ describe("ThemeIcon", () => {
   });
 
   /**
-   * 测试目标：当 tone="dark" 时使用反差更高的强前景颜色类。
+   * 测试目标：tone="dark" 与默认语义保持一致，确保组件不会因暗色主题出现低对比度。
    * 前置条件：当前主题 resolvedTheme=light；tone=dark。
    * 步骤：
    *  1) 渲染 ThemeIcon 并传入 tone="dark"；
    *  2) 查找 role="img" 元素；
    *  3) 断言 className。
    * 断言：
-   *  - className 包含 text-onsurface-strong。
+   *  - className 与默认 text-onsurface 一致。
    * 边界/异常：
-   *  - tone 未提供时应使用默认 text-onsurface（已由上一测试覆盖）。
+   *  - tone 未提供时应同样产出 text-onsurface（由默认测试覆盖）。
    */
-  test("applies strong role class when forcing dark tone", () => {
+  test("treats dark tone as default foreground to preserve contrast", () => {
     render(<ThemeIcon name="glancy-web" alt="brand" tone="dark" />);
     const icon = screen.getByRole("img", { name: "brand" });
-    expect(icon.className).toContain("text-onsurface-strong");
+    expect(icon.className).toContain("text-onsurface");
+  });
+
+  /**
+   * 测试目标：在暗色主题下自动切换为 text-onsurface 保持足够对比度。
+   * 前置条件：currentTheme=dark；tone=auto。
+   * 步骤：
+   *  1) 设置 currentTheme=dark；
+   *  2) 渲染 ThemeIcon；
+   *  3) 校验 className。
+   * 断言：
+   *  - className 包含 text-onsurface。
+   * 边界/异常：
+   *  - 若主题无法解析则回退到 text-onsurface（默认实现）。
+   */
+  test("uses surface role in dark theme for auto tone", () => {
+    currentTheme = "dark";
+    render(<ThemeIcon name="glancy-web" alt="brand" />);
+    const icon = screen.getByRole("img", { name: "brand" });
+    expect(icon.className).toContain("text-onsurface");
   });
 
   /**

--- a/website/src/components/ui/Icon/index.tsx
+++ b/website/src/components/ui/Icon/index.tsx
@@ -84,17 +84,31 @@ const THEMED_VARIANT_PRIORITY: Readonly<
   dark: Object.freeze(["dark", "light"]),
 });
 
+const DEFAULT_ROLE_BY_THEME: Record<ResolvedTheme, IconRoleClass> =
+  Object.freeze({
+    light: "onsurface",
+    dark: "onsurface",
+  });
+
 const legacyToneToRole = (
   tone: LegacyTone | undefined,
   resolvedTheme: ResolvedTheme,
 ): IconRoleClass => {
-  if (tone === "dark") {
-    return "onsurfaceStrong";
-  }
+  /**
+   * 背景：
+   *  - 旧版 tone="dark" 默认假设浅色主题，仅返回 text-onsurface-strong，导致暗色主题下图标仍为深色。
+   * 目的：
+   *  - 统一回落到与当前主题一致的基础前景色，保证 SearchBox 等通用组件在 dark 模式下依旧可读。
+   * 关键决策与取舍：
+   *  - “dark” 与默认 auto 等价，均采用按主题解析的标准前景色；
+   *  - “light” 保留遗留语义，仅在浅色主题下取高亮前景，在暗色主题中退回标准前景以避免反差不足。
+   * 影响范围：
+   *  - 所有未显式指定 roleClass 的 ThemeIcon 调用方。
+   */
   if (tone === "light") {
-    return "onsurface";
+    return resolvedTheme === "light" ? "onsurfaceStrong" : "onsurface";
   }
-  return resolvedTheme === "dark" ? "onsurfaceStrong" : "onsurface";
+  return DEFAULT_ROLE_BY_THEME[resolvedTheme] ?? "onsurface";
 };
 
 const composeClassName = (


### PR DESCRIPTION
## Summary
- adjust ThemeIcon legacy tone resolver to use theme-aware default roles so icons stay legible in dark mode
- expand ThemeIcon unit tests to cover the new tone behaviour and dark theme auto mode

## Testing
- npm test -- ThemeIcon

------
https://chatgpt.com/codex/tasks/task_e_68e13d27732c8332b313a4e2df04cbf5