### PR TITLE
Fix sidebar user menu help submenu hover interactions

### DIFF
--- a/website/src/components/Sidebar/UserMenu/UserMenu.tsx
+++ b/website/src/components/Sidebar/UserMenu/UserMenu.tsx
@@ -535,8 +535,8 @@ function UserMenu({
         aria-hidden={!open}
         tabIndex={-1}
         onKeyDown={handleMenuKeyDown}
-        onMouseEnter={cancelScheduledClose}
-        onMouseLeave={() => {
+        onPointerEnter={cancelScheduledClose}
+        onPointerLeave={() => {
           if (submenuState.id) {
             scheduleSubmenuClose();
           }
@@ -560,7 +560,9 @@ function UserMenu({
                   closeSubmenu();
                 }
               },
-              onMouseEnter: () => {
+              // 统一切换到 Pointer 事件，避免在 pen/touch 等输入设备下遗漏悬浮态，
+              // 解决“帮助”项悬浮不触发子菜单的问题；Mouse 事件由 Pointer 兼容层兜底。
+              onPointerEnter: () => {
                 setActiveIndex(interactiveIndex);
                 if (item.kind === "submenu") {
                   scheduleSubmenuOpen(item, interactiveIndex);
@@ -568,7 +570,7 @@ function UserMenu({
                   closeSubmenu();
                 }
               },
-              onMouseLeave: () => {
+              onPointerLeave: () => {
                 if (item.kind === "submenu") {
                   scheduleSubmenuClose();
                 }

--- a/website/src/components/Sidebar/UserMenu/UserSubmenu.tsx
+++ b/website/src/components/Sidebar/UserMenu/UserSubmenu.tsx
@@ -153,8 +153,9 @@ const UserSubmenu = forwardRef<UserSubmenuHandle, UserSubmenuProps>(
         style={{ top }}
         role="menu"
         aria-hidden={!open}
-        onMouseEnter={onPointerEnter}
-        onMouseLeave={onPointerLeave}
+        // 子菜单保持与父级一致的 Pointer 事件，以统一处理多输入设备的悬浮与离开判定。
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}
         onKeyDown={handleKeyDown}
       >
         <div className={styles["submenu-list"]}>

--- a/website/src/components/Sidebar/UserMenu/__tests__/UserMenu.test.jsx
+++ b/website/src/components/Sidebar/UserMenu/__tests__/UserMenu.test.jsx
@@ -80,7 +80,7 @@ describe("Sidebar/UserMenu", () => {
   const openHelpSubmenu = async () => {
     fireEvent.click(screen.getByRole("button", { name: "Alice" }));
     const helpTrigger = await screen.findByRole("menuitem", { name: /帮助/ });
-    fireEvent.mouseEnter(helpTrigger);
+    fireEvent.pointerEnter(helpTrigger, { pointerType: "mouse" });
     await waitFor(() => {
       const menus = screen.getAllByRole("menu");
       expect(menus.length).toBeGreaterThan(1);

--- a/website/src/components/Sidebar/UserMenu/__tests__/UserMenu.test.tsx
+++ b/website/src/components/Sidebar/UserMenu/__tests__/UserMenu.test.tsx
@@ -120,7 +120,7 @@ const hoverHelpItem = (container: HTMLElement) => {
   Object.defineProperty(helpItem, "getBoundingClientRect", {
     value: () => createRect({ top: 180, bottom: 240, right: 280, left: 0 }),
   });
-  fireEvent.mouseEnter(helpItem);
+  fireEvent.pointerEnter(helpItem, { pointerType: "mouse" });
   act(() => {
     jest.advanceTimersByTime(40);
   });
@@ -176,8 +176,8 @@ test("Given_SubmenuOpen_WhenPointerTransfersQuickly_ThenKeepVisible", () => {
   const { container } = openUserMenu();
   const { helpItem, submenu } = hoverHelpItem(container);
 
-  fireEvent.mouseLeave(helpItem);
-  fireEvent.mouseEnter(submenu);
+  fireEvent.pointerLeave(helpItem, { pointerType: "mouse" });
+  fireEvent.pointerEnter(submenu, { pointerType: "mouse" });
 
   act(() => {
     jest.advanceTimersByTime(100);


### PR DESCRIPTION
## Summary
- switch the sidebar user menu hover logic to pointer events so the help submenu opens reliably across input devices
- align the submenu container with pointer event handling and refresh the hover tests to exercise the pointer-based flow

## Testing
- npm test -- --runTestsByPath src/components/Sidebar/UserMenu/__tests__/UserMenu.test.tsx
- npm test -- --runTestsByPath src/components/Sidebar/UserMenu/__tests__/UserMenu.test.jsx
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e27164b90c83328939b9a48d814779