### PR TITLE
Remove header help entry from user menu

### DIFF
--- a/website/src/components/Header/Header.module.css
+++ b/website/src/components/Header/Header.module.css
@@ -186,16 +186,6 @@
   letter-spacing: 0.04em;
 }
 
-.menu-item-trailing {
-  display: inline-flex;
-  align-items: center;
-  color: color-mix(
-    in srgb,
-    var(--sidebar-muted-color, var(--app-color)) 72%,
-    transparent
-  );
-}
-
 .menu-item-danger {
   color: color-mix(in srgb, var(--color-danger) 82%, transparent);
 }
@@ -215,78 +205,6 @@
     var(--sidebar-border-color, var(--border-color)) 48%,
     transparent
   );
-}
-
-.submenu-panel {
-  position: absolute;
-  top: 10px;
-  left: calc(100% + 20px);
-  min-width: 280px;
-  padding: 14px;
-  border-radius: 20px;
-  background: var(--sidebar-panel, var(--sb-bg));
-  border: 1px solid var(--sidebar-border-color, var(--sb-border));
-  box-shadow: var(--sidebar-panel-shadow, var(--sb-shadow));
-  display: none;
-  gap: 6px;
-  z-index: calc(var(--z-index-popover) + 1);
-}
-
-.submenu-panel[data-open="true"] {
-  display: grid;
-}
-
-.submenu-item {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 16px;
-  min-height: 50px;
-  padding: 0 14px;
-  border-radius: 12px;
-  background: var(--sidebar-item-bg, transparent);
-  border: none;
-  color: inherit;
-  font: inherit;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  text-align: left;
-  transition:
-    background-color 160ms ease,
-    transform 160ms ease;
-}
-
-.submenu-item:hover,
-.submenu-item:focus-visible {
-  background: var(--sidebar-hover-bg, var(--sb-bg-hover));
-  transform: translateX(2px);
-}
-
-.submenu-item:focus-visible {
-  outline: none;
-  box-shadow: var(--sidebar-ring, var(--sb-ring));
-}
-
-.submenu-icon-wrapper {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 10px;
-  background: var(--sidebar-hover-bg, var(--sb-bg-hover));
-  box-shadow: inset 0 0 0 1px var(--sidebar-border-color, var(--sb-border));
-}
-
-.submenu-icon {
-  width: 18px;
-  height: 18px;
-  color: inherit;
-}
-
-.submenu-label {
-  font-size: var(--text-sm);
-  letter-spacing: 0.03em;
 }
 
 .mobile-user-menu .user-menu-dropdown,

--- a/website/src/components/Header/UserMenuDropdown.jsx
+++ b/website/src/components/Header/UserMenuDropdown.jsx
@@ -1,22 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef } from "react";
 import PropTypes from "prop-types";
 import ThemeIcon from "@/components/ui/Icon";
 import styles from "./Header.module.css";
