### PR TITLE
feat: equal width settings tabs on narrow panels

### DIFF
--- a/website/src/components/modals/SettingsBody.module.css
+++ b/website/src/components/modals/SettingsBody.module.css
@@ -96,7 +96,12 @@
   }
 
   .nav-scroller > * {
-    min-width: max-content;
+    /*
+     * 当设置面板切换为单列布局时，让导航容器占满可用宽度，
+     * 避免 min-content 触发横向滚动并破坏等宽栅格。此处使用 100%
+     * 而非固定像素，方便未来根据内容动态扩展列数。
+     */
+    min-width: 100%;
   }
 
   .content-column {

--- a/website/src/components/modals/SettingsNav.jsx
+++ b/website/src/components/modals/SettingsNav.jsx
@@ -21,6 +21,7 @@ function SettingsNav({
   renderCloseAction,
   classes,
 }) {
+  const sectionCount = sections.length;
   const containerClassName = classes?.container ?? "";
   const actionWrapperClassName = classes?.action ?? "";
   const navClassName = classes?.nav ?? "";
@@ -42,6 +43,14 @@ function SettingsNav({
         aria-orientation="vertical"
         className={navClassName}
         role="tablist"
+        /*
+         * 通过 CSS 变量暴露分区数量，便于窄屏布局在不引入额外脚本的情况下
+         * 等分标签宽度。相比在组件内写死栅格列数，此做法可随 sections 变化
+         * 自动适配未来新增的设置分区。
+         */
+        style={{
+          "--settings-nav-section-count": sectionCount,
+        }}
       >
         {closeActionNode ? (
           <div role="presentation" className={actionWrapperClassName}>

--- a/website/src/components/modals/__tests__/SettingsNavPanel.test.jsx
+++ b/website/src/components/modals/__tests__/SettingsNavPanel.test.jsx
@@ -114,6 +114,24 @@ test("Given navigation sections When rendering Then only primary label is expose
 });
 
 /**
+ * 测试目标：在渲染导航时暴露分区数量 CSS 变量供响应式样式消费。
+ * 前置条件：渲染默认的 TestSettingsHarness，提供两个分区。
+ * 步骤：
+ *  1) 查询 role 为 tablist 的导航元素。
+ *  2) 读取行内 style 中的 --settings-nav-section-count。
+ * 断言：
+ *  - CSS 自定义属性等于字符串 "2"，指示当前分区数量。
+ * 边界/异常：
+ *  - 若未来通过容器注入外部 style，需同步更新此断言以匹配最新接口。
+ */
+test("Given navigation sections When rendering Then exposes section count variable", () => {
+  render(<TestSettingsHarness />);
+
+  const tablist = screen.getByRole("tablist", { name: "Example sections" });
+  expect(tablist.style.getPropertyValue("--settings-nav-section-count")).toBe("2");
+});
+
+/**
  * 测试目标：切换分区后标题获得焦点并滚动至首部。
  * 前置条件：渲染 TestSettingsHarness，激活默认 account 分区。
  * 步骤：

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -411,14 +411,25 @@
 
   .tabs {
     flex: none;
-    flex-direction: row;
+    display: grid;
+    /*
+     * 结合 SettingsNav 注入的分区数量，窄宽度时将标签横向等分，
+     * 避免继续使用纵向布局导致挤压。auto-fit 无法保证与 sections 对齐，
+     * 因此采用 repeat(var(--settings-nav-section-count)) 精确匹配。 
+     */
+    grid-template-columns: repeat(
+      var(--settings-nav-section-count, 1),
+      minmax(0, 1fr)
+    );
+    grid-auto-rows: minmax(0, 1fr);
     gap: 10px;
     min-height: auto;
     padding: calc(var(--preferences-close-offset) + 10px) 10px 10px;
   }
 
   .tab {
-    min-width: 220px;
+    min-width: 0;
+    height: 100%;
   }
 
   .section {


### PR DESCRIPTION
## Summary
- expose the number of settings sections via CSS variable so responsive styles can evenly size the tabs
- switch the compact navigation layout to a grid that spans the full width of narrow panels and prevent overflow in the scroller container
- cover the new CSS contract with a unit test to guard the injected variable

## Testing
- npm run test -- SettingsNavPanel.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e13e666af0833297f8e147b8e5bc94