### PR TITLE
Fix chat action icons for light theme contrast

### DIFF
--- a/website/src/components/ui/ChatInput/icons/SendIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/SendIcon.jsx
@@ -14,6 +14,7 @@
 import PropTypes from "prop-types";
 
 import sendButtonAsset from "@/assets/send-button.svg";
+import sendButtonInline from "@/assets/send-button.svg?raw";
 
 import renderStaticIcon from "./renderStaticIcon.jsx";
 
@@ -23,6 +24,7 @@ export default function SendIcon({ className }) {
   return renderStaticIcon({
     className,
     iconName: SEND_ICON_NAME,
+    inline: sendButtonInline,
     src: sendButtonAsset,
   });
 }

--- a/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/VoiceIcon.jsx
@@ -14,6 +14,7 @@
 import PropTypes from "prop-types";
 
 import voiceButtonAsset from "@/assets/voice-button.svg";
+import voiceButtonInline from "@/assets/voice-button.svg?raw";
 
 import renderStaticIcon from "./renderStaticIcon.jsx";
 
@@ -23,6 +24,7 @@ export default function VoiceIcon({ className }) {
   return renderStaticIcon({
     className,
     iconName: VOICE_ICON_NAME,
+    inline: voiceButtonInline,
     src: voiceButtonAsset,
   });
 }

--- a/website/src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx
+++ b/website/src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx
@@ -6,9 +6,9 @@ import { jest } from "@jest/globals";
  * 背景：
  *  - SendIcon 改用静态 SVG 渲染后，需要验证 data 标识与资源引用是否保持一致。
  * 目的：
- *  - 确保发送按钮输出可访问的 img 元素，并暴露语义化属性便于样式与测试复用。
+ *  - 确保发送按钮输出可继承主题色的 inline SVG，并暴露语义化属性便于样式与测试复用。
  * 关键决策与取舍：
- *  - 通过资源 mock 固定 src，聚焦结构与属性校验，避免依赖真实打包路径。
+ *  - 通过资源 mock 固定 inline 内容，聚焦结构与属性校验，避免依赖真实打包路径。
  * 影响范围：
  *  - ChatInput 发送按钮的展示层稳定性回归验证。
  * 演进与TODO：
@@ -20,30 +20,36 @@ jest.unstable_mockModule("@/assets/send-button.svg", () => ({
   default: "send-asset.svg",
 }));
 