-
-const noop = () => {};
-
-const HELP_ITEMS = [
-  { key: "center", icon: "question-mark-circle", labelKey: "helpCenter" },
-  { key: "notes", icon: "refresh", labelKey: "releaseNotes" },
-  { key: "terms", icon: "shield-check", labelKey: "termsPolicies" },
-  { key: "bug", icon: "flag", labelKey: "reportBug" },
-  { key: "apps", icon: "phone", labelKey: "downloadApps" },
-];
-
-const emitHelpEvent = (action) => {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent("glancy-help", { detail: { action } }));
-};
 
 function UserMenuDropdown({
   open,
@@ -28,27 +13,13 @@ function UserMenuDropdown({
   onOpenLogout,
 }) {
   const rootRef = useRef(null);
-  const blurTimeoutRef = useRef(null);
-  const [helpOpen, setHelpOpen] = useState(false);
-
-  /**
-   * 背景说明：
-   *  - Header 的帮助入口需要与 Sidebar 一致地支持 Pointer 事件，以保证触控/触笔设备的悬浮能力。
-   * 设计取舍：
-   *  - 采用最小状态机（open/close）而非延时器方案，避免一次性补丁并保持可读性；
-   *    若未来需引入延时策略，可在此处扩展。
-   */
-  const openHelpSubmenu = useCallback(() => setHelpOpen(true), []);
-  const closeHelpSubmenu = useCallback(() => setHelpOpen(false), []);
 
   useEffect(() => {
     if (!open) {
-      closeHelpSubmenu();
-      return noop;
+      return undefined;
     }
     const handlePointerDown = (event) => {
       if (!rootRef.current?.contains(event.target)) {
-        closeHelpSubmenu();
         setOpen(false);
       }
     };
@@ -56,22 +27,11 @@ function UserMenuDropdown({
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown);
     };
-  }, [closeHelpSubmenu, open, setOpen]);
-
-  useEffect(
-    () => () => {
-      if (blurTimeoutRef.current) {
-        window.clearTimeout(blurTimeoutRef.current);
-        blurTimeoutRef.current = null;
-      }
-    },
-    [],
-  );
+  }, [open, setOpen]);
 
   const closeMenu = useCallback(() => {
-    closeHelpSubmenu();
     setOpen(false);
-  }, [closeHelpSubmenu, setOpen]);
+  }, [setOpen]);
 
   const handleMenuAction = useCallback(
     (callback) => () => {
@@ -83,33 +43,57 @@ function UserMenuDropdown({
     [closeMenu],
   );
 
-  const resolvedHelpItems = useMemo(
-    () =>
-      HELP_ITEMS.map((item) => ({
-        ...item,
-        label: t[item.labelKey] || item.labelKey,
-      })),
+  const translate = useCallback(
+    (key, fallback) => {
+      if (!t || typeof t !== "object") return fallback;
+      return t[key] || fallback;
+    },
     [t],
   );
 
-  const handleHelpBlur = useCallback(() => {
-    if (blurTimeoutRef.current) {
-      window.clearTimeout(blurTimeoutRef.current);
-    }
-    blurTimeoutRef.current = window.setTimeout(() => {
-      if (!rootRef.current?.contains(document.activeElement)) {
-        closeHelpSubmenu();
-      }
-    }, 120);
-  }, [closeHelpSubmenu]);
+  /**
+   * 背景：
+   *  - 帮助入口下线后，菜单仍需保持可拓展性，以支持未来新增能力。
+   * 关键决策与取舍：
+   *  - 采用“组合模式”描述菜单分区，统一通过配置驱动渲染，避免硬编码按钮顺序。
+   *  - 替代方案是写死 JSX 结构，但那会在新增按钮时重复修改多处代码且易出现顺序差异。
+   */
+  const menuSections = useMemo(() => {
+    const primaryItems = [];
 
-  const handleHelpItem = useCallback(
-    (item) => () => {
-      emitHelpEvent(item.key);
-      closeMenu();
-    },
-    [closeMenu],
-  );
+    if (!isPro) {
+      primaryItems.push({
+        key: "upgrade",
+        icon: "shield-check",
+        label: translate("upgrade", "Upgrade"),
+        action: onOpenUpgrade,
+        tone: "default",
+      });
+    }
+
+    primaryItems.push({
+      key: "settings",
+      icon: "cog-6-tooth",
+      label: translate("settings", "Settings"),
+      action: onOpenSettings,
+      tone: "default",
+    });
+
+    const exitItems = [
+      {
+        key: "logout",
+        icon: "arrow-right-on-rectangle",
+        label: translate("logout", "Logout"),
+        action: onOpenLogout,
+        tone: "danger",
+      },
+    ];
+
+    return [
+      { key: "primary", items: primaryItems },
+      { key: "exit", items: exitItems },
+    ];
+  }, [isPro, onOpenLogout, onOpenSettings, onOpenUpgrade, translate]);
 
   if (!open) {
     return null;
@@ -119,122 +103,40 @@ function UserMenuDropdown({
     <div
       ref={rootRef}
       className={styles["user-menu-dropdown"]}
-      onPointerLeave={closeHelpSubmenu}
     >
       <div className={styles["menu-panel"]} role="menu">
-        {!isPro ? (
-          <button
-            type="button"
-            role="menuitem"
-            className={styles["menu-item"]}
-            onClick={handleMenuAction(onOpenUpgrade)}
-          >
-            <span className={styles["menu-item-leading"]} aria-hidden="true">
-              <ThemeIcon
-                name="shield-check"
-                className={styles["menu-icon"]}
-                width={20}
-                height={20}
-                tone="dark"
-              />
-            </span>
-            <span className={styles["menu-label"]}>{t.upgrade}</span>
-          </button>
-        ) : null}
-        <button
-          type="button"
-          role="menuitem"
-          className={styles["menu-item"]}
-          onClick={handleMenuAction(onOpenSettings)}
-        >
-          <span className={styles["menu-item-leading"]} aria-hidden="true">
-            <ThemeIcon
-              name="cog-6-tooth"
-              className={styles["menu-icon"]}
-              width={20}
-              height={20}
-              tone="dark"
-            />
-          </span>
-          <span className={styles["menu-label"]}>{t.settings}</span>
-        </button>
-        <button
-          type="button"
-          role="menuitem"
-          className={styles["menu-item"]}
-          aria-haspopup="true"
-          aria-expanded={helpOpen}
-          onPointerEnter={openHelpSubmenu}
-          onFocus={openHelpSubmenu}
-          onBlur={handleHelpBlur}
-          onClick={() => setHelpOpen((prev) => !prev)}
-        >
-          <span className={styles["menu-item-leading"]} aria-hidden="true">
-            <ThemeIcon
-              name="question-mark-circle"
-              className={styles["menu-icon"]}
-              width={20}
-              height={20}
-              tone="dark"
-            />
-          </span>
-          <span className={styles["menu-label"]}>{t.help}</span>
-          <span className={styles["menu-item-trailing"]} aria-hidden="true">
-            <ThemeIcon
-              name="arrow-right"
-              className={styles["menu-icon"]}
-              width={18}
-              height={18}
-              tone="dark"
-            />
-          </span>
-        </button>
-        <div className={styles["menu-divider"]} aria-hidden="true" />
-        <button
-          type="button"
-          role="menuitem"
-          className={`${styles["menu-item"]} ${styles["menu-item-danger"]}`}
-          onClick={handleMenuAction(onOpenLogout)}
-        >
-          <span className={styles["menu-item-leading"]} aria-hidden="true">
-            <ThemeIcon
-              name="arrow-right-on-rectangle"
-              className={styles["menu-icon"]}
-              width={20}
-              height={20}
-              tone="dark"
-            />
-          </span>
-          <span className={styles["menu-label"]}>{t.logout}</span>
-        </button>
-      </div>
-      <div
-        className={styles["submenu-panel"]}
-        role="menu"
-        aria-hidden={!helpOpen}
-        data-open={helpOpen ? "true" : "false"}
-      >
-        {resolvedHelpItems.map((item) => (
-          <button
-            key={item.key}
-            type="button"
-            role="menuitem"
-            className={styles["submenu-item"]}
-            onClick={handleHelpItem(item)}
-            onPointerEnter={openHelpSubmenu}
-            onFocus={openHelpSubmenu}
-          >
-            <span className={styles["submenu-icon-wrapper"]} aria-hidden="true">
-              <ThemeIcon
-                name={item.icon}
-                className={styles["submenu-icon"]}
-                width={22}
-                height={22}
-                tone="dark"
-              />
-            </span>
-            <span className={styles["submenu-label"]}>{item.label}</span>
-          </button>
+        {menuSections.map((section, sectionIndex) => (
+          <Fragment key={section.key}>
+            {section.items.map((item) => {
+              const buttonClassName =
+                item.tone === "danger"
+                  ? `${styles["menu-item"]} ${styles["menu-item-danger"]}`
+                  : styles["menu-item"];
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  role="menuitem"
+                  className={buttonClassName}
+                  onClick={handleMenuAction(item.action)}
+                >
+                  <span className={styles["menu-item-leading"]} aria-hidden="true">
+                    <ThemeIcon
+                      name={item.icon}
+                      className={styles["menu-icon"]}
+                      width={20}
+                      height={20}
+                      tone="dark"
+                    />
+                  </span>
+                  <span className={styles["menu-label"]}>{item.label}</span>
+                </button>
+              );
+            })}
+            {sectionIndex < menuSections.length - 1 ? (
+              <div className={styles["menu-divider"]} aria-hidden="true" />
+            ) : null}
+          </Fragment>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the help submenu from the header user menu and rebuild the action list via a composable configuration
- delete the obsolete submenu styling hooks now that no nested menu is rendered
- refresh the user menu dropdown tests to validate the remaining actions and close behaviour

## Testing
- npm test -- --runTestsByPath src/components/Header/__tests__/UserMenuDropdown.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e27cc67c6c8332b125694852886d95