### PR TITLE
Align change avatar button with other preference actions

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -801,7 +801,7 @@
 
 .identity-row {
   align-items: center;
-  grid-template-columns: minmax(140px, 0.28fr) minmax(72px, max-content)
+  grid-template-columns: minmax(140px, 0.28fr) minmax(72px, 1fr)
     max-content;
 }
 


### PR DESCRIPTION
## Summary
- allow the identity row grid to stretch its middle column so the change-avatar button lines up with other actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28afb6e44833292bcc86672830c06