### PR TITLE
feat: stabilize settings panel layout

### DIFF
--- a/website/src/components/modals/SettingsBody.module.css
+++ b/website/src/components/modals/SettingsBody.module.css
@@ -14,10 +14,26 @@
 
 .container {
   display: grid;
-  grid-template-columns: var(--settings-body-grid-template, minmax(220px, 0.36fr) minmax(0, 1fr));
+  grid-template-columns: var(
+    --settings-body-grid-template,
+    minmax(220px, 0.36fr) minmax(0, 1fr)
+  );
   grid-template-rows: minmax(0, 1fr);
   gap: var(--settings-body-column-gap, 36px);
-  max-height: calc(100vh - var(--settings-body-safe-area, 160px));
+
+  /*
+   * 通过锁定容器高度，确保模态在不同分区间切换时不发生跳动，
+   * 并在右侧内容溢出时依赖内部滚动容器承接滚动职责。
+   */
+  /* stylelint-disable-next-line declaration-empty-line-before */
+
+  --settings-body-height-fallback: calc(
+    100vh - var(--settings-body-safe-area, 160px)
+  );
+  /* stylelint-disable-next-line declaration-empty-line-before */
+  height: var(--settings-body-height, var(--settings-body-height-fallback));
+  /* stylelint-disable-next-line declaration-empty-line-before */
+  max-height: var(--settings-body-height, var(--settings-body-height-fallback));
   min-height: 0;
   width: 100%;
   align-items: stretch;
@@ -56,11 +72,13 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  border-inline-start: var(--settings-body-divider-width, 1px)
-    solid
+  border-inline-start: var(--settings-body-divider-width, 1px) solid
     var(
       --settings-body-divider-color,
-      var(--sb-divider, color-mix(in srgb, var(--border-color, #1f2937) 70%, transparent 30%))
+      var(
+        --sb-divider,
+        color-mix(in srgb, var(--border-color, #1f2937) 70%, transparent 30%)
+      )
     );
 }
 
@@ -77,6 +95,7 @@
   .container {
     grid-template-columns: 1fr;
     grid-template-rows: auto minmax(0, 1fr);
+    height: auto;
     max-height: none;
     gap: var(--settings-body-column-gap-mobile, 28px);
   }

--- a/website/src/components/modals/SettingsModal.module.css
+++ b/website/src/components/modals/SettingsModal.module.css
@@ -15,6 +15,13 @@
   --modal-color: var(--preferences-panel-text);
   --modal-shadow: var(--preferences-panel-shadow);
 
+  /*
+   * 预先扣除模态内边距，为内容区提供稳定高度，避免切换分区时
+   * 发生跳动并确保滚动条始终驻留在右侧内容区域。
+   */
+
+  --settings-body-height: max(0px, calc(var(--modal-max-height, 86vh) - 88px));
+
   padding: 44px;
   box-sizing: border-box;
   border: 1px solid var(--preferences-panel-border);
@@ -42,11 +49,8 @@
   inline-size: var(--btn-action, 44px);
   block-size: var(--btn-action, 44px);
   border-radius: 999px;
-  border: 1px solid color-mix(
-    in srgb,
-    var(--preferences-panel-border) 68%,
-    transparent
-  );
+  border: 1px solid
+    color-mix(in srgb, var(--preferences-panel-border) 68%, transparent);
   background: color-mix(
     in srgb,
     var(--preferences-panel-surface) 94%,

--- a/website/src/components/modals/SettingsNav.jsx
+++ b/website/src/components/modals/SettingsNav.jsx
@@ -12,6 +12,37 @@
  */
 import { useMemo } from "react";
 import PropTypes from "prop-types";
+import { useLanguage } from "@/context";
+
+/**
+ * 意图：针对英文环境生成 Title Case 文案，保证标签语气与设计规范一致。
+ * 复杂度：O(n) 取决于词条长度；空间：O(1)。
+ */
+const formatSectionLabel = (label, locale) => {
+  if (typeof label !== "string") {
+    return label;
+  }
+  if (locale !== "en") {
+    return label;
+  }
+  return label
+    .split(/(\s+)/)
+    .map((segment) => {
+      if (!segment.trim()) {
+        return segment;
+      }
+      const characters = Array.from(segment);
+      const [first, ...rest] = characters;
+      if (!first) {
+        return segment;
+      }
+      return (
+        first.toLocaleUpperCase("en-US") +
+        rest.join("").toLocaleLowerCase("en-US")
+      );
+    })
+    .join("");
+};
 
 function SettingsNav({
   sections,
@@ -21,6 +52,7 @@ function SettingsNav({
   renderCloseAction,
   classes,
 }) {
+  const { lang } = useLanguage();
   const sectionCount = sections.length;
   const containerClassName = classes?.container ?? "";
   const actionWrapperClassName = classes?.action ?? "";
@@ -83,7 +115,9 @@ function SettingsNav({
                * 偏好设置导航仅展示主标签文本，避免双列信息导致键盘导航朗读冗余。
                * 如需补充副标题，应改由 tab 内容区域呈现而非按钮内部。
                */}
-              <span className={labelClassName}>{section.label}</span>
+              <span className={labelClassName}>
+                {formatSectionLabel(section.label, lang)}
+              </span>
             </button>
           );
         })}
@@ -121,4 +155,3 @@ SettingsNav.defaultProps = {
 };
 
 export default SettingsNav;
-

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -195,7 +195,7 @@
   font-size: 15px;
   font-weight: 600;
   letter-spacing: 0.04em;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .tab[data-state="active"] .tab-summary {
@@ -292,6 +292,14 @@
   border: none;
   display: grid;
   gap: var(--space-3);
+}
+
+/*
+ * fieldset 在多数浏览器中不会响应 gap，需要手动补齐 legend 与控件之间的竖向间距，
+ * 以维持与 label 对应控件一致的节奏。
+ */
+.control-field legend + * {
+  margin-top: var(--space-3);
 }
 
 .control-label {


### PR DESCRIPTION
## Summary
- lock the modal settings body height so the right column scrolls without resizing the dialog
- normalize spacing within the General section to align theme and language controls
- render settings navigation labels in Title Case for English locales instead of all caps

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e24d61e7808332a190675bb9154849