### PR TITLE
Fix account avatar row layout

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -793,6 +793,8 @@
 
 .identity-row {
   align-items: center;
+  grid-template-columns: minmax(140px, 0.28fr) minmax(72px, max-content)
+    max-content;
 }
 
 .identity-avatar-image {
@@ -874,10 +876,9 @@
 }
 
 .identity-label {
-  margin: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .identity-value {

--- a/website/src/pages/preferences/sections/AccountSection.jsx
+++ b/website/src/pages/preferences/sections/AccountSection.jsx
@@ -72,10 +72,14 @@ function AccountSection({
       </div>
       <dl className={styles.details}>
         <div className={`${styles["detail-row"]} ${styles["identity-row"]}`}>
-          <dt className={styles["identity-label"]}>
-            <span className={styles["visually-hidden"]}>
-              {normalizedIdentity.label}
-            </span>
+          <dt
+            className={`${styles["detail-label"]} ${styles["identity-label"]}`}
+          >
+            {normalizedIdentity.label}
+          </dt>
+          <dd
+            className={`${styles["detail-value"]} ${styles["identity-value"]}`}
+          >
             <Avatar
               width={AVATAR_SIZE}
               height={AVATAR_SIZE}
@@ -83,13 +87,11 @@ function AccountSection({
               alt={normalizedIdentity.avatarAlt}
               className={styles["identity-avatar-image"]}
             />
-          </dt>
-          <dd
-            className={`${styles["detail-value"]} ${styles["identity-value"]}`}
-          >
-            <span className={styles["visually-hidden"]}>
-              {normalizedIdentity.displayName}
-            </span>
+            {normalizedIdentity.displayName ? (
+              <span className={styles["visually-hidden"]}>
+                {normalizedIdentity.displayName}
+              </span>
+            ) : null}
           </dd>
           <div className={styles["detail-action"]}>
             <input

--- a/website/src/pages/preferences/sections/__tests__/AccountSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/AccountSection.test.jsx
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("@/components/ui/Avatar", () => ({
+  __esModule: true,
+  default: ({ className, ...props }) => (
+    <div data-testid="mock-avatar" className={className} {...props}>
+      avatar
+    </div>
+  ),
+}));
+
+const { default: AccountSection } = await import("../AccountSection.jsx");
+
+const baseBindings = Object.freeze({
+  title: "Connected accounts",
+  items: [],
+});
+
+/**
+ * 测试目标：头像行展示为“标签-头像-操作”三列结构且按钮可用。
+ * 前置条件：提供包含标签、头像替代文本与操作文案的 identity；绑定区无项。
+ * 步骤：
+ *  1) 渲染 AccountSection 组件；
+ *  2) 获取头像行的列节点；
+ *  3) 查询头像与操作按钮。
+ * 断言：
+ *  - 第一列标签节点文本为“头像”；
+ *  - 第二列包含头像占位元素与隐藏用户名；
+ *  - 第三列按钮文案为“更换头像”且处于可点击状态。
+ * 边界/异常：
+ *  - 若 identity.displayName 缺失，应保证头像 aria-hidden 为 true（另行覆盖）。
+ */
+test("GivenIdentityRow_WhenRendered_ThenLabelAvatarAndActionArranged", () => {
+  const { container } = render(
+    <AccountSection
+      title="Account"
+      headingId="account-heading"
+      fields={[]}
+      identity={{
+        label: "头像",
+        displayName: "Taylor",
+        changeLabel: "更换头像",
+        avatarAlt: "Taylor 的头像",
+        onSelectAvatar: jest.fn(),
+      }}
+      bindings={baseBindings}
+    />,
+  );
+
+  const identityLabel = screen.getByText("头像");
+  expect(identityLabel.tagName).toBe("DT");
+
+  const identityRow = identityLabel.closest("div");
+  expect(identityRow).not.toBeNull();
+
+  const columnElements = identityRow ? [...identityRow.children] : [];
+  expect(columnElements).toHaveLength(3);
+
+  const [labelColumn, valueColumn, actionColumn] = columnElements;
+  expect(labelColumn).toBe(identityLabel);
+  expect(valueColumn.tagName).toBe("DD");
+
+  const avatar = screen.getByTestId("mock-avatar");
+  expect(valueColumn).toContainElement(avatar);
+  expect(avatar.getAttribute("aria-hidden")).toBe("false");
+  const hiddenName = valueColumn.querySelector("span");
+  expect(hiddenName?.textContent).toBe("Taylor");
+
+  const actionButton = screen.getByRole("button", { name: "更换头像" });
+  expect(actionColumn).toContainElement(actionButton);
+  expect(actionButton).toBeEnabled();
+
+  expect(container.querySelectorAll("input[type=\"file\"]")).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary
- render the account avatar label in the first column and move the avatar image into the value column for clearer semantics
- tune the identity row grid to center the avatar cell while keeping the action button aligned
- add a focused AccountSection test to cover the expected three-column structure

## Testing
- npm test -- AccountSection
- npm test -- Preferences
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e2865675048332b03774be7e500d13