+jest.unstable_mockModule("@/assets/send-button.svg?raw", () => ({
+  __esModule: true,
+  default: "<svg data-token=\"send-inline\"></svg>",
+}));
+
 const { default: SendIcon } = await import("../SendIcon.jsx");
 
 describe("SendIcon", () => {
   /**
-   * 测试目标：渲染发送图标时应输出带有语义标记的 img 元素。
+   * 测试目标：渲染发送图标时应输出带有语义标记的 inline 节点。
    * 前置条件：传入标准 className。
    * 步骤：
    *  1) 渲染组件并查询 data-icon 节点。
    *  2) 校验元素标签与关键属性。
    * 断言：
-   *  - 返回 IMG 元素，包含 data-icon-name 与 src。
-   *  - alt 为空且 aria-hidden=true，符合装饰图标要求。
+   *  - 返回 inline 节点并标记 data-render-mode=inline。
+   *  - 节点输出非空 inline 内容且 aria-hidden=true，符合装饰图标要求。
    * 边界/异常：
    *  - 若未来需要可见文本，应同步调整此断言。
    */
-  test("GivenClassName_WhenRendering_ThenExposeStaticImage", () => {
+  test("GivenClassName_WhenRendering_ThenPreferInlinePayload", () => {
     const { container } = render(<SendIcon className="icon" />);
 
-    const node = container.querySelector('img[data-icon-name="send-button"]');
+    const node = container.querySelector('[data-icon-name="send-button"]');
 
     expect(node).not.toBeNull();
-    expect(node?.tagName).toBe("IMG");
-    expect(node?.getAttribute("src")).toBe("send-asset.svg");
-    expect(node?.getAttribute("alt")).toBe("");
+    expect(node?.tagName).toBe("SPAN");
+    expect(node?.getAttribute("data-render-mode")).toBe("inline");
+    expect(node?.getAttribute("src")).toBeNull();
+    expect(node?.innerHTML).not.toHaveLength(0);
     expect(node?.getAttribute("aria-hidden")).toBe("true");
     expect(node?.classList.contains("icon")).toBe(true);
   });

--- a/website/src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
+++ b/website/src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
@@ -6,9 +6,9 @@ import { jest } from "@jest/globals";
  * 背景：
  *  - VoiceIcon 现采用静态 SVG 方案，需校验语义属性是否与发送按钮保持一致。
  * 目的：
- *  - 确保语音按钮渲染出 img 元素并标记为 voice-button，避免回退逻辑残留。
+ *  - 确保语音按钮渲染出可继承主题色的 inline SVG，并标记为 voice-button，避免回退逻辑残留。
  * 关键决策与取舍：
- *  - 模拟资源导入以固定 src，聚焦节点结构验证。
+ *  - 模拟资源导入以固定 inline 内容，聚焦节点结构验证。
  * 影响范围：
  *  - ChatInput 语音态按钮视觉回归测试。
  * 演进与TODO：
@@ -20,30 +20,36 @@ jest.unstable_mockModule("@/assets/voice-button.svg", () => ({
   default: "voice-asset.svg",
 }));
 
+jest.unstable_mockModule("@/assets/voice-button.svg?raw", () => ({
+  __esModule: true,
+  default: "<svg data-token=\"voice-inline\"></svg>",
+}));
+
 const { default: VoiceIcon } = await import("../VoiceIcon.jsx");
 
 describe("VoiceIcon", () => {
   /**
-   * 测试目标：语音图标应渲染装饰性 img 元素并正确暴露 data 属性。
+   * 测试目标：语音图标应渲染装饰性 inline 节点并正确暴露 data 属性。
    * 前置条件：传入标准 className。
    * 步骤：
    *  1) 渲染组件后查询 voice-button 节点。
    *  2) 校验属性与类名。
    * 断言：
-   *  - 节点为 IMG，且 src 指向模拟资源。
-   *  - alt 为空并设置 aria-hidden=true。
+   *  - 节点为 inline 容器且标记 data-render-mode=inline。
+   *  - 节点输出非空 inline 内容并设置 aria-hidden=true。
    * 边界/异常：
    *  - 暂无额外分支，未来如增加可视文案需同步调整。
    */
-  test("GivenClassName_WhenRendering_ThenExposeStaticImage", () => {
+  test("GivenClassName_WhenRendering_ThenPreferInlinePayload", () => {
     const { container } = render(<VoiceIcon className="icon" />);
 
-    const node = container.querySelector('img[data-icon-name="voice-button"]');
+    const node = container.querySelector('[data-icon-name="voice-button"]');
 
     expect(node).not.toBeNull();
-    expect(node?.tagName).toBe("IMG");
-    expect(node?.getAttribute("src")).toBe("voice-asset.svg");
-    expect(node?.getAttribute("alt")).toBe("");
+    expect(node?.tagName).toBe("SPAN");
+    expect(node?.getAttribute("data-render-mode")).toBe("inline");
+    expect(node?.getAttribute("src")).toBeNull();
+    expect(node?.innerHTML).not.toHaveLength(0);
     expect(node?.getAttribute("aria-hidden")).toBe("true");
     expect(node?.classList.contains("icon")).toBe(true);
   });

--- a/website/src/components/ui/ChatInput/icons/renderStaticIcon.jsx
+++ b/website/src/components/ui/ChatInput/icons/renderStaticIcon.jsx
@@ -5,20 +5,45 @@
  *  - 提供纯函数帮助，以组合方式复用 img 渲染逻辑，同时保持与旧遮罩方案完全解耦。
  * 关键决策与取舍：
  *  - 使用最小化的模板函数而非组件包装，避免在调试时引入额外节点层级。
+ *  - 优先渲染 inline SVG，以便继承 currentColor，从而契合浅色主题的反相需求；
+ *    若缺失 inline 资源则回退到静态图片，保持对历史资产的兼容。
  * 影响范围：
  *  - 当前仅服务 SendIcon 与 VoiceIcon，未来扩展静态图标时可继续复用。
  * 演进与TODO：
  *  - 若需要根据主题切换资源，可在调用侧扩展 src 选择逻辑后传入此函数。
  */
-export default function renderStaticIcon({ className, iconName, src }) {
-  return (
-    <img
-      alt=""
-      aria-hidden="true"
-      className={className}
-      data-icon-name={iconName}
-      draggable={false}
-      src={src}
-    />
-  );
+const hasInlinePayload = (payload) =>
+  typeof payload === "string" && Boolean(payload.trim());
+
+const renderInlineVariant = ({ className, iconName, inline }) => (
+  <span
+    aria-hidden="true"
+    className={className}
+    data-icon-name={iconName}
+    data-render-mode="inline"
+    dangerouslySetInnerHTML={{ __html: inline }}
+    draggable={false}
+  />
+);
+
+const renderImageVariant = ({ className, iconName, src }) => (
+  <img
+    alt=""
+    aria-hidden="true"
+    className={className}
+    data-icon-name={iconName}
+    data-render-mode="image"
+    draggable={false}
+    src={src}
+  />
+);
+
+export default function renderStaticIcon({ className, iconName, src, inline }) {
+  if (hasInlinePayload(inline)) {
+    return renderInlineVariant({ className, iconName, inline });
+  }
+  if (src) {
+    return renderImageVariant({ className, iconName, src });
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
- import inline SVG payloads for the chat send and voice icons so they follow the action button theme colors
- extend the shared static icon renderer with an inline-first strategy while keeping image fallback support
- update unit tests to verify the inline rendering contract for send and voice icons

## Testing
- npm test -- --runTestsByPath src/components/ui/ChatInput/icons/__tests__/SendIcon.test.jsx src/components/ui/ChatInput/icons/__tests__/VoiceIcon.test.jsx
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e2257b1cc4833290042d9ad5b22d37