### PR TITLE
Refactor favicon bootstrap to reuse existing asset

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,31 +6,14 @@
       id="favicon"
       rel="icon"
       type="image/svg+xml"
-      href="/src/assets/brand/glancy-web-light.svg"
+      href="/src/assets/glancy-web.svg"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>格律词典</title>
+    <script type="module" src="/src/theme/bootstrapBrowserEnvironment.ts"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script>
-      (function () {
-        const storedLang = localStorage.getItem("lang");
-        if (storedLang) {
-          document.documentElement.lang = storedLang;
-        }
-        const theme = localStorage.getItem("theme") || "system";
-        const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        const resolved = theme === "system" ? (dark ? "dark" : "light") : theme;
-        document.documentElement.dataset.theme = resolved;
-        const link = document.getElementById("favicon");
-        if (link) {
-          link.href = dark
-            ? "/src/assets/brand/glancy-web-dark.svg"
-            : "/src/assets/brand/glancy-web-light.svg";
-        }
-      })();
-    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/website/jest.config.js
+++ b/website/jest.config.js
@@ -5,6 +5,7 @@ export default {
     "^@/(.*)$": "<rootDir>/src/$1",
     "^(\\.{1,2}/.*)\\.js$": "$1",
     "^.+\\.css$": "identity-obj-proxy",
+    "^.+\\.svg\\?raw$": "<rootDir>/test/__mocks__/rawSvgMock.cjs",
     "^.+\\.(svg)$": "<rootDir>/test/__mocks__/fileMock.cjs",
   },
   extensionsToTreatAsEsm: [".ts", ".tsx", ".jsx"],

--- a/website/src/theme/__tests__/browserFaviconConfigurator.test.ts
+++ b/website/src/theme/__tests__/browserFaviconConfigurator.test.ts
@@ -1,0 +1,141 @@
+import { createBrowserFaviconConfigurator } from "@/theme/browserFaviconConfigurator";
+import { createFaviconRegistry } from "@/theme/faviconRegistry";
+
+type MutableMediaQueryList = MediaQueryList & {
+  dispatch: (matches: boolean) => void;
+  listeners: Array<(event: MediaQueryListEvent) => void>;
+};
+
+const createMediaQuery = (initialMatches: boolean): MutableMediaQueryList => {
+  let matches = initialMatches;
+  const media: Partial<MutableMediaQueryList> = {
+    media: "(prefers-color-scheme: dark)",
+    matches,
+    listeners: [],
+    addEventListener(type: string, listener: (event: MediaQueryListEvent) => void) {
+      if (type === "change") {
+        media.listeners?.push(listener);
+      }
+    },
+    removeEventListener(type: string, listener: (event: MediaQueryListEvent) => void) {
+      if (type === "change" && media.listeners) {
+        media.listeners = media.listeners.filter((item) => item !== listener);
+      }
+    },
+    dispatch(nextMatch: boolean) {
+      matches = nextMatch;
+      media.matches = nextMatch;
+      for (const listener of media.listeners ?? []) {
+        listener({
+          matches: nextMatch,
+          media: media.media ?? "",
+        } as MediaQueryListEvent);
+      }
+    },
+  };
+
+  return media as MutableMediaQueryList;
+};
+
+describe("BrowserFaviconConfigurator", () => {
+  const registry = createFaviconRegistry({
+    default: "https://assets.local/light.svg",
+    light: "https://assets.local/light.svg",
+    dark: "https://assets.local/dark.svg",
+  });
+
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * 测试目标：在浏览器暗色主题下应立即切换到白色 favicon。
+   * 前置条件：存在 id 为 favicon 的 link 节点，媒体查询初始匹配暗色。
+   * 步骤：
+   *  1) 启动配置器；
+   *  2) 观察 link 属性。
+   * 断言：
+   *  - href 指向暗色资源；
+   *  - dataset.browserColorScheme === "dark"。
+   * 边界/异常：
+   *  - 验证不会抛出异常。
+   */
+  test("Given_dark_preference_When_starting_Then_apply_dark_icon", () => {
+    document.head.innerHTML =
+      '<link id="favicon" rel="icon" href="https://assets.local/light.svg" />';
+    const media = createMediaQuery(true);
+    const configurator = createBrowserFaviconConfigurator({
+      registry,
+      matchMedia: () => media,
+      document,
+    });
+
+    expect(() => configurator.start()).not.toThrow();
+
+    const link = document.getElementById("favicon");
+    expect(link).toBeInstanceOf(HTMLLinkElement);
+    expect((link as HTMLLinkElement).href).toBe("https://assets.local/dark.svg");
+    expect((link as HTMLLinkElement).dataset.browserColorScheme).toBe("dark");
+  });
+
+  /**
+   * 测试目标：媒体查询变化时应同步切换到对应 favicon。
+   * 前置条件：已启动配置器，初始为暗色匹配。
+   * 步骤：
+   *  1) 触发媒体查询变更为亮色；
+   *  2) 检查 link 属性；
+   *  3) 调用 stop 并确认监听被移除。
+   * 断言：
+   *  - href 更新为亮色资源；
+   *  - dataset.browserColorScheme === "light"；
+   *  - 停止后监听列表为空。
+   * 边界/异常：
+   *  - 覆盖 stop 释放监听的路径。
+   */
+  test("Given_media_change_When_dispatching_Then_update_icon_and_detach_on_stop", () => {
+    document.head.innerHTML =
+      '<link id="favicon" rel="icon" href="https://assets.local/light.svg" />';
+    const media = createMediaQuery(true);
+    const configurator = createBrowserFaviconConfigurator({
+      registry,
+      matchMedia: () => media,
+      document,
+    });
+
+    configurator.start();
+    media.dispatch(false);
+
+    const link = document.getElementById("favicon");
+    expect((link as HTMLLinkElement).href).toBe("https://assets.local/light.svg");
+    expect((link as HTMLLinkElement).dataset.browserColorScheme).toBe("light");
+
+    configurator.stop();
+    expect(media.listeners).toHaveLength(0);
+  });
+
+  /**
+   * 测试目标：缺失 favicon link 时不应抛错或注册监听。
+   * 前置条件：文档中不存在 id=missing 元素。
+   * 步骤：
+   *  1) 启动配置器；
+   *  2) 检查媒体查询监听状态。
+   * 断言：
+   *  - media.listeners 长度保持 0；
+   *  - start 返回后未抛异常。
+   * 边界/异常：
+   *  - 验证容错路径。
+   */
+  test("Given_missing_link_When_starting_Then_fail_silently", () => {
+    const media = createMediaQuery(true);
+    const configurator = createBrowserFaviconConfigurator({
+      registry,
+      matchMedia: () => media,
+      document,
+      linkId: "missing",
+    });
+
+    expect(() => configurator.start()).not.toThrow();
+    expect(media.listeners).toHaveLength(0);
+  });
+});

