### PR TITLE
refactor: simplify icon registry single variant

### DIFF
--- a/website/src/assets/__tests__/iconRegistry.test.js
+++ b/website/src/assets/__tests__/iconRegistry.test.js
@@ -3,25 +3,8 @@ import { buildDynamicRegistry } from "@/assets/icons.js";
 
 describe("buildDynamicRegistry", () => {
   /**
-   * 验证基础用例：带有主题后缀的资源应聚合为同一图标实体，
-   * 即便所有 SVG 均位于 assets 根目录，也能正确推断明暗态。
-   */
-  test("aggregates theme variants into a single registry entry", () => {
-    const registry = buildDynamicRegistry({
-      "./eye-light.svg": "/assets/eye-light.svg",
-      "./eye-dark.svg": "/assets/eye-dark.svg",
-      "./wechat.svg": "/assets/wechat.svg",
-    });
-
-    expect(registry).toEqual({
-      eye: { light: "/assets/eye-light.svg", dark: "/assets/eye-dark.svg" },
-      wechat: { single: "/assets/wechat.svg" },
-    });
-  });
-
-  /**
    * 验证跨平台场景：当打包环境使用 Windows 风格路径分隔符时，
-   * 仍能提取出正确的图标名称并关联到原始 SVG 素材，避免回退占位符。
+   * 仍能提取出正确的图标名称并关联到单一 SVG 素材，避免回退占位符。
    */
   test("normalises windows style paths to keep original svg assets", () => {
     const registry = buildDynamicRegistry({

--- a/website/src/assets/icons.js
+++ b/website/src/assets/icons.js
@@ -20,7 +20,7 @@ const NORMALISED_SEPARATOR = "/";
 const normaliseResourcePath = (resourcePath) =>
   resourcePath.replace(/\\/g, NORMALISED_SEPARATOR);
 
-const extractIconDescriptor = (resourcePath) => {
+const extractIconName = (resourcePath) => {
   if (!resourcePath) {
     return null;
   }
@@ -32,39 +32,20 @@ const extractIconDescriptor = (resourcePath) => {
     return null;
   }
 
-  const baseName = filename.replace(/\.svg$/i, "");
-
-  if (baseName.endsWith("-light")) {
-    return { name: baseName.slice(0, -6), variant: "light" };
-  }
-
-  if (baseName.endsWith("-dark")) {
-    return { name: baseName.slice(0, -5), variant: "dark" };
-  }
-
-  return { name: baseName, variant: "single" };
+  return filename.replace(/\.svg$/i, "");
 };
 
 export const buildDynamicRegistry = (moduleEntries) => {
   const collected = {};
 
   for (const [path, mod] of Object.entries(moduleEntries || {})) {
-    const descriptor = extractIconDescriptor(path);
+    const iconName = extractIconName(path);
 
-    if (!descriptor) {
+    if (!iconName) {
       continue;
     }
 
-    const { name, variant } = descriptor;
-    const variants = collected[name] || {};
-
-    if (variant === "single") {
-      variants.single = mod;
-    } else {
-      variants[variant] = mod;
-    }
-
-    collected[name] = variants;
+    collected[iconName] = { single: mod };
   }
 
   return collected;

--- a/website/src/components/ui/ChatInput/icons/SendIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/SendIcon.jsx
@@ -4,7 +4,8 @@
  * 目的：
  *  - 基于统一的 createMaskedIconRenderer 模板方法，将资源解析与遮罩样式构建作为策略注入，确保发送图标与语音图标共享一致骨架。
  * 关键决策与取舍：
- *  - 采用策略函数描述主题资源选择与样式生成，保留模板对降级逻辑的控制，避免自定义实现偏离探测流程。
+ *  - 采用策略函数描述资源选择与样式生成，保留模板对降级逻辑的控制，避免自定义实现偏离探测流程。
+ *  - 在主题退化逻辑下仅消费单一矢量资源（single），统一样式来源，减少多态素材的维护成本。
  *  - 保留 SVG fallback 以应对遮罩不可用场景，并在注释中保留扩展点说明，确保未来动画或主题扩展有容纳空间。
  * 影响范围：
  *  - ChatInput 的发送按钮图标渲染逻辑及其单测；其他依赖 send-button 令牌的入口也将受益于统一策略。
@@ -17,23 +18,9 @@ import createMaskedIconRenderer from "./createMaskedIconRenderer.jsx";
 
 const SEND_ICON_TOKEN = "send-button";
 
-const resolveSendIconResource = ({ registry, resolvedTheme }) => {
+const resolveSendIconResource = ({ registry }) => {
   const entry = registry?.[SEND_ICON_TOKEN];
-  if (!entry) {
-    return null;
-  }
-
-  const themeKey = resolvedTheme === "dark" ? "dark" : "light";
-  if (entry[themeKey]) {
-    return entry[themeKey];
-  }
-
-  if (entry.single) {
-    return entry.single;
-  }
-
-  const alternativeKey = themeKey === "dark" ? "light" : "dark";
-  return entry[alternativeKey] ?? null;
+  return entry?.single ?? null;
 };
 
 const buildSendIconInlineStyle = ({ resource }) => {

--- a/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
@@ -4,7 +4,7 @@
  * 目的：
  *  - 借助 createMaskedIconRenderer 模板统一遮罩渲染流程，仅以策略函数定义语音资源的解析与样式构造，消除重复实现导致的偏差。
  * 关键决策与取舍：
- *  - 继续保留麦克风 SVG 作为 fallback，保证在遮罩不受支持时仍具备语义图形；策略函数优先选择主题匹配资源，兜底返回 single/light/dark 变体。
+ *  - 继续保留麦克风 SVG 作为 fallback，保证在遮罩不受支持时仍具备语义图形；策略函数仅依赖 single 资源，统一素材来源。
  * 影响范围：
  *  - ChatInput 语音按钮渲染行为与对应单元测试，修复部分浏览器下的黑块问题，并为未来语音动画扩展预留策略接口。
  * 演进与TODO：
@@ -16,18 +16,9 @@ import createMaskedIconRenderer from "./createMaskedIconRenderer.jsx";
 
 const VOICE_ICON_TOKEN = "voice-button";
 
-const resolveVoiceIconResource = ({ registry, resolvedTheme }) => {
+const resolveVoiceIconResource = ({ registry }) => {
   const entry = registry?.[VOICE_ICON_TOKEN];
-
-  if (!entry) {
-    return null;
-  }
-
-  if (resolvedTheme && entry?.[resolvedTheme]) {
-    return entry[resolvedTheme];
-  }
-
-  return entry.single ?? entry.light ?? entry.dark ?? null;
+  return entry?.single ?? null;
 };
 
 const buildVoiceIconMaskStyle = ({ resource }) => {

--- a/website/src/components/ui/Icon/index.tsx
+++ b/website/src/components/ui/Icon/index.tsx
@@ -1,8 +1,8 @@
 import type { CSSProperties } from "react";
 import { useTheme } from "@/context";
-import type { ResolvedTheme } from "@/theme/mode";
 import ICONS from "@/assets/icons.js";
 import styles from "./ThemeIcon.module.css";
+import type { ResolvedTheme } from "@/theme/mode";
 
 /**
  * 背景：
@@ -60,8 +60,6 @@ type FallbackPreset = {
 
 type IconModuleEntry = {
   single?: string;
-  light?: string;
-  dark?: string;
   [variant: string]: string | undefined;
 };
 
@@ -72,17 +70,6 @@ const FALLBACK_PRESETS: Record<FallbackPresetKey, FallbackPreset> =
     wechat: { label: "W", variant: "wechat" },
     default: { label: "•", variant: "default" },
   });
-
-/**
- * 采用“主题 -> 资源优先级队列”的策略映射，确保未来扩展更多主题时仅需更新此处而无需触碰消费端组件。
- * 当前按照 light/dark 双态设计，优先使用语义匹配的资源，缺失时自动回退到对立主题。
- */
-const THEMED_VARIANT_PRIORITY: Readonly<
-  Record<ResolvedTheme, ReadonlyArray<keyof IconModuleEntry>>
-> = Object.freeze({
-  light: Object.freeze(["light", "dark"]),
-  dark: Object.freeze(["dark", "light"]),
-});
 
 const DEFAULT_ROLE_BY_THEME: Record<ResolvedTheme, IconRoleClass> =
   Object.freeze({
@@ -117,35 +104,9 @@ const composeClassName = (
   external?: string,
 ) => [base, ROLE_CLASSNAME_MAP[roleClass], external].filter(Boolean).join(" ");
 
-const pickVariantForTheme = (
-  entry: IconModuleEntry,
-  resolvedTheme: ResolvedTheme,
-) => {
-  /**
-   * 意图：按主题挑选最契合的图标资源，保证 dark 模式优先亮色资源、light 模式优先深色资源。
-   * 流程：遍历当前主题的候选列表，返回首个存在的资源；若都缺失则交由调用方处理回退。
-   */
-  const candidates = THEMED_VARIANT_PRIORITY[resolvedTheme];
-  for (const variantKey of candidates) {
-    const candidate = entry[variantKey];
-    if (candidate) {
-      return candidate;
-    }
-  }
-  return undefined;
-};
-
-const resolveIconSrc = (name: string, resolvedTheme: ResolvedTheme) => {
+const resolveIconSrc = (name: string) => {
   const entry = ICONS[name] as IconModuleEntry | undefined;
-  if (!entry) {
-    return undefined;
-  }
-
-  if (entry.single) {
-    return entry.single;
-  }
-
-  return pickVariantForTheme(entry, resolvedTheme) ?? entry.light ?? entry.dark;
+  return entry?.single;
 };
 
 const resolveFallback = (name: string): FallbackPreset => {
@@ -186,7 +147,7 @@ export function ThemeIcon({
 }: IconProps) {
   const { resolvedTheme } = useTheme();
   const iconRole = roleClass ?? legacyToneToRole(tone, resolvedTheme);
-  const src = resolveIconSrc(name, resolvedTheme);
+  const src = resolveIconSrc(name);
   const commonClassName = composeClassName(
     "inline-block align-middle",
     iconRole,


### PR DESCRIPTION
## Summary
- drop themed suffix parsing from the icon registry and treat every asset as a single variant entry
- update ThemeIcon along with SendIcon and VoiceIcon to resolve only single-sourced assets with consistent fallbacks
- refresh the related unit tests to assert the streamlined single-variant paths and fallback behaviour

## Testing
- npm run test -- --runTestsByPath src/assets/__tests__/iconRegistry.test.js src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e14df0c92c8332b717f9a18129f31b