### PR TITLE
Fix stylelint spacing issues in CSS modules

### DIFF
--- a/website/src/components/Layout/Layout.module.css
+++ b/website/src/components/Layout/Layout.module.css
@@ -304,6 +304,7 @@
 
   .docker-inner {
     width: 100%;
+
     --docker-row-max-width: 100%;
     --docker-row-width: 100%;
   }

--- a/website/src/components/OutputToolbar/OutputToolbar.module.css
+++ b/website/src/components/OutputToolbar/OutputToolbar.module.css
@@ -4,7 +4,7 @@
   align-items: center;
   justify-content: flex-start;
   gap: var(--space-3, 12px);
-  row-gap: var(--output-toolbar-row-gap, 0px);
+  row-gap: var(--output-toolbar-row-gap, 0);
   padding: 10px 12px;
   border-radius: var(--radius-xl, 16px);
   border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
@@ -13,6 +13,7 @@
     --shadow-elevated,
     0 12px 30px color-mix(in srgb, var(--shadow-color) 40%, transparent)
   );
+
   /*
    * 背景：不同调用方的按钮数量与布局节奏差异较大，固定 hidden+nowrap 会导致溢出裁切。
    * 取舍：开放 wrap/overflow/row-gap 三个变量，默认保持历史行为，

--- a/website/src/components/ui/SearchBox/SearchBox.module.css
+++ b/website/src/components/ui/SearchBox/SearchBox.module.css
@@ -2,6 +2,7 @@
   position: relative;
   display: flex;
   align-items: center;
+
   /*
    * 背景：SearchBox 会嵌套于 ChatInput 与释义面板两种布局中，需要共享统一宽度约束。
    * 取舍：通过 --sb-shell-width 让调用方显式传入壳层宽度，默认仍保持主题 token 的最小值，


### PR DESCRIPTION
## Summary
- insert grouping whitespace before custom properties in responsive layout styles
- normalize zero-length unit usage and whitespace before comments in toolbar and search box styles to satisfy stylelint

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e16b1f80ec8332bbb496ec3cfb3ba5