### PR TITLE
Expand system language menu clickable area

### DIFF
--- a/website/src/components/ui/LanguageMenu/LanguageMenu.module.css
+++ b/website/src/components/ui/LanguageMenu/LanguageMenu.module.css
@@ -19,16 +19,22 @@
   height: 100%;
 }
 
+.language-select-wrapper[data-fullwidth="true"] {
+  width: 100%;
+}
+
 .language-trigger {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--seg-arrow-gap, 12px);
   height: 100%;
-  padding: 0;
+  min-height: var(--language-trigger-height, 100%);
+  padding-inline: var(--language-trigger-padding-inline, 0);
+  padding-block: var(--language-trigger-padding-block, 0);
   border: none;
-  border-radius: calc(var(--seg-r, 22px) - 6px);
-  background: transparent;
+  border-radius: var(--language-trigger-radius, calc(var(--seg-r, 22px) - 6px));
+  background: var(--language-trigger-background, transparent);
   color: inherit;
   font: inherit;
   letter-spacing: inherit;
@@ -37,6 +43,11 @@
   transition:
     background-color 0.2s ease,
     color 0.2s ease;
+}
+
+.language-trigger[data-fullwidth="true"] {
+  width: 100%;
+  justify-content: flex-start;
 }
 
 .language-trigger[data-open="true"],

--- a/website/src/components/ui/LanguageMenu/__tests__/LanguageMenu.test.jsx
+++ b/website/src/components/ui/LanguageMenu/__tests__/LanguageMenu.test.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import LanguageMenu from "../index.jsx";
+
+const baseOptions = [
+  { value: "en", label: "English" },
+  { value: "zh", label: "Chinese" },
+];
+
+/**
+ * 测试目标：fullWidth 策略应为触发器与包装容器标记 data-fullwidth。
+ * 前置条件：提供最小选项集并传入 fullWidth。
+ * 步骤：
+ *  1) 渲染 LanguageMenu 并定位触发按钮。
+ * 断言：
+ *  - 按钮与包装容器均暴露 data-fullwidth="true" 供样式层消费。
+ * 边界/异常：
+ *  - 若属性缺失则表明布局策略未生效。
+ */
+test("Given full width layout When rendered Then expose data attribute for styling", () => {
+  render(
+    <LanguageMenu
+      id="language-menu"
+      options={baseOptions}
+      value="en"
+      onChange={() => {}}
+      ariaLabel="System language"
+      fullWidth
+    />,
+  );
+
+  const trigger = screen.getByRole("button", { name: "System language" });
+  expect(trigger).toHaveAttribute("data-fullwidth", "true");
+  expect(trigger.parentElement).toHaveAttribute("data-fullwidth", "true");
+});
+
+/**
+ * 测试目标：选择新语言时仍调用 onChange。
+ * 前置条件：初始值为 en。
+ * 步骤：
+ *  1) 打开菜单并点击 Chinese。
+ * 断言：
+ *  - onChange 收到 zh。
+ * 边界/异常：
+ *  - 若回调未触发或值不匹配，表明 fullWidth 变更破坏交互。
+ */
+test("Given menu interaction When selecting option Then propagate change", async () => {
+  const user = userEvent.setup();
+  const handleChange = jest.fn();
+  render(
+    <LanguageMenu
+      id="language-menu"
+      options={baseOptions}
+      value="en"
+      onChange={handleChange}
+      ariaLabel="System language"
+      fullWidth
+    />,
+  );
+
+  await user.click(screen.getByRole("button", { name: "System language" }));
+  await user.click(screen.getByRole("menuitemradio", { name: /Chinese/i }));
+
+  expect(handleChange).toHaveBeenCalledTimes(1);
+  expect(handleChange).toHaveBeenCalledWith("ZH");
+});

--- a/website/src/components/ui/LanguageMenu/index.jsx
+++ b/website/src/components/ui/LanguageMenu/index.jsx
@@ -10,6 +10,7 @@
  *  - ChatInput、Preferences 等引用语言菜单的模块；
  * 演进与TODO：
  *  - TODO: 后续可在 options 内支持图标或分组信息，需同步拓展菜单项模板。
