### PR TITLE
Refine data controls export and styling

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -501,12 +501,20 @@
   transition: border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
+.subscription-action-danger {
+  border-color: color-mix(in srgb, var(--color-danger) 78%, transparent);
+}
+
 .subscription-action:hover {
   border-color: color-mix(
     in srgb,
     var(--preferences-panel-ring) 65%,
     transparent
   );
+}
+
+.subscription-action-danger:hover {
+  border-color: var(--color-danger);
 }
 
 .subscription-matrix {


### PR DESCRIPTION
## Summary
- switch the preferences data section export to a CSV-focused flow and suppress the header description/background per the new layout
- highlight the clear-all history command with a danger-styled border
- update the data section unit test to cover the CSV export behaviour

## Testing
- npm run test -- --runTestsByPath src/pages/preferences/sections/__tests__/DataSection.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e28794cdb883329abeb6c6c0558313