### PR TITLE
fix: ensure dictionary markdown inline labels render on new lines

### DIFF
--- a/website/src/utils/markdown.test.js
+++ b/website/src/utils/markdown.test.js
@@ -66,6 +66,15 @@ test("polishDictionaryMarkdown enforces translation line break", () => {
 });
 
 /**
+ * 验证英译英 Markdown 中的行内标签（如 Example）也会断行，保证可读性。
+ */
+test("polishDictionaryMarkdown splits english inline labels", () => {
+  const source = "- **Meaning**: to light  **Example**: She lights a candle";
+  const result = polishDictionaryMarkdown(source);
+  expect(result).toBe("- **Meaning**: to light\n  **Example**: She lights a candle");
+});
+
+/**
  * 验证翻译行会继承有序列表的缩进，使得“翻译”与“例句”保持列对齐。
  */
 test("translation line keeps ordered list indentation", () => {


### PR DESCRIPTION
## Summary
- align the markdown polishing utility with backend section tokens so inline labels like Example render on separate lines
- add unit coverage ensuring English dictionary markdown benefits from the same formatting

## Testing
- npm test -- --runTestsByPath src/utils/markdown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e264f6ad648332a6871b01ae35cbaf