--- a/website/src/theme/__tests__/browserFaviconManifest.test.ts
+++ b/website/src/theme/__tests__/browserFaviconManifest.test.ts
@@ -1,0 +1,60 @@
+const baseGlancyWebSvg = "<svg><rect fill='currentColor'/></svg>";
+import {
+  buildBrowserFaviconManifest,
+  createBrowserFaviconRegistry,
+  ensureBrowserFaviconManifest,
+  getBrowserFaviconBaseSvgGlobalKey,
+  getBrowserFaviconManifestGlobalKey,
+  setBrowserFaviconBaseSvg,
+} from "@/theme/browserFaviconManifest";
+
+/**
+ * 测试目标：使用默认调色板构建 manifest 时应生成黑白两款数据 URI。
+ * 前置条件：提供原始 glancy-web.svg 文本。
+ * 步骤：
+ *  1) 调用 buildBrowserFaviconManifest；
+ *  2) 校验浅色与深色条目。
+ * 断言：
+ *  - light/default 包含 %23000000；
+ *  - dark 包含 %23ffffff；
+ * 边界/异常：
+ *  - 验证返回结构包含所需键值。
+ */
+ test("Given_default_palette_When_building_manifest_Then_generate_black_and_white_icons", () => {
+   const manifest = buildBrowserFaviconManifest(baseGlancyWebSvg);
+   expect(manifest.light).toContain("%23000000");
+   expect(manifest.default).toBe(manifest.light);
+   expect(manifest.dark).toContain("%23ffffff");
+ });
+
+/**
+ * 测试目标：ensureBrowserFaviconManifest 应复用全局缓存并供注册表解析。
+ * 前置条件：准备隔离的全局对象。
+ * 步骤：
+ *  1) 首次调用 ensureBrowserFaviconManifest；
+ *  2) 再次调用验证缓存；
+ *  3) 使用 createBrowserFaviconRegistry 解析浏览器配色。
+ * 断言：
+ *  - 两次返回同一引用；
+ *  - 全局对象挂载 manifest；
+ *  - 注册表可解析 dark/light。
+ * 边界/异常：
+ *  - 覆盖无浏览器环境时的降级全局。
+ */
+ test("Given_isolated_global_When_ensuring_manifest_Then_cache_and_resolve_through_registry", () => {
+   const mockGlobal: Record<string, unknown> = {};
+   setBrowserFaviconBaseSvg(mockGlobal, baseGlancyWebSvg);
+   const manifestA = ensureBrowserFaviconManifest(mockGlobal);
+   const manifestB = ensureBrowserFaviconManifest(mockGlobal);
+   expect(manifestA).toBe(manifestB);
+
+   const manifestKey = getBrowserFaviconManifestGlobalKey();
+   expect(mockGlobal[manifestKey]).toBe(manifestA);
+
+   const baseKey = getBrowserFaviconBaseSvgGlobalKey();
+    expect(mockGlobal[baseKey]).toBe(baseGlancyWebSvg);
+
+   const registry = createBrowserFaviconRegistry(mockGlobal);
+   expect(registry.resolve("dark")).toBe(manifestA.dark);
+   expect(registry.resolve("light")).toBe(manifestA.light);
+ });

