### PR TITLE
Remove background from subscription details panel

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -445,11 +445,6 @@
   gap: var(--space-3);
   padding: var(--space-5);
   border-radius: 16px;
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface) 96%,
-    transparent
-  );
 }
 
 .subscription-current-header {


### PR DESCRIPTION
## Summary
- remove the background fill from the subscription details block in the settings view to align with the updated design

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2731e9318833287c1dacea42a41a9