### PR TITLE
Refactor highlight palette to remove yellow accents

### DIFF
--- a/website/src/styles/index.css
+++ b/website/src/styles/index.css
@@ -14,7 +14,10 @@
   -moz-osx-font-smoothing: grayscale;
 
   --vh: 100vh;
-  --highlight-color: var(--color-link-light);
+
+  /* 高亮统一走黑白体系，链接单独复用品牌色，避免语义混淆。 */
+  --highlight-color: var(--hl-dark);
+  --link-color: var(--color-link-light);
   --shadow-color: rgb(0 0 0 / 15%);
 
   /* Loader 动画需感知主题，默认以深色文字基调渲染扁平矩形。 */
@@ -58,7 +61,8 @@
   color: var(--sys-text-dark);
   background-color: var(--sys-bg-dark);
 
-  --highlight-color: var(--color-link-dark);
+  --highlight-color: var(--hl-light);
+  --link-color: var(--color-link-dark);
   --app-bg: var(--neutral-900);
   --app-color: var(--text-primary-dark);
   --chat-window-bg: var(--neutral-900);
@@ -97,7 +101,8 @@
   color: var(--sys-text-light);
   background-color: var(--sys-bg-light);
 
-  --highlight-color: var(--color-link-light);
+  --highlight-color: var(--hl-dark);
+  --link-color: var(--color-link-light);
   --app-bg: var(--neutral-50);
   --app-color: var(--text-primary-light);
   --chat-window-bg: var(--neutral-0);
@@ -137,16 +142,16 @@
 
 a {
   font-weight: 500;
-  color: var(--highlight-color);
+  color: var(--link-color);
   text-decoration: inherit;
 }
 
 a:hover {
-  color: var(--highlight-color);
+  color: var(--link-color);
 }
 
 :root[data-theme="light"] a:hover {
-  color: var(--highlight-color);
+  color: var(--link-color);
 }
 
 body {

--- a/website/src/styles/tokens/roles.css
+++ b/website/src/styles/tokens/roles.css
@@ -22,8 +22,8 @@
   --role-on-surface-strong: var(--neutral-1);
   --role-success: #16a34a;
   --role-on-success: #fff;
-  --role-warning: #f59e0b;
-  --role-on-warning: #111;
+  --role-warning: color-mix(in srgb, var(--brand-primary) 80%, white 20%);
+  --role-on-warning: var(--hl-dark);
   --role-danger: #dc2626;
   --role-on-danger: #fff;
   --role-focus: var(--brand-10);
@@ -40,8 +40,8 @@
   --role-on-surface-strong: var(--neutral-1);
   --role-success: #22c55e;
   --role-on-success: #0b0d10;
-  --role-warning: #fbbf24;
-  --role-on-warning: #0b0d10;
+  --role-warning: color-mix(in srgb, var(--brand-primary) 68%, black 32%);
+  --role-on-warning: var(--hl-light);
   --role-danger: #ef4444;
   --role-on-danger: #0b0d10;
   --role-focus: var(--brand-10);

--- a/website/src/theme/colors.css
+++ b/website/src/theme/colors.css
@@ -15,18 +15,21 @@
   --neutral-950: #121212;
 
   /* brand palette */
-  --brand-primary: #facc15;
-  --brand-primary-emphasis: #d4a20a;
-  --brand-primary-soft: #fff4c2;
-  --brand-primary-contrast: var(--neutral-950);
-  --brand-secondary: #f7d46b;
-  --brand-surface-light: #fff8da;
-  --brand-surface-dark: #5a4303;
-  --brand-outline: #d4a20a;
-  --brand-glow: rgb(250 204 21 / 40%);
+  --brand-primary: var(--brand-9);
+  --brand-primary-emphasis: var(--brand-10);
+  --brand-primary-soft: var(--brand-3);
+  --brand-primary-contrast: var(--neutral-1);
+  --brand-secondary: var(--brand-8);
+  --brand-surface-light: var(--brand-2);
+  --brand-surface-dark: color-mix(in srgb, var(--brand-9) 78%, black 22%);
+  --brand-outline: var(--brand-10);
+  --brand-glow: rgb(37 99 235 / 40%);
   --brand-color: var(--brand-primary);
 
-  /* highlight colors */
+  /* highlight colors
+   *  - 响应「高亮不再使用黄色」的设计军规，统一将高亮语义映射到黑白对比，
+   *    以便跨主题保持一致的视觉节奏。
+   */
   --hl-light: var(--neutral-0);
   --hl-dark: var(--neutral-950);
 
@@ -58,8 +61,8 @@
   --surface: var(--panel);
 
   /* link colors */
-  --color-link-light: #d49f0a;
-  --color-link-dark: #ffe899;
+  --color-link-light: var(--brand-primary);
+  --color-link-dark: color-mix(in srgb, var(--brand-primary) 82%, white 18%);
 
   /* system colors */
   --sys-text-light: var(--neutral-900);


### PR DESCRIPTION
## Summary
- replace yellow brand tokens with palette-driven blue accents and monochrome highlight mapping
- decouple highlight and link variables so highlight renders black in light theme and white in dark theme
- derive warning role colors from the new brand palette while aligning foregrounds with the monochrome highlight directive

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e27254e9f88332bb6151967ddb4554