### PR TITLE
Align dictionary actions width with bottom search panel

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -254,16 +254,21 @@
 }
 
 .docker-inner {
-  width: min(100%, var(--sb-max-width));
+  width: var(
+    --docker-row-width,
+    min(100%, var(--sb-max-width))
+  );
 
   /*
-   * 背景：底部 docker 承载的搜索与释义区域需保持统一宽度比例，
-   *       避免在不同内容节点中重复硬编码宽度值。
-   * 取舍：通过暴露 --docker-row-width 变量，让子组件按需读取，
-   *       默认设置为父容器宽度的 90%，既满足本次需求又为未来调优保留入口。
+   * 背景：底部 docker 需要对搜索输入与释义操作提供一致的宽度基线，
+   *       过去直接下发 90% 宽度导致 SearchBox 与工具栏出现偏差与裁切。
+   * 取舍：通过集中定义 --docker-row-max-width 与 --docker-row-width，
+   *       让子组件统一消费“最大宽度 + 容器宽度”两类信号，既保证等宽，
+   *       又为未来在 Layout 处调整断点或内边距预留单一入口。
    */
 
-  --docker-row-width: 90%;
+  --docker-row-max-width: var(--sb-max-width);
+  --docker-row-width: min(100%, var(--docker-row-max-width));
 
   display: flex;
   flex-direction: column;
@@ -299,6 +304,8 @@
 
   .docker-inner {
     width: 100%;
+    --docker-row-max-width: 100%;
+    --docker-row-width: 100%;
   }
 }
 

--- a/website/src/components/OutputToolbar/OutputToolbar.module.css
+++ b/website/src/components/OutputToolbar/OutputToolbar.module.css
@@ -4,6 +4,7 @@
   align-items: center;
   justify-content: flex-start;
   gap: var(--space-3, 12px);
+  row-gap: var(--output-toolbar-row-gap, 0px);
   padding: 10px 12px;
   border-radius: var(--radius-xl, 16px);
   border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
@@ -12,9 +13,14 @@
     --shadow-elevated,
     0 12px 30px color-mix(in srgb, var(--shadow-color) 40%, transparent)
   );
-  overflow: hidden;
+  /*
+   * 背景：不同调用方的按钮数量与布局节奏差异较大，固定 hidden+nowrap 会导致溢出裁切。
+   * 取舍：开放 wrap/overflow/row-gap 三个变量，默认保持历史行为，
+   *       让新场景（如释义面板）仅通过变量覆写即可扩展布局策略。
+   */
+  overflow: var(--output-toolbar-overflow, hidden);
   min-height: 44px;
-  flex-wrap: nowrap;
+  flex-wrap: var(--output-toolbar-wrap, nowrap);
   width: 100%;
   box-sizing: border-box;
 

--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -1,12 +1,16 @@
 .container {
   /*
    * 背景：需要与释义面板共享宽度比例，确保 docker 栏内组件节奏统一。
-   * 取舍：优先读取 Layout 提供的 --docker-row-width，脱离 docker 时回退为 100%。
+   * 取舍：优先消费 Layout 集中下发的 --docker-row-width/--docker-row-max-width，
+   *       既保证搜索态与动作态的等宽，又在脱离 docker 时回落到 SearchBox 默认宽度。
    */
-  width: var(--docker-row-width, 100%);
+  width: var(
+    --docker-row-width,
+    min(100%, var(--sb-max-width))
+  );
   display: flex;
   justify-content: center;
-  max-width: var(--sb-max-width);
+  max-width: var(--docker-row-max-width, var(--sb-max-width));
   margin-inline: auto;
 }
 
@@ -30,6 +34,7 @@
     --sidebar-hover-bg,
     color-mix(in srgb, var(--sidebar-panel, var(--sb-surface)) 94%, white 6%)
   );
+  --sb-shell-width: 100%;
   --padding-y: 0;
   --slot-gap: 0;
 

--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -2,7 +2,12 @@
   position: relative;
   display: flex;
   align-items: center;
-  width: min(100%, var(--sb-max-width));
+  /*
+   * 背景：SearchBox 会嵌套于 ChatInput 与释义面板两种布局中，需要共享统一宽度约束。
+   * 取舍：通过 --sb-shell-width 让调用方显式传入壳层宽度，默认仍保持主题 token 的最小值，
+   *       避免组件内部出现多份“自我感知”逻辑并提升复用弹性。
+   */
+  width: var(--sb-shell-width, min(100%, var(--sb-max-width)));
   min-height: var(--sb-h, 56px);
   padding-block: var(--padding-y, 0);
   padding-inline: var(--sb-pad-x, 20px);

--- a/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
+++ b/website/src/features/dictionary-experience/components/DictionaryActionPanel.module.css
@@ -4,10 +4,13 @@
    * 关键取舍：通过读取 Layout 注入的 --docker-row-width 变量集中控制宽度，
    *           避免在父级分散样式并保持 SearchBox 的壳层解耦。
    */
-  width: var(--docker-row-width, 100%);
+  width: var(
+    --docker-row-width,
+    min(100%, var(--sb-max-width))
+  );
   display: flex;
   justify-content: center;
-  max-width: var(--sb-max-width);
+  max-width: var(--docker-row-max-width, var(--sb-max-width));
   margin-inline: auto;
 }
 
@@ -28,6 +31,7 @@
    * 取舍：将变量重置为 0，并在组件作用域内直接消费 ChatInput 的 padding-block 令牌，
    *       避免 SearchBox 与动作面板各自维护高度导致交互态跳动。
    */
+  --sb-shell-width: 100%;
   --padding-y: 0;
   --slot-gap: var(--chat-input-bottom-gap, 12px);
 
@@ -81,6 +85,18 @@
   width: 100%;
   align-items: center;
   flex-wrap: nowrap;
+
+  /*
+   * 背景：释义工具栏按钮数量随业务扩展而增长，原先的 nowrap+hidden 会裁切尾部动作。
+   * 取舍：通过向 OutputToolbar 注入 wrap/overflow 变量允许在必要时换行，
+   *       并保持默认 gap 设置由 SearchBox 继承，避免本地写死值。
+   */
+  --output-toolbar-wrap: wrap;
+  --output-toolbar-overflow: visible;
+  --output-toolbar-row-gap: var(
+    --dictionary-panel-toolbar-row-gap,
+    var(--chat-input-bottom-gap, 12px)
+  );
 
   /*
    * 背景：词典面板需与 ChatInput 搜索态共用壳层高度，防止 search/actions 切换出现高度闪烁。


### PR DESCRIPTION
## Summary
- centralize bottom docker width variables so chat input and dictionary actions read the same bounds
- let SearchBox consumers opt into explicit shell widths to keep the action panel aligned with the search box
- expose OutputToolbar wrap/overflow controls and enable wrapping inside the dictionary panel to stop button clipping

## Testing
- npm run lint --silent

------
https://chatgpt.com/codex/tasks/task_e_68e16615ac948332b68623a69010c26f