--- a/website/src/theme/bootstrapBrowserEnvironment.ts
+++ b/website/src/theme/bootstrapBrowserEnvironment.ts
@@ -1,0 +1,76 @@
+/**
+ * 背景：
+ *  - 入口页需在 React 启动前同步浏览器主题与 favicon，否则首屏会闪烁错误配色；
+ * 目的：
+ *  - 复用 browserFaviconManifest 的调色逻辑，集中处理语言、主题、favicon 三项启动配置；
+ * 关键决策与取舍：
+ *  - 采用同步 IIFE，确保在主 bundle 加载前完成；备选 async/await 会引入首屏延迟；
+ * 影响范围：
+ *  - index.html 中的启动脚本、ThemeProvider 初始化时的默认状态；
+ * 演进与TODO：
+ *  - 后续可引入持久化错误上报或与服务端协商语言偏好。
+ */
+import glancyWebBaseSvg from "@/assets/glancy-web.svg?raw";
+import {
+  createBrowserFaviconRegistry,
+  ensureBrowserFaviconManifest,
+  getBrowserFaviconBaseSvgGlobalKey,
+  getBrowserFaviconManifestGlobalKey,
+  setBrowserFaviconBaseSvg,
+} from "@/theme/browserFaviconManifest";
+
+const DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+const resolveResolvedTheme = (preference: string, prefersDark: boolean) => {
+  if (preference === "dark" || preference === "light") {
+    return preference;
+  }
+  return prefersDark ? "dark" : "light";
+};
+
+(() => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+
+  const globalScope = window as typeof window & {
+    [key: string]: unknown;
+  };
+  const baseSvgKey = getBrowserFaviconBaseSvgGlobalKey();
+  globalScope[baseSvgKey] = glancyWebBaseSvg;
+  setBrowserFaviconBaseSvg(globalScope, glancyWebBaseSvg);
+  const manifest = ensureBrowserFaviconManifest(globalScope);
+  const manifestKey = getBrowserFaviconManifestGlobalKey();
+  // 将 manifest 写回全局，供 React 生命周期与调试复用。
+  globalScope[manifestKey] = manifest;
+
+  const { localStorage } = window;
+  try {
+    const storedLang = localStorage?.getItem("lang");
+    if (storedLang) {
+      document.documentElement.lang = storedLang;
+    }
+  } catch {
+    // 访问 localStorage 可能因隐私模式被拒绝，忽略即可。
+  }
+
+  let preference = "system";
+  try {
+    preference = localStorage?.getItem("theme") ?? "system";
+  } catch {
+    preference = "system";
+  }
+
+  const prefersDark = window.matchMedia(DARK_MEDIA_QUERY).matches;
+  const resolvedTheme = resolveResolvedTheme(preference, prefersDark);
+  document.documentElement.dataset.theme = resolvedTheme;
+
+  const registry = createBrowserFaviconRegistry(globalScope);
+  const link = document.getElementById("favicon");
+  if (link instanceof HTMLLinkElement) {
+    const scheme = prefersDark ? "dark" : "light";
+    const asset = registry.resolve(scheme);
+    link.href = asset;
+    link.dataset.browserColorScheme = scheme;
+  }
+})();

