### PR TITLE
fix: map chat action fallbacks to neutral token

### DIFF
--- a/website/src/theme/__tests__/variablesTokens.test.ts
+++ b/website/src/theme/__tests__/variablesTokens.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+
+const readVariablesCss = () => {
+  const fileUrl = new URL("../variables.css", import.meta.url);
+  return fs.readFileSync(fileUrl, "utf8");
+};
+
+const extractThemeBlock = (css: string, selector: string) => {
+  const selectorIndex = css.indexOf(selector);
+  if (selectorIndex === -1) {
+    return "";
+  }
+
+  const blockStart = css.indexOf("{", selectorIndex);
+  if (blockStart === -1) {
+    return "";
+  }
+
+  let depth = 0;
+  for (let cursor = blockStart; cursor < css.length; cursor += 1) {
+    const char = css[cursor];
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return css.slice(blockStart + 1, cursor);
+      }
+    }
+  }
+
+  return "";
+};
+
+describe("theme variable mappings", () => {
+  /**
+   * 测试目标：验证浅色主题下语音/发送按钮图标色令牌映射到反相文字语义，避免黑色图标叠加深色底。 
+   * 前置条件：无，直接读取 CSS 变量定义。 
+   * 步骤：
+   *  1) 读取 variables.css 文件内容。
+   *  2) 抽取 light 主题代码块。
+   *  3) 判断 voice/send 颜色变量是否指向 color-text-inverse，并具备 neutral-0 令牌兜底。
+   * 断言：变量字符串同时包含 color-text-inverse 与 neutral-0，缺失时提示具体变量名称。
+   * 边界/异常：若匹配失败返回空字符串，断言会明确说明未捕获到对应主题块。
+   */
+  it("Given light theme tokens When reading send/voice colors Then they map to inverse text", () => {
+    const css = readVariablesCss();
+    const lightBlock = extractThemeBlock(css, ':root[data-theme="light"]');
+
+    expect(lightBlock.length).toBeGreaterThan(0);
+    expect(lightBlock).toMatch(
+      /--sb-voice-color: var\(\s*--color-text-inverse,\s*var\(--neutral-0\)\s*\);/u,
+    );
+    expect(lightBlock).toMatch(
+      /--sb-send-color: var\(\s*--color-text-inverse,\s*var\(--neutral-0\)\s*\);/u,
+    );
+  });
+});

--- a/website/src/theme/variables.css
+++ b/website/src/theme/variables.css
@@ -201,7 +201,15 @@
   --sb-action-icon: var(--color-text);
   --sb-cta: color-mix(in srgb, var(--neutral-0) 96%, transparent 4%);
   --sb-cta-icon: var(--color-text);
-  --sb-voice-color: var(--text-inverse-light);
+  /*
+   * 语音/发送按钮在浅色主题下采用深色壳体，为避免再度出现黑色前景与黑底冲突，
+   * 这里将前景显式映射到“反相文字”语义，并通过 neutral-0 令牌兜底，
+   * 以保证在未引入 colors.css 的隔离样式中依旧能读取到正确颜色。
+   */
+  --sb-voice-color: var(
+    --color-text-inverse,
+    var(--neutral-0)
+  );
   --sb-border: var(--sb-stroke);
   --sb-border-active: color-mix(
     in srgb,
@@ -277,7 +285,10 @@
     transparent 15%
   );
   --sb-send-bg: color-mix(in srgb, var(--neutral-950) 92%, transparent 8%);
-  --sb-send-color: var(--text-inverse-light);
+  --sb-send-color: var(
+    --color-text-inverse,
+    var(--neutral-0)
+  );
   --sb-cta-shadow: 0 18px 40px
     color-mix(in srgb, var(--shadow-color) 55%, transparent 45%);
   --sb-cta-shadow-hover: 0 22px 48px
@@ -304,7 +315,10 @@
   --sb-action-icon: var(--color-text);
   --sb-cta: color-mix(in srgb, var(--neutral-0) 96%, transparent 4%);
   --sb-cta-icon: var(--color-text);
-  --sb-voice-color: var(--text-inverse-light);
+  --sb-voice-color: var(
+    --color-text-inverse,
+    var(--neutral-0)
+  );
   --sb-border: var(--sb-stroke);
   --sb-border-active: color-mix(
     in srgb,
@@ -380,7 +394,10 @@
     transparent 15%
   );
   --sb-send-bg: color-mix(in srgb, var(--neutral-950) 92%, transparent 8%);
-  --sb-send-color: var(--text-inverse-light);
+  --sb-send-color: var(
+    --color-text-inverse,
+    var(--neutral-0)
+  );
   --sb-cta-shadow: 0 18px 40px
     color-mix(in srgb, var(--shadow-color) 55%, transparent 45%);
   --sb-cta-shadow-hover: 0 22px 48px


### PR DESCRIPTION
## Summary
- remove the literal #fff fallback from the ChatInput send/voice color tokens and rely on the neutral-0 token to keep the inverse semantic
- update the light theme regression test to assert the neutral-0 fallback instead of the hard-coded value

## Testing
- npm test -- --runTestsByPath src/theme/__tests__/variablesTokens.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2392d33648332af73dc0049ec2b3e