### PR TITLE
feat: refresh waiting loader animation

### DIFF
--- a/website/src/components/ui/Loader/Loader.jsx
+++ b/website/src/components/ui/Loader/Loader.jsx
@@ -1,4 +1,9 @@
+import waitingFrame1 from "@/assets/waiting-frame-1.svg";
+import waitingFrame2 from "@/assets/waiting-frame-2.svg";
+import waitingFrame3 from "@/assets/waiting-frame-3.svg";
 import styles from "./Loader.module.css";
+
+const WAITING_FRAMES = [waitingFrame1, waitingFrame2, waitingFrame3];
 
 function Loader() {
   return (
@@ -9,11 +14,16 @@ function Loader() {
       aria-busy="true"
     >
       <div className={styles.symbol} aria-hidden="true">
-        <span className={styles.bar} />
-        <span className={styles.bar} />
-        <span className={styles.bar} />
-        <span className={styles.bar} />
-        <span className={styles.bar} />
+        {WAITING_FRAMES.map((frameSrc) => (
+          <img
+            key={frameSrc}
+            className={styles.frame}
+            src={frameSrc}
+            alt=""
+            loading="lazy"
+            decoding="async"
+          />
+        ))}
       </div>
       <span className={styles.label}>Loading…</span>
     </div>

--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -6,84 +6,94 @@
   padding: var(--space-4);
   background: transparent;
 
-  /* 采用扁平化矩形动画，通过变量让主题色与尺寸易于后续扩展。 */
-  --loader-bar-color: var(--loader-bar-tone);
-
   /*
-   * 取舍：配合等待页面的新版交互稿，将每个矩形统一拉伸至 160px
-   *      （以 calc(var(--space-5) * 5) 取代硬编码），并以主题 radius-xl
-   *       token 维持 20px 圆角；高度沿用既有 token，保持节奏感。
+   * 背景：等待页动画从矩形波动升级为三帧往返的 SVG 序列。
+   * 取舍：通过变量固定最大宽度与节奏，让后续更换素材时只需替换帧图。
    */
-  --loader-bar-width: calc(var(--space-5) * 5);
-  --loader-bar-height: calc(var(--space-5) + var(--space-4));
-  --loader-bar-radius: var(--radius-xl);
-  --loader-bar-stroke: var(--space-1); /* 控制矩形描边厚度，便于主题扩展。 */
+  --waiting-frame-max-width: calc(var(--space-5) * 9);
+  --waiting-animation-duration: 2.4s;
 }
 
 .symbol {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-2);
-  padding: calc(var(--space-2) + var(--space-1));
+  position: relative;
+  inline-size: min(80vw, var(--waiting-frame-max-width));
+  aspect-ratio: 682 / 454;
+  display: grid;
+  place-items: center;
   border-radius: var(--radius-xl);
-
-  /* 保持透明底以让动效悬浮于背景之上，遵循 2024-03 视觉规范的“纯净等待”策略。 */
-
-  /* 维持无底色，仅通过阴影拉开层级，便于后续针对无障碍主题微调。 */
   box-shadow: var(
     --loader-symbol-shadow,
     0 24px 48px color-mix(in srgb, var(--shadow-color) 35%, transparent)
   );
+  isolation: isolate; /* 确保帧间叠加时阴影不受混合干扰。 */
 }
 
-.bar {
-  /* 矩形围绕中心伸缩，确保所有矩形中心保持同一水平线。 */
-  inline-size: var(--loader-bar-width);
-  block-size: var(--loader-bar-height);
-  border-radius: var(--loader-bar-radius);
-  position: relative;
-  overflow: hidden;
-  background: none;
-  transform-origin: center;
-  animation: bar-wave 1.4s ease-in-out infinite;
+.frame {
+  position: absolute;
+  inset: 0;
+  inline-size: 100%;
+  block-size: 100%;
+  display: block;
+  object-fit: contain;
+  opacity: 0;
+  animation-duration: var(--waiting-animation-duration);
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  animation-fill-mode: both;
+  will-change: opacity;
 }
 
-.bar:nth-child(1) {
-  animation-delay: 0s;
+.frame:nth-child(1) {
+  animation-name: waiting-animation-frame-one;
 }
 
-.bar:nth-child(2) {
-  animation-delay: 0.12s;
+.frame:nth-child(2) {
+  animation-name: waiting-animation-frame-two;
 }
 
-.bar:nth-child(3) {
-  animation-delay: 0.24s;
+.frame:nth-child(3) {
+  animation-name: waiting-animation-frame-three;
 }
 
-.bar:nth-child(4) {
-  animation-delay: 0.36s;
-}
-
-.bar:nth-child(5) {
-  animation-delay: 0.48s;
-}
-
-@keyframes bar-wave {
+@keyframes waiting-animation-frame-one {
   0%,
-  100% {
-    transform: scaleY(0.55);
-    opacity: 0.35;
-  }
-
-  35% {
-    transform: scaleY(1.1);
+  24% {
     opacity: 1;
   }
 
+  40%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes waiting-animation-frame-two {
+  0%,
+  28% {
+    opacity: 0;
+  }
+
+  38%,
+  62% {
+    opacity: 1;
+  }
+
+  72%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes waiting-animation-frame-three {
+  0%,
   60% {
-    transform: scaleY(0.75);
-    opacity: 0.65;
+    opacity: 0;
+  }
+
+  76%,
+  100% {
+    opacity: 1;
   }
 }
 
@@ -100,13 +110,7 @@
 }
 
 @media (width <= 480px) {
-  .loader {
-    --loader-bar-height: calc(var(--space-4) + var(--space-3));
-    --loader-bar-width: calc(var(--space-5) * 5);
-  }
-
   .symbol {
-    gap: var(--space-1);
-    padding: var(--space-2);
+    inline-size: min(90vw, calc(var(--space-5) * 7));
   }
 }


### PR DESCRIPTION
## Summary
- replace the loader bars with the new SVG frame-based waiting animation
- add frame sequencing keyframes and responsive sizing to keep the artwork centered

## Testing
- npx eslint src/components/ui/Loader/Loader.jsx
- npx stylelint "src/components/ui/Loader/*.css"
- npx prettier --write src/components/ui/Loader/Loader.jsx src/components/ui/Loader/Loader.module.css

------
https://chatgpt.com/codex/tasks/task_e_68e28a74629883328ebc18da54e65300