--- a/website/src/theme/browserFaviconConfigurator.ts
+++ b/website/src/theme/browserFaviconConfigurator.ts
@@ -1,0 +1,139 @@
+/**
+ * 背景：
+ *  - 旧实现直接在 ThemeContext 中根据网页主题切换 favicon，无法覆盖浏览器自身主题变更；
+ *  - index.html 内联脚本重复维护逻辑，易于漂移并缺乏测试覆盖。
+ * 目的：
+ *  - 以配置器模式集中管理浏览器页签 favicon 的浅深色切换，确保与浏览器主题解耦；
+ * 关键决策与取舍：
+ *  - 采用“配置器 + 注册表”的组合模式：注册表负责资产映射，配置器负责监听浏览器主题并应用（相较于一次性脚本更易扩展及测试）；
+ *  - 依赖 matchMedia 构建观察者（Observer）模式，避免手动轮询，同时在缺失能力的环境中安全回退；
+ * 影响范围：
+ *  - 浏览器 favicon 切换逻辑、ThemeProvider 初始化流程、与 favicon 相关的单测；
+ * 演进与TODO：
+ *  - 可扩展更多浏览器特性（如 high-contrast）或允许多 favicon 节点，通过策略模式封装匹配规则。
+ */
+import { FaviconRegistry } from "@/theme/faviconRegistry";
+
+const DEFAULT_LINK_ID = "favicon";
+const DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+export type BrowserFaviconConfiguratorOptions = {
+  linkId?: string;
+  registry: FaviconRegistry;
+  matchMedia?: ((query: string) => MediaQueryList) | null;
+  document?: Document | null;
+};
+
+type BrowserColorScheme = "dark" | "light";
+
+type MediaChangeListener = (event: MediaQueryListEvent) => void;
+
+export class BrowserFaviconConfigurator {
+  private readonly linkId: string;
+
+  private readonly registry: FaviconRegistry;
+
+  private readonly matchMedia: ((query: string) => MediaQueryList) | null;
+
+  private readonly document: Document | null;
+
+  private mediaQueryList: MediaQueryList | null = null;
+
+  private listener: MediaChangeListener | null = null;
+
+  constructor(options: BrowserFaviconConfiguratorOptions) {
+    const {
+      linkId = DEFAULT_LINK_ID,
+      registry,
+      matchMedia = null,
+      document: doc = null,
+    } = options;
+    this.linkId = linkId;
+    this.registry = registry;
+    this.matchMedia = matchMedia;
+    this.document = doc;
+  }
+
+  /**
+   * 意图：启动配置器并根据浏览器主题应用 favicon。
+   * 输入：无（依赖构造时注入的 registry/matchMedia/document）。
+   * 输出：无显式返回，通过修改 DOM 产生副作用。
+   * 流程：
+   *  1) 查找目标 link 元素；
+   *  2) 依据媒体查询结果确定当前配色；
+   *  3) 应用 favicon 并注册监听，实现实时切换。
+   * 错误处理：
+   *  - 若环境缺失 document 或 link 节点，则直接回退，不抛出异常；
+   *  - 若 matchMedia 不存在，则默认使用亮色资源。
+   * 复杂度：O(1)，仅涉及常量级 DOM 查询与监听绑定。
+   */
+  start(): void {
+    const targetDocument = this.document;
+    if (!targetDocument) {
+      return;
+    }
+
+    const element = targetDocument.getElementById(this.linkId);
+    if (!(element instanceof HTMLLinkElement)) {
+      return;
+    }
+
+    const applyScheme = (scheme: BrowserColorScheme) => {
+      element.href = this.registry.resolve(scheme);
+      element.dataset.browserColorScheme = scheme;
+    };
+
+    this.stop();
+
+    const mediaQuery = this.matchMedia ? this.matchMedia(DARK_MEDIA_QUERY) : null;
+    const initialScheme: BrowserColorScheme = mediaQuery?.matches ? "dark" : "light";
+    applyScheme(initialScheme);
+
+    if (!mediaQuery) {
+      return;
+    }
+
+    const handleChange: MediaChangeListener = (event) => {
+      applyScheme(event.matches ? "dark" : "light");
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    this.mediaQueryList = mediaQuery;
+    this.listener = handleChange;
+  }
+
+  /**
+   * 意图：移除媒体查询监听，释放资源，便于热更新或重复初始化。
+   * 输入/输出：无。
+   * 流程：
+   *  1) 若存在已注册的监听器，则解除绑定；
+   *  2) 清空内部引用，等待 GC。
+   * 错误处理：所有操作安全判空，不抛出异常。
+   * 复杂度：O(1)。
+   */
+  stop(): void {
+    if (this.mediaQueryList && this.listener) {
+      this.mediaQueryList.removeEventListener("change", this.listener);
+    }
+    this.mediaQueryList = null;
+    this.listener = null;
+  }
+}
+
+export function createBrowserFaviconConfigurator(
+  options: BrowserFaviconConfiguratorOptions,
+): BrowserFaviconConfigurator {
+  const safeDocument =
+    options.document ?? (typeof document !== "undefined" ? document : null);
+  const safeMatchMedia =
+    options.matchMedia ??
+    (typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? (query: string) => window.matchMedia(query)
+      : null);
+
+  return new BrowserFaviconConfigurator({
+    ...options,
+    document: safeDocument,
+    matchMedia: safeMatchMedia,
+  });
+}

--- a/website/src/theme/browserFaviconManifest.ts
+++ b/website/src/theme/browserFaviconManifest.ts
@@ -1,0 +1,158 @@
+/**
+ * 背景：
+ *  - favicon 需根据浏览器颜色方案切换，但设计稿仅提供单个 base SVG；
+ *  - 过往方案通过复制多份素材实现，维护成本高且易与品牌资产脱钩。
+ * 目的：
+ *  - 复用现有 glancy-web.svg，通过运行时着色生成浅深两款 favicon 并挂载到全局供多处复用；
+ * 关键决策与取舍：
+ *  - 选择“数据 URI + 动态染色”策略，避免额外素材文件；备选方案为预构建静态资源但需调整构建链路，故暂缓；
+ *  - 以全局注册表缓存生成结果，确保引导脚本与 React 生命周期共享同一份 manifest；
+ * 影响范围：
+ *  - 浏览器 favicon 渲染、启动脚本、ThemeContext 中的配置器初始化；
+ * 演进与TODO：
+ *  - 后续可增加更多配色（如高对比）或改造为服务端可注入的多租户调色板。
+ */
+import {
+  createFaviconRegistry,
+  type FaviconManifest,
+  type FaviconRegistry,
+} from "@/theme/faviconRegistry";
+
+const GLOBAL_KEY = "__GLANCY_BROWSER_FAVICON_MANIFEST__" as const;
+const BASE_SVG_KEY = "__GLANCY_BROWSER_FAVICON_BASE_SVG__" as const;
+
+const DEFAULT_LIGHT_COLOR = "#000000";
+const DEFAULT_DARK_COLOR = "#ffffff";
+
+const FALLBACK_BASE_SVG =
+  "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>" +
+  "<rect x='7' y='5' width='4' height='14' rx='1' fill='currentColor'/>" +
+  "<rect x='13' y='3' width='4' height='12' rx='1' fill='currentColor'/>" +
+  "<rect x='3' y='9' width='4' height='12' rx='1' fill='currentColor'/></svg>";
+
+const CURRENT_COLOR_PATTERN = /currentColor/g;
+const WHITESPACE_PATTERN = new RegExp(">\\s+<", "g");
+
+export type BrowserFaviconManifest = FaviconManifest;
+
+export type BrowserFaviconPalette = {
+  light?: string;
+  dark?: string;
+};
+
+type BrowserGlobalScope = {
+  [GLOBAL_KEY]?: BrowserFaviconManifest;
+  [BASE_SVG_KEY]?: string;
+} &
+  Partial<typeof globalThis>;
+
+const sanitizeColor = (hex: string, fallback: string): string => {
+  const trimmed = typeof hex === "string" ? hex.trim() : "";
+  if (trimmed.startsWith("#")) {
+    const normalized = trimmed.slice(1);
+    if (
+      normalized.length === 3 ||
+      normalized.length === 6 ||
+      normalized.length === 8
+    ) {
+      const hexPattern = /^[0-9a-fA-F]+$/;
+      if (hexPattern.test(normalized)) {
+        return `#${normalized}`;
+      }
+    }
+  }
+  return fallback;
+};
+
+const encodeSvgDataUri = (svg: string): string => {
+  const compact = svg.replace(WHITESPACE_PATTERN, "><").trim();
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(compact)}`;
+};
+
+const tintSvg = (svg: string, color: string): string =>
+  svg.replace(CURRENT_COLOR_PATTERN, color);
+
+const isValidSvgSource = (svg: unknown): svg is string =>
+  typeof svg === "string" && svg.includes("currentColor");
+
+const resolveBaseSvg = (scope: BrowserGlobalScope): string => {
+  if (isValidSvgSource(scope[BASE_SVG_KEY])) {
+    return scope[BASE_SVG_KEY] as string;
+  }
+  return FALLBACK_BASE_SVG;
+};
+
+export const buildBrowserFaviconManifest = (
+  svgSource: string,
+  palette: BrowserFaviconPalette = {},
+): BrowserFaviconManifest => {
+  const lightColor = sanitizeColor(palette.light ?? "", DEFAULT_LIGHT_COLOR);
+  const darkColor = sanitizeColor(palette.dark ?? "", DEFAULT_DARK_COLOR);
+  const lightSvg = tintSvg(svgSource, lightColor);
+  const darkSvg = tintSvg(svgSource, darkColor);
+  const lightIcon = encodeSvgDataUri(lightSvg);
+  const darkIcon = encodeSvgDataUri(darkSvg);
+
+  return {
+    default: lightIcon,
+    light: lightIcon,
+    dark: darkIcon,
+  };
+};
+
+const readManifestFromGlobal = (
+  scope: BrowserGlobalScope,
+): BrowserFaviconManifest | null => {
+  const candidate = scope[GLOBAL_KEY];
+  if (!candidate) {
+    return null;
+  }
+  const entries = Object.entries(candidate);
+  if (entries.every(([, value]) => typeof value === "string" && value.length > 0)) {
+    return candidate;
+  }
+  return null;
+};
+
+export const setBrowserFaviconBaseSvg = (
+  scope: BrowserGlobalScope,
+  svgSource: string,
+) => {
+  if (isValidSvgSource(svgSource)) {
+    scope[BASE_SVG_KEY] = svgSource;
+  }
+};
+
+const assignManifestToGlobal = (
+  scope: BrowserGlobalScope,
+  manifest: BrowserFaviconManifest,
+) => {
+  try {
+    scope[GLOBAL_KEY] = manifest;
+  } catch {
+    // 某些环境（如严格 CSP 或模拟对象）可能拒绝赋值，此时忽略即可。
+  }
+};
+
+export const ensureBrowserFaviconManifest = (
+  scope: BrowserGlobalScope = globalThis as BrowserGlobalScope,
+): BrowserFaviconManifest => {
+  const existing = readManifestFromGlobal(scope);
+  if (existing) {
+    return existing;
+  }
+  const manifest = buildBrowserFaviconManifest(resolveBaseSvg(scope));
+  assignManifestToGlobal(scope, manifest);
+  return manifest;
+};
+
+export const createBrowserFaviconRegistry = (
+  scope: BrowserGlobalScope = globalThis as BrowserGlobalScope,
+): FaviconRegistry => {
+  const manifest = ensureBrowserFaviconManifest(scope);
+  return createFaviconRegistry(manifest);
+};
+
+export const getBrowserFaviconManifestGlobalKey = () => GLOBAL_KEY;
+
+export const getBrowserFaviconBaseSvgGlobalKey = () => BASE_SVG_KEY;

--- a/website/src/theme/faviconRegistry.ts
+++ b/website/src/theme/faviconRegistry.ts
@@ -15,7 +15,7 @@
 
 const FALLBACK_KEY = "default";
 
-type FaviconManifest = Record<string, string>;
+export type FaviconManifest = Record<string, string>;
 
 type RegistryOptions = {
   manifest: FaviconManifest;

--- a/website/test/__mocks__/rawSvgMock.cjs
+++ b/website/test/__mocks__/rawSvgMock.cjs
@@ -1,0 +1,1 @@
+module.exports = "<svg><rect fill='currentColor'/></svg>";


### PR DESCRIPTION
## Summary
- replace the inline bootstrap script with an ESM initializer that sets language, theme and favicon using a shared manifest
- add a browser favicon manifest utility that tints the single glancy-web.svg into light/dark data URIs and expose it to the theme provider
- drop the duplicated light/dark favicon assets, wire Jest to mock raw SVG imports, and cover the manifest builder with unit tests

## Testing
- npm test -- --no-cache --runTestsByPath src/theme/__tests__/browserFaviconConfigurator.test.ts src/theme/__tests__/browserFaviconManifest.test.ts
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e23c919fac833292faa080fe0eb2eb