### PR TITLE
fix: align ChatInput action icons with light theme palette

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -246,7 +246,7 @@
    * 背景：通过 CSS 变量统一动作按钮的填充与阴影，语音/发送共享壳层策略，方便后续扩展更多态。
    */
   --action-btn-bg: transparent;
-  --action-btn-color: var(--sb-icon);
+  --action-btn-color: var(--sb-action-icon, var(--sb-icon));
   --action-btn-shadow: none;
 
   background: var(--action-btn-bg);
@@ -294,7 +294,10 @@
 }
 
 .action-button-voice {
-  color: var(--sb-icon);
+  --action-btn-color: var(
+    --sb-voice-color,
+    var(--sb-action-icon, var(--sb-icon))
+  );
 }
 
 .action-button-voice[aria-pressed="true"] {
@@ -312,13 +315,13 @@
 .action-button-voice:hover,
 .action-button-voice:focus-visible {
   background: var(--action-btn-bg);
-  color: var(--sb-icon);
+  color: var(--action-btn-color);
   box-shadow: var(--sb-cta-shadow-hover, var(--sb-cta-shadow));
 }
 
 .action-button-voice:active {
   background: var(--action-btn-bg);
-  color: var(--sb-icon);
+  color: var(--action-btn-color);
   box-shadow: var(--sb-cta-shadow);
 }
 
@@ -339,6 +342,7 @@
   width: 18px;
   height: 18px;
   display: block;
+  color: inherit;
 }
 
 .submit-proxy {

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -53,8 +53,10 @@
   --sb-text: #edeff2;
   --sb-muted: #9fa7b3;
   --sb-icon: #edeff2;
+  --sb-action-icon: var(--sb-icon);
   --sb-cta: #fff;
   --sb-cta-icon: #0e1116;
+  --sb-voice-color: var(--sb-icon);
 
   /*
    * search bar 在桌面稿中的最大内容宽度，统一复用布局主内容宽度令牌，
@@ -191,8 +193,10 @@
   --sb-text: var(--color-text);
   --sb-muted: color-mix(in srgb, var(--color-text) 58%, transparent 42%);
   --sb-icon: var(--color-text);
+  --sb-action-icon: var(--primary-color);
   --sb-cta: var(--primary-bg);
   --sb-cta-icon: var(--primary-color);
+  --sb-voice-color: var(--primary-color);
   --sb-border: var(--sb-stroke);
   --sb-border-active: color-mix(
     in srgb,
@@ -288,8 +292,10 @@
   --sb-text: var(--color-text);
   --sb-muted: color-mix(in srgb, var(--color-text) 58%, transparent 42%);
   --sb-icon: var(--color-text);
+  --sb-action-icon: var(--primary-color);
   --sb-cta: var(--primary-bg);
   --sb-cta-icon: var(--primary-color);
+  --sb-voice-color: var(--primary-color);
   --sb-border: var(--sb-stroke);
   --sb-border-active: color-mix(
     in srgb,
@@ -382,8 +388,10 @@
   --sb-text: #edeff2;
   --sb-muted: #9fa7b3;
   --sb-icon: #edeff2;
+  --sb-action-icon: var(--sb-icon);
   --sb-cta: #fff;
   --sb-cta-icon: #0e1116;
+  --sb-voice-color: var(--sb-icon);
   --sb-border: var(--sb-stroke);
   --sb-border-active: color-mix(in srgb, var(--sb-stroke) 60%, white 40%);
   --sb-bg: var(--sidebar-panel, var(--sb-surface));


### PR DESCRIPTION
## Summary
- introduce light theme overrides for ChatInput action icon tokens so the assets render in white
- have the ChatInput action button styles consume the new tokens and inherit the themed color states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1850940588332937b41d7d7ac2f65