### PR TITLE
fix: 调整 light 主题聊天动作按钮对比度

### DIFF
--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -195,13 +195,13 @@
   --sb-icon: var(--color-text);
 
   /*
-   * 交互背景：轻量主题下沿用白色系 CTA 壳体，避免深色按钮在浅底部产生突兀对比。
-   * 取舍：统一将 send/voice 按钮映射到中性白底 + 深色图标，保持与暗色主题的一致语义。
+   * 交互背景：轻量主题需在浅色面板上提供足够对比度，语音/发送按钮统一使用深色壳体。
+   * 取舍：按钮底色改为接近中性黑，图标采用反相白，维持与暗色主题互为对偶的语义层级。
    */
   --sb-action-icon: var(--color-text);
   --sb-cta: color-mix(in srgb, var(--neutral-0) 96%, transparent 4%);
   --sb-cta-icon: var(--color-text);
-  --sb-voice-color: var(--color-text);
+  --sb-voice-color: var(--text-inverse-light);
   --sb-border: var(--sb-stroke);
   --sb-border-active: color-mix(
     in srgb,
@@ -276,8 +276,8 @@
     var(--menu-scroll-thumb) 85%,
     transparent 15%
   );
-  --sb-send-bg: color-mix(in srgb, var(--neutral-0) 94%, transparent 6%);
-  --sb-send-color: var(--color-text);
+  --sb-send-bg: color-mix(in srgb, var(--neutral-950) 92%, transparent 8%);
+  --sb-send-color: var(--text-inverse-light);
   --sb-cta-shadow: 0 18px 40px
     color-mix(in srgb, var(--shadow-color) 55%, transparent 45%);
   --sb-cta-shadow-hover: 0 22px 48px
@@ -299,12 +299,12 @@
   --sb-icon: var(--color-text);
 
   /*
-   * system 模式在浅色媒体查询下与 light 对齐，CTA 壳体同样采用白色系映射。
+   * system 模式在浅色媒体查询下复用 light 策略，确保语音/发送按钮对比度一致。
    */
   --sb-action-icon: var(--color-text);
   --sb-cta: color-mix(in srgb, var(--neutral-0) 96%, transparent 4%);
   --sb-cta-icon: var(--color-text);
-  --sb-voice-color: var(--color-text);
+  --sb-voice-color: var(--text-inverse-light);
   --sb-border: var(--sb-stroke);
   --sb-border-active: color-mix(
     in srgb,
@@ -379,8 +379,8 @@
     var(--menu-scroll-thumb) 85%,
     transparent 15%
   );
-  --sb-send-bg: color-mix(in srgb, var(--neutral-0) 94%, transparent 6%);
-  --sb-send-color: var(--color-text);
+  --sb-send-bg: color-mix(in srgb, var(--neutral-950) 92%, transparent 8%);
+  --sb-send-color: var(--text-inverse-light);
   --sb-cta-shadow: 0 18px 40px
     color-mix(in srgb, var(--shadow-color) 55%, transparent 45%);
   --sb-cta-shadow-hover: 0 22px 48px


### PR DESCRIPTION
## Summary
- 调整 light/system 主题下 send/voice 动作按钮的背景为深色圆形并切换图标为反白
- 保持 dark 主题白色圆形背景不变以维持两套主题的对偶对比

## Testing
- npx prettier -w src/theme/variables.css
- npx stylelint "src/**/*.css" --fix
- npx eslint . --fix

------
https://chatgpt.com/codex/tasks/task_e_68e18cad78b0833291ada2306f0645ab