### PR TITLE
Refine chat input icon rendering fallbacks

### DIFF
--- a/website/src/components/ui/ChatInput/icons/SendIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/SendIcon.jsx
@@ -36,17 +36,37 @@ const buildSendIconInlineStyle = ({ resource }) => {
   });
 };
 
-const defaultFallback = ({ className }) => (
-  <svg
-    aria-hidden="true"
-    className={className}
-    viewBox="0 0 18 18"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path d="M2.25 15.75 16.5 9 2.25 2.25l4.5 6-4.5 7.5Z" />
-  </svg>
-);
+const defaultFallback = ({
+  className,
+  resource,
+  iconName = SEND_ICON_TOKEN,
+}) => {
+  if (resource) {
+    return (
+      <img
+        aria-hidden="true"
+        alt=""
+        className={className}
+        data-icon-name={iconName}
+        draggable={false}
+        src={resource}
+      />
+    );
+  }
+
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      data-icon-name={iconName}
+      viewBox="0 0 18 18"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M2.25 15.75 16.5 9 2.25 2.25l4.5 6-4.5 7.5Z" />
+    </svg>
+  );
+};
 
 const SendIcon = createMaskedIconRenderer({
   token: SEND_ICON_TOKEN,

--- a/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
@@ -34,18 +34,37 @@ const buildVoiceIconMaskStyle = ({ resource }) => {
   });
 };
 
-const defaultFallback = ({ className, iconName = VOICE_ICON_TOKEN }) => (
-  <svg
-    aria-hidden="true"
-    className={className}
-    viewBox="0 0 1024 1024"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-    data-icon-name={iconName}
-  >
-    <path d="M512 128C417.707 128 341.333 204.373 341.333 298.667v256c0 94.293 76.373 170.667 170.667 170.667s170.667-76.373 170.667-170.667V298.667c0-94.293-76.373-170.667-170.667-170.667zm213.333 298.667v85.333c0 117.76-95.573 213.333-213.333 213.333s-213.333-95.573-213.333-213.333v-85.333H213.333v85.333c0 150.613 111.36 274.347 256 295.253V896h85.333v-88.747c144.64-20.907 256-144.64 256-295.253v-85.333h-85.333z" />
-  </svg>
-);
+const defaultFallback = ({
+  className,
+  resource,
+  iconName = VOICE_ICON_TOKEN,
+}) => {
+  if (resource) {
+    return (
+      <img
+        aria-hidden="true"
+        alt=""
+        className={className}
+        data-icon-name={iconName}
+        draggable={false}
+        src={resource}
+      />
+    );
+  }
+
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 1024 1024"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      data-icon-name={iconName}
+    >
+      <path d="M512 128C417.707 128 341.333 204.373 341.333 298.667v256c0 94.293 76.373 170.667 170.667 170.667s170.667-76.373 170.667-170.667V298.667c0-94.293-76.373-170.667-170.667-170.667zm213.333 298.667v85.333c0 117.76-95.573 213.333-213.333 213.333s-213.333-95.573-213.333-213.333v-85.333H213.333v85.333c0 150.613 111.36 274.347 256 295.253V896h85.333v-88.747c144.64-20.907 256-144.64 256-295.253v-85.333h-85.333z" />
+    </svg>
+  );
+};
 
 const VoiceIcon = createMaskedIconRenderer({
   token: VOICE_ICON_TOKEN,

--- a/website/src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx
+++ b/website/src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx
@@ -95,7 +95,7 @@ describe("SendIcon", () => {
    * 边界/异常：
    *  - 用例结束后恢复注册表。
    */
-  test("GivenEntryWithoutSingle_WhenRendering_ThenRenderFallback", () => {
+  test("GivenEntryWithoutSingle_WhenRendering_ThenRenderFallbackSvg", () => {
     const originalEntry = { ...sendRegistry["send-button"] };
     sendRegistry["send-button"] = {};
 
@@ -104,7 +104,9 @@ describe("SendIcon", () => {
     expect(
       container.querySelector('span[data-icon-name="send-button"]'),
     ).toBeNull();
-    expect(container.querySelector("svg")).not.toBeNull();
+    expect(
+      container.querySelector('svg[data-icon-name="send-button"]'),
+    ).not.toBeNull();
 
     sendRegistry["send-button"] = originalEntry;
   });
@@ -120,12 +122,14 @@ describe("SendIcon", () => {
    * 边界/异常：
    *  - 如未来提供渐进增强，需要同步更新断言。
    */
-  test("GivenMaskUnsupported_WhenRendering_ThenRenderFallbackSvg", () => {
+  test("GivenMaskUnsupported_WhenRendering_ThenRenderFallbackImage", () => {
     mockUseMaskSupport.mockReturnValueOnce(false);
 
     const { container } = render(<SendIcon className="icon" />);
 
-    expect(container.querySelector("svg")).not.toBeNull();
+    expect(
+      container.querySelector('img[data-icon-name="send-button"]'),
+    ).not.toBeNull();
   });
 
   /**
@@ -150,6 +154,8 @@ describe("SendIcon", () => {
     expect(fallback).toHaveBeenCalledWith({
       className: "icon",
       iconName: "send-button",
+      resource: null,
+      resolvedTheme: "light",
     });
 
     sendRegistry["send-button"] = originalEntry;

--- a/website/src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
+++ b/website/src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
@@ -106,6 +106,8 @@ describe("VoiceIcon", () => {
     expect(fallback).toHaveBeenCalledWith({
       className: "icon",
       iconName: "voice-button",
+      resource: null,
+      resolvedTheme: "light",
     });
 
     voiceRegistry["voice-button"] = originalEntry;
@@ -122,7 +124,7 @@ describe("VoiceIcon", () => {
    * 边界/异常：
    *  - 用例结束后恢复注册表。
    */
-  test("GivenEntryWithoutSingle_WhenRendering_ThenRenderFallback", () => {
+  test("GivenEntryWithoutSingle_WhenRendering_ThenRenderFallbackSvg", () => {
     const originalEntry = { ...voiceRegistry["voice-button"] };
     voiceRegistry["voice-button"] = {};
 
@@ -149,11 +151,13 @@ describe("VoiceIcon", () => {
    * 边界/异常：
    *  - 若未来引入渐进增强策略，此用例需同步调整断言。
    */
-  test("GivenMaskHookDisabled_WhenRendering_ThenRenderFallbackSvg", () => {
+  test("GivenMaskHookDisabled_WhenRendering_ThenRenderFallbackImage", () => {
     mockUseMaskSupport.mockReturnValueOnce(false);
 
     const { container } = render(<VoiceIcon className="icon" />);
 
-    expect(container.querySelector("svg")).not.toBeNull();
+    expect(
+      container.querySelector('img[data-icon-name="voice-button"]'),
+    ).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- update the masked icon factory to always resolve assets and pass them into fallbacks
- render chat input send/voice fallbacks with the new SVG assets when masks are unavailable while keeping SVG backups for registry gaps
- refresh unit tests to cover the new fallback contract and resource propagation

## Testing
- npm test -- --runTestsByPath src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e15542530883329857dc54710a6123