### PR TITLE
Fix English inline label line wrapping

### DIFF
--- a/website/src/utils/markdown.test.js
+++ b/website/src/utils/markdown.test.js
@@ -71,7 +71,21 @@ test("polishDictionaryMarkdown enforces translation line break", () => {
 test("polishDictionaryMarkdown splits english inline labels", () => {
   const source = "- **Meaning**: to light  **Example**: She lights a candle";
   const result = polishDictionaryMarkdown(source);
-  expect(result).toBe("- **Meaning**: to light\n  **Example**: She lights a candle");
+  expect(result).toBe(
+    "- **Meaning**: to light\n  **Example**: She lights a candle",
+  );
+});
+
+/**
+ * 验证组合标签（如 Pronunciation-British 或 AudioNotes）在英译英场景中也会断行，保持缩进对齐。
+ */
+test("polishDictionaryMarkdown splits composite english inline labels", () => {
+  const source =
+    "- **Pronunciation-British**: /ˈhjuː.mən/  **AudioNotes**: authoritative archival";
+  const result = polishDictionaryMarkdown(source);
+  expect(result).toBe(
+    "- **Pronunciation-British**: /ˈhjuː.mən/\n  **AudioNotes**: authoritative archival",
+  );
 });
 
 /**


### PR DESCRIPTION
## Summary
- normalize dictionary inline labels to split camelCase and hyphenated English markers before matching
- extend the English token vocabulary so composite pronunciation and metadata rows break onto new lines
- add regression coverage for composite English inline labels in the Markdown formatter

## Testing
- npm test -- --runTestsByPath src/utils/markdown.test.js
- npm run lint -- --fix
- npm run lint:css -- --fix
- npx prettier -w src/utils/markdown.js src/utils/markdown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e26d547d948332bb87d843aed547ba