+ *  - 近期扩展：fullWidth 策略用于让触发器撑满父容器，避免偏好设置等场景出现仅文字可点的体验断层。
  */
 import { useCallback, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
@@ -108,6 +109,7 @@ export default function LanguageMenu({
   showLabel,
   variant,
   onOpen,
+  fullWidth,
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
@@ -191,7 +193,10 @@ export default function LanguageMenu({
   const showTriggerLabel = Boolean(showLabel);
 
   return (
-    <div className={styles["language-select-wrapper"]}>
+    <div
+      className={styles["language-select-wrapper"]}
+      data-fullwidth={fullWidth ? "true" : undefined}
+    >
       <button
         type="button"
         id={id}
@@ -205,6 +210,7 @@ export default function LanguageMenu({
         ref={triggerRef}
         data-open={open}
         data-variant={variant}
+        data-fullwidth={fullWidth ? "true" : undefined}
       >
         <span className={styles["language-trigger-content"]}>
           <span className={styles["language-trigger-code"]}>
@@ -291,6 +297,7 @@ LanguageMenu.propTypes = {
   showLabel: PropTypes.bool,
   variant: PropTypes.oneOf(["source", "target"]),
   onOpen: PropTypes.func,
+  fullWidth: PropTypes.bool,
 };
 
 LanguageMenu.defaultProps = {
@@ -303,4 +310,5 @@ LanguageMenu.defaultProps = {
   showLabel: false,
   variant: "source",
   onOpen: undefined,
+  fullWidth: false,
 };

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -367,24 +367,23 @@
 }
 
 .language-shell {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 12px;
-  height: var(--preferences-language-height, 48px);
-  padding-inline: 14px;
-  border-radius: 20px;
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 82%,
-    transparent
-  );
+  display: block;
+  width: 100%;
   color: var(--preferences-panel-text);
   font-size: 14px;
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: none;
 
+  --language-trigger-height: var(--preferences-language-height, 48px);
+  --language-trigger-padding-inline: 14px;
+  --language-trigger-padding-block: 0px;
+  --language-trigger-radius: 20px;
+  --language-trigger-background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface) 82%,
+    transparent
+  );
   --seg-r: 22px;
   --seg-arrow-gap: 12px;
   --seg-code-width: 4ch;

--- a/website/src/pages/preferences/sections/GeneralSection.jsx
+++ b/website/src/pages/preferences/sections/GeneralSection.jsx
@@ -164,6 +164,7 @@ function GeneralSection({ title, headingId }) {
               ariaLabel={languageLabel}
               normalizeValue={normalizeSystemLanguage}
               showLabel
+              fullWidth
             />
           </div>
         </div>

--- a/website/src/pages/preferences/sections/__tests__/GeneralSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/GeneralSection.test.jsx
@@ -70,6 +70,7 @@ test("Given initial preferences When rendered Then current selection highlighted
   const languageTrigger = screen.getByRole("button", {
     name: "Interface language",
   });
+  expect(languageTrigger).toHaveAttribute("data-fullwidth", "true");
   expect(languageTrigger).toHaveTextContent(/Match device language/i);
 });
 


### PR DESCRIPTION
## Summary
- extend the shared LanguageMenu with an optional fullWidth strategy so the trigger spans its container and exposes data attributes for styling
- adjust the preferences language shell to feed trigger layout tokens and request the new full width mode from GeneralSection
- add unit coverage to assert the new layout contract and update existing expectations for the preferences section

## Testing
- npm test -- LanguageMenu
- npm test -- GeneralSection
- npm run lint
- npm run lint:css
- npx prettier -w src/components/ui/LanguageMenu/index.jsx src/components/ui/LanguageMenu/LanguageMenu.module.css src/components/ui/LanguageMenu/__tests__/LanguageMenu.test.jsx src/pages/preferences/Preferences.module.css src/pages/preferences/sections/GeneralSection.jsx src/pages/preferences/sections/__tests__/GeneralSection.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e25db55ad883328ca5f267605fd27d