### PR TITLE
Fix dictionary markdown line breaks for dash-separated labels

### DIFF
--- a/website/src/utils/markdown.test.js
+++ b/website/src/utils/markdown.test.js
@@ -108,6 +108,23 @@ test("polishDictionaryMarkdown splits composite english inline labels", () => {
 });
 
 /**
+ * 测试目标：验证当释义标签使用破折号或连字符与正文连接时，仍能识别为需要换行的行内标签。
+ * 前置条件：行内结构包含 Definition 标签，且释义与例句之间仅以单个空格与破折号分隔。
+ * 步骤：
+ *  1) 构造带有破折号分隔的 markdown 字符串。
+ *  2) 调用 polishDictionaryMarkdown 处理文本。
+ * 断言：
+ *  - Example 标签会换行并保持列表缩进；若失败则说明破折号未被识别为合法分隔符。
+ * 边界/异常：
+ *  - 覆盖 LLM 输出常见的“—”与“-”混用场景，防止未来回退导致英译英释义粘连。
+ */
+test("polishDictionaryMarkdown splits definition labels joined by dash", () => {
+  const source = "- **Definition** — to light **Example**: She lights a candle";
+  const result = polishDictionaryMarkdown(source);
+  expect(result).toBe("- **Definition** — to light\n  **Example**: She lights a candle");
+});
+
+/**
  * 验证翻译行会继承有序列表的缩进，使得“翻译”与“例句”保持列对齐。
  */
 test("translation line keeps ordered list indentation", () => {


### PR DESCRIPTION
## Summary
- extend inline label parsing to treat dash-style separators the same as colons, preserving newline insertion for English-to-English definitions
- add a regression test covering definition sections joined with dashes to guard against future regressions

## Testing
- npm test -- --runTestsByPath src/utils/markdown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2766cf028833292e8a40d0b813cdb