### PR TITLE
调整帮助菜单去除快捷键入口

### DIFF
--- a/website/src/components/Header/UserMenu.jsx
+++ b/website/src/components/Header/UserMenu.jsx
@@ -42,7 +42,7 @@ function UserMenu({ size = 24, showName = false, TriggerComponent }) {
       clearUser={clearUser}
       clearHistory={clearHistory}
     >
-      {({ openSettings, openShortcuts, openUpgrade, openLogout }) => (
+      {({ openSettings, openUpgrade, openLogout }) => (
         <Trigger
           size={size}
           showName={showName}
@@ -58,7 +58,6 @@ function UserMenu({ size = 24, showName = false, TriggerComponent }) {
               isPro={isPro}
               onOpenSettings={() => openSettings("general")}
               onOpenUpgrade={openUpgrade}
-              onOpenKeyboard={openShortcuts}
               onOpenLogout={openLogout}
             />
           )}

--- a/website/src/components/Header/UserMenuDropdown.jsx
+++ b/website/src/components/Header/UserMenuDropdown.jsx
@@ -11,7 +11,6 @@ const HELP_ITEMS = [
   { key: "terms", icon: "shield-check", labelKey: "termsPolicies" },
   { key: "bug", icon: "flag", labelKey: "reportBug" },
   { key: "apps", icon: "phone", labelKey: "downloadApps" },
-  { key: "shortcuts", icon: "command-line", labelKey: "shortcuts" },
 ];
 
 const emitHelpEvent = (action) => {
@@ -26,7 +25,6 @@ function UserMenuDropdown({
   isPro,
   onOpenSettings,
   onOpenUpgrade,
-  onOpenKeyboard,
   onOpenLogout,
 }) {
   const rootRef = useRef(null);
@@ -97,17 +95,10 @@ function UserMenuDropdown({
 
   const handleHelpItem = useCallback(
     (item) => () => {
-      if (item.key === "shortcuts") {
-        if (typeof onOpenKeyboard === "function") {
-          onOpenKeyboard();
-        }
-        closeMenu();
-        return;
-      }
       emitHelpEvent(item.key);
       closeMenu();
     },
-    [closeMenu, onOpenKeyboard],
+    [closeMenu],
   );
 
   if (!open) {
@@ -246,7 +237,6 @@ UserMenuDropdown.propTypes = {
   isPro: PropTypes.bool,
   onOpenSettings: PropTypes.func,
   onOpenUpgrade: PropTypes.func,
-  onOpenKeyboard: PropTypes.func,
   onOpenLogout: PropTypes.func,
 };
 
@@ -254,7 +244,6 @@ UserMenuDropdown.defaultProps = {
   isPro: false,
   onOpenSettings: undefined,
   onOpenUpgrade: undefined,
-  onOpenKeyboard: undefined,
   onOpenLogout: undefined,
 };
 

--- a/website/src/components/Sidebar/UserMenu/UserMenu.tsx
+++ b/website/src/components/Sidebar/UserMenu/UserMenu.tsx
@@ -12,8 +12,6 @@ interface UserMenuProps {
   labels: {
     help: string;
     settings: string;
-    shortcuts: string;
-    shortcutsDescription?: string;
     logout: string;
     helpCenter?: string;
     releaseNotes?: string;
@@ -22,7 +20,6 @@ interface UserMenuProps {
     downloadApps?: string;
   };
   onOpenSettings: (section?: string) => void;
-  onOpenShortcuts: () => void;
   onOpenLogout: () => void;
 }
 
@@ -71,7 +68,6 @@ const HELP_ITEMS = [
   { key: "terms", icon: "shield-check", labelKey: "termsPolicies" },
   { key: "bug", icon: "flag", labelKey: "reportBug" },
   { key: "apps", icon: "phone", labelKey: "downloadApps" },
-  { key: "shortcuts", icon: "command-line", labelKey: "shortcuts" },
 ] as const;
 
 type HelpItemConfig = (typeof HELP_ITEMS)[number];
@@ -89,7 +85,6 @@ function UserMenu({
   planLabel,
   labels,
   onOpenSettings,
-  onOpenShortcuts,
   onOpenLogout,
 }: UserMenuProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -111,8 +106,6 @@ function UserMenu({
     helpCenter,
     releaseNotes,
     reportBug,
-    shortcuts,
-    shortcutsDescription,
     termsPolicies,
     downloadApps,
     settings,
@@ -124,24 +117,13 @@ function UserMenu({
       helpCenter,
       releaseNotes,
       reportBug,
-      shortcuts,
       termsPolicies,
       downloadApps,
     };
 
     return HELP_ITEMS.map<SubmenuLinkItem>((item) => {
       const labelKey = item.labelKey as HelpLabelKey;
-      const rawLabel = labelMap[labelKey];
-      const label = item.key === "shortcuts" ? shortcuts : rawLabel ?? help;
-      if (item.key === "shortcuts") {
-        return {
-          id: item.key,
-          icon: item.icon,
-          label,
-          onSelect: onOpenShortcuts,
-        };
-      }
-
+      const label = labelMap[labelKey] ?? help;
       return {
         id: item.key,
         icon: item.icon,
@@ -153,10 +135,8 @@ function UserMenu({
     downloadApps,
     help,
     helpCenter,
-    onOpenShortcuts,
     releaseNotes,
     reportBug,
-    shortcuts,
     termsPolicies,
   ]);
 
@@ -176,7 +156,6 @@ function UserMenu({
       id: "help",
       icon: "question-mark-circle",
       label: help,
-      description: shortcutsDescription,
       items: supportItems,
     };
 
@@ -199,7 +178,6 @@ function UserMenu({
     onOpenLogout,
     onOpenSettings,
     settings,
-    shortcutsDescription,
     supportItems,
   ]);
 

--- a/website/src/components/Sidebar/UserMenu/__tests__/UserMenu.test.tsx
+++ b/website/src/components/Sidebar/UserMenu/__tests__/UserMenu.test.tsx
@@ -12,8 +12,6 @@ const labels = {
   help: "帮助",
   helpSection: "支持",
   settings: "设置",
-  shortcuts: "快捷键",
-  shortcutsDescription: "",
   upgrade: "升级",
   logout: "退出",
   accountSection: "账户",
@@ -101,7 +99,6 @@ const openUserMenu = () => {
       labels={labels}
       isPro={false}
       onOpenSettings={noop}
-      onOpenShortcuts={noop}
       onOpenUpgrade={noop}
       onOpenLogout={noop}
     />,

--- a/website/src/components/Sidebar/__tests__/AuthenticatedDock.test.jsx
+++ b/website/src/components/Sidebar/__tests__/AuthenticatedDock.test.jsx
@@ -40,7 +40,6 @@ describe("AuthenticatedDock", () => {
     const labels = {
       help: "帮助",
       settings: "设置",
-      shortcuts: "快捷键",
       logout: "退出",
     };
     const props = {
@@ -48,13 +47,20 @@ describe("AuthenticatedDock", () => {
       planLabel: "Plus",
       labels,
       onOpenSettings: jest.fn(),
-      onOpenShortcuts: jest.fn(),
       onOpenLogout: jest.fn(),
     };
 
     render(<AuthenticatedDock {...props} />);
 
     expect(screen.getByTestId("sidebar-user-dock")).toHaveClass("wrapper");
-    expect(mockUserMenu).toHaveBeenCalledWith(expect.objectContaining(props));
+    expect(mockUserMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: props.displayName,
+        planLabel: props.planLabel,
+        labels: props.labels,
+        onOpenSettings: props.onOpenSettings,
+        onOpenLogout: props.onOpenLogout,
+      }),
+    );
   });
 });

--- a/website/src/components/Sidebar/__tests__/useSidebarUserDock.test.js
+++ b/website/src/components/Sidebar/__tests__/useSidebarUserDock.test.js
@@ -25,7 +25,6 @@ describe("useSidebarUserDock", () => {
         navRegister: "注册",
         help: "帮助",
         settings: "设置",
-        shortcuts: "快捷键",
         logout: "退出",
       },
     };
@@ -72,7 +71,6 @@ describe("useSidebarUserDock", () => {
    */
   test("Given_pro_user_When_build_props_Then_maps_modal_controls", () => {
     const openSettings = jest.fn();
-    const openShortcuts = jest.fn();
     const openLogout = jest.fn();
 
     userState = {
@@ -84,7 +82,6 @@ describe("useSidebarUserDock", () => {
       t: {
         help: "帮助",
         settings: "设置",
-        shortcuts: "快捷键",
         logout: "退出",
         helpCenter: "帮助中心",
         releaseNotes: "版本说明",
@@ -103,7 +100,6 @@ describe("useSidebarUserDock", () => {
 
     const props = result.current.buildAuthenticatedProps({
       openSettings,
-      openShortcuts,
       openLogout,
     });
 
@@ -117,7 +113,6 @@ describe("useSidebarUserDock", () => {
     expect(props.labels.reportBug).toBe("反馈");
     expect(props.labels.downloadApps).toBe("下载应用");
     expect(props.onOpenSettings).toBe(openSettings);
-    expect(props.onOpenShortcuts).toBe(openShortcuts);
     expect(props.onOpenLogout).toBe(openLogout);
   });
 
@@ -141,7 +136,6 @@ describe("useSidebarUserDock", () => {
       t: {
         help: "帮助",
         settings: "设置",
-        shortcuts: "快捷键",
         logout: "退出",
         helpCenter: "帮助中心",
         report: "举报",
@@ -152,7 +146,6 @@ describe("useSidebarUserDock", () => {
 
     const props = result.current.buildAuthenticatedProps({
       openSettings: jest.fn(),
-      openShortcuts: jest.fn(),
       openLogout: jest.fn(),
     });
 
@@ -166,8 +159,6 @@ describe("useSidebarUserDock", () => {
         "releaseNotes",
         "reportBug",
         "settings",
-        "shortcuts",
-        "shortcutsDescription",
         "termsPolicies",
       ].sort(),
     );

--- a/website/src/components/Sidebar/hooks/useSidebarUserDock.js
+++ b/website/src/components/Sidebar/hooks/useSidebarUserDock.js
@@ -63,8 +63,6 @@ export function useSidebarUserDock() {
     () => ({
       help: t.help || "Help",
       settings: t.settings || "Settings",
-      shortcuts: t.shortcuts || t.shortcutsTitle || "Keyboard shortcuts",
-      shortcutsDescription: t.shortcutsDescription || undefined,
       logout: t.logout || "Logout",
       helpCenter: t.helpCenter || undefined,
       releaseNotes: t.releaseNotes || undefined,
@@ -111,10 +109,9 @@ export function useSidebarUserDock() {
   );
 
   const buildAuthenticatedProps = useCallback(
-    ({ openSettings, openShortcuts, openLogout }) => ({
+    ({ openSettings, openLogout }) => ({
       ...authenticatedBaseProps,
       onOpenSettings: openSettings,
-      onOpenShortcuts: openShortcuts,
       onOpenLogout: openLogout,
     }),
     [authenticatedBaseProps],

--- a/website/src/components/Sidebar/user/AuthenticatedDock.jsx
+++ b/website/src/components/Sidebar/user/AuthenticatedDock.jsx
@@ -20,7 +20,6 @@ function AuthenticatedDock({
   planLabel,
   labels,
   onOpenSettings,
-  onOpenShortcuts,
   onOpenLogout,
 }) {
   return (
@@ -30,7 +29,6 @@ function AuthenticatedDock({
         planLabel={planLabel}
         labels={labels}
         onOpenSettings={onOpenSettings}
-        onOpenShortcuts={onOpenShortcuts}
         onOpenLogout={onOpenLogout}
       />
     </div>
@@ -43,8 +41,6 @@ AuthenticatedDock.propTypes = {
   labels: PropTypes.shape({
     help: PropTypes.string.isRequired,
     settings: PropTypes.string.isRequired,
-    shortcuts: PropTypes.string.isRequired,
-    shortcutsDescription: PropTypes.string,
     logout: PropTypes.string.isRequired,
     helpCenter: PropTypes.string,
     releaseNotes: PropTypes.string,
@@ -53,7 +49,6 @@ AuthenticatedDock.propTypes = {
     downloadApps: PropTypes.string,
   }).isRequired,
   onOpenSettings: PropTypes.func.isRequired,
-  onOpenShortcuts: PropTypes.func.isRequired,
   onOpenLogout: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
## Summary
- 移除头部与侧边栏帮助子菜单中的快捷键项，统一保留帮助、公告、条款、反馈与下载入口
- 更新侧边栏用户菜单的 Hook 与展示组件，简化属性协议并保持 glancy-help 事件派发
- 调整相关单测，验证子菜单内容与事件行为符合新规范

## Testing
- npm run lint
- npm run lint:css
- npm test -- --runTestsByPath src/components/Sidebar/UserMenu/__tests__/UserMenu.test.jsx
- npm test -- --runTestsByPath src/components/Sidebar/UserMenu/__tests__/UserMenu.test.tsx src/components/Sidebar/__tests__/useSidebarUserDock.test.js src/components/Sidebar/__tests__/AuthenticatedDock.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e259ded3b48332bd6e6a0a36db904b