### PR TITLE
Refine avatar layout in preferences account section

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -875,33 +875,30 @@
 
 .identity-label {
   margin: 0;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--preferences-panel-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .identity-value {
   margin: 0;
-  font-size: 20px;
-  line-height: 1.6;
-  color: var(--preferences-panel-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow-wrap: break-word;
-  display: flex;
-  align-items: center;
 }
 
-.identity-figure {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-}
-
-.identity-display {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--preferences-panel-text);
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .bindings {

--- a/website/src/pages/preferences/sections/AccountSection.jsx
+++ b/website/src/pages/preferences/sections/AccountSection.jsx
@@ -72,22 +72,24 @@ function AccountSection({
       </div>
       <dl className={styles.details}>
         <div className={`${styles["detail-row"]} ${styles["identity-row"]}`}>
-          <dt className={styles["identity-label"]}>{normalizedIdentity.label}</dt>
+          <dt className={styles["identity-label"]}>
+            <span className={styles["visually-hidden"]}>
+              {normalizedIdentity.label}
+            </span>
+            <Avatar
+              width={AVATAR_SIZE}
+              height={AVATAR_SIZE}
+              aria-hidden={!normalizedIdentity.displayName}
+              alt={normalizedIdentity.avatarAlt}
+              className={styles["identity-avatar-image"]}
+            />
+          </dt>
           <dd
             className={`${styles["detail-value"]} ${styles["identity-value"]}`}
           >
-            <div className={styles["identity-figure"]}>
-              <Avatar
-                width={AVATAR_SIZE}
-                height={AVATAR_SIZE}
-                aria-hidden={!normalizedIdentity.displayName}
-                alt={normalizedIdentity.avatarAlt}
-                className={styles["identity-avatar-image"]}
-              />
-              <span className={styles["identity-display"]}>
-                {normalizedIdentity.displayName}
-              </span>
-            </div>
+            <span className={styles["visually-hidden"]}>
+              {normalizedIdentity.displayName}
+            </span>
           </dd>
           <div className={styles["detail-action"]}>
             <input


### PR DESCRIPTION
## Summary
- render the account avatar directly in the first column and remove the redundant display name column
- center the avatar within the identity row and add an accessible hidden label
- clean up unused identity layout styles after restructuring the markup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2824a72788332b8588aed117b8ec6