### PR TITLE
fix: align sidebar brand icon color with navigation

### DIFF
--- a/website/src/components/Brand/index.jsx
+++ b/website/src/components/Brand/index.jsx
@@ -22,6 +22,14 @@ function PrimaryNavItem({ icon, iconAlt, label, onClick, isActive, title }) {
             width={20}
             height={20}
             className="primary-nav-item-icon-asset"
+            /*
+             * 背景：
+             *  - 侧边栏品牌入口沿用 muted → active 的色彩策略，若 ThemeIcon 使用默认语义类会强行套用文本色，
+             *    导致“格律词典”图标与同组按钮色调不一致。
+             * 取舍：
+             *  - 通过 roleClass="inherit" 沿用容器 color，使按钮状态机控制权回到 Brand 样式层，避免重复定义专用色值。
+             */
+            roleClass="inherit"
           />
         ) : null}
       </span>

--- a/website/src/components/Sidebar/NavItem.jsx
+++ b/website/src/components/Sidebar/NavItem.jsx
@@ -25,7 +25,20 @@ function renderIcon(icon, label) {
   }
   return (
     <span className={styles.icon} aria-hidden="true">
-      <ThemeIcon name={icon} alt={label} width={18} height={18} />
+      {/*
+       * 背景：
+       *  - ThemeIcon 默认附带 text-onsurface 语义类，导致侧边栏 muted → active 渐变被覆盖，
+       *    品牌图标呈现与其余导航图标产生色差。
+       * 目的：
+       *  - 显式声明 inherit 角色，让图标遵循容器 color 继承链，保持不同状态下的统一色板。
+       */}
+      <ThemeIcon
+        name={icon}
+        alt={label}
+        width={18}
+        height={18}
+        roleClass="inherit"
+      />
     </span>
   );
 }

--- a/website/src/components/ui/Icon/__tests__/ThemeIcon.test.jsx
+++ b/website/src/components/ui/Icon/__tests__/ThemeIcon.test.jsx
@@ -63,7 +63,7 @@ describe("ThemeIcon", () => {
   test("renders single-source icon with semantic role class", () => {
     render(<ThemeIcon name="glancy-web" alt="brand" />);
     const icon = screen.getByRole("img", { name: "brand" });
-    expect(icon.innerHTML).toContain("data-icon=\"glancy\"");
+    expect(icon.innerHTML).toContain('data-icon="glancy"');
     expect(icon.className).toContain("text-onsurface");
   });
 
@@ -83,7 +83,7 @@ describe("ThemeIcon", () => {
     currentTheme = "light";
     render(<ThemeIcon name="apple" alt="apple" />);
     const icon = screen.getByRole("img", { name: "apple" });
-    expect(icon.innerHTML).toContain("data-variant=\"light\"");
+    expect(icon.innerHTML).toContain('data-variant="light"');
   });
 
   /**
@@ -102,7 +102,7 @@ describe("ThemeIcon", () => {
     currentTheme = "dark";
     render(<ThemeIcon name="apple" alt="apple" />);
     const icon = screen.getByRole("img", { name: "apple" });
-    expect(icon.innerHTML).toContain("data-variant=\"dark\"");
+    expect(icon.innerHTML).toContain('data-variant="dark"');
   });
 
   /**
@@ -158,6 +158,23 @@ describe("ThemeIcon", () => {
     render(<ThemeIcon name="glancy-web" alt="brand" roleClass="danger" />);
     const icon = screen.getByRole("img", { name: "brand" });
     expect(icon.className).toContain("text-ondanger");
+  });
+
+  /**
+   * 测试目标：当 roleClass 指定为 inherit 时不再覆盖外层 color，保证侧边栏等场景的色彩继承链一致。
+   * 前置条件：roleClass="inherit"；iconRegistry 存在 glancy-web 的 single 资源。
+   * 步骤：
+   *  1) 渲染 ThemeIcon，并传入 roleClass="inherit"；
+   *  2) 获取 role="img" 元素；
+   * 断言：
+   *  - className 不包含 text-onsurface（即未注入语义色类名）。
+   * 边界/异常：
+   *  - inherit 仅跳过语义色注入，其余属性保持默认处理。
+   */
+  test("skips semantic role classes when inherit is requested", () => {
+    render(<ThemeIcon name="glancy-web" alt="brand" roleClass="inherit" />);
+    const icon = screen.getByRole("img", { name: "brand" });
+    expect(icon.className).not.toContain("text-onsurface");
   });
 
   /**

--- a/website/src/components/ui/Icon/index.tsx
+++ b/website/src/components/ui/Icon/index.tsx
@@ -28,6 +28,16 @@ const ROLE_CLASSNAME_MAP = Object.freeze({
   success: "text-onsuccess",
   warning: "text-onwarning",
   danger: "text-ondanger",
+  /**
+   * 背景：
+   *  - 侧边栏导航希望沿用自身的 muted → active 渐进策略，但默认 role class 会强行套用主题前景色，
+   *    导致品牌图标颜色与其他 icon 不一致。
+   * 目的：
+   *  - 提供显式的 inherit 角色以跳过语义色注入，让上层容器的 color 继承链能够生效。
+   * 取舍：
+   *  - 相比引入布尔开关（如 inheritColor），直接纳入角色映射可沿用既有策略模式与类型约束。
+   */
+  inherit: "",
 });
 
 type IconRoleClass = keyof typeof ROLE_CLASSNAME_MAP;
@@ -173,7 +183,8 @@ const pickRenderableAsset = (variant: IconVariantResource | null) => {
   if (!variant) {
     return { inline: null, url: null };
   }
-  const inline = variant.inline && variant.inline.length > 0 ? variant.inline : null;
+  const inline =
+    variant.inline && variant.inline.length > 0 ? variant.inline : null;
   const url = variant.url && variant.url.length > 0 ? variant.url : null;
   return { inline, url };
 };


### PR DESCRIPTION
## Summary
- add an explicit `inherit` role option to ThemeIcon so callers can opt out of semantic color overrides
- request inherited coloring for sidebar navigation icons to keep the brand glyph in sync with neighboring items
- cover the new inherit behavior with a ThemeIcon unit test and adjust existing snapshots to the normalized format

## Testing
- npm test -- ThemeIcon
- npx eslint src/components/ui/Icon/index.tsx src/components/Sidebar/NavItem.jsx src/components/Brand/index.jsx src/components/ui/Icon/__tests__/ThemeIcon.test.jsx --fix
- npx stylelint "src/**/*.css" --fix
- npx prettier -w src/components/ui/Icon/index.tsx src/components/Sidebar/NavItem.jsx src/components/Brand/index.jsx src/components/ui/Icon/__tests__/ThemeIcon.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e17efd90148332b8b397b7e74de85c