### PR TITLE
fix: 为数据分区补充无障碍描述关联

### DIFF
--- a/website/src/pages/preferences/sections/DataSection.jsx
+++ b/website/src/pages/preferences/sections/DataSection.jsx
@@ -154,10 +154,17 @@ const toLanguageOptions = (history, translations) => {
     .sort((a, b) => a.label.localeCompare(b.label));
 };
 
-function DataSection({ title, message: _message, headingId, descriptionId: _descriptionId }) {
+function DataSection({ title, message, headingId, descriptionId }) {
   const { t } = useLanguage();
   const userStore = useUser();
   const user = userStore?.user;
+
+  const fallbackSectionDescriptionId = useId();
+  const hasSectionMessage =
+    typeof message === "string" && message.trim().length > 0;
+  const sectionDescriptionId = hasSectionMessage
+    ? descriptionId ?? fallbackSectionDescriptionId
+    : undefined;
 
   const {
     historyCaptureEnabled,
@@ -347,6 +354,7 @@ function DataSection({ title, message: _message, headingId, descriptionId: _desc
   return (
     <section
       aria-labelledby={headingId}
+      aria-describedby={sectionDescriptionId}
       className={composeClassName(styles.section, styles["section-plain"])}
     >
       <div className={styles["section-header"]}>
@@ -355,6 +363,15 @@ function DataSection({ title, message: _message, headingId, descriptionId: _desc
         </h3>
         <div className={styles["section-divider"]} aria-hidden="true" />
       </div>
+      {hasSectionMessage ? (
+        // 使用视觉隐藏的描述串联 message，确保屏幕阅读器获得上下文而不干扰视觉布局。
+        <p
+          id={sectionDescriptionId}
+          className={styles["visually-hidden"]}
+        >
+          {message}
+        </p>
+      ) : null}
       <div className={styles.controls}>
         <fieldset
           className={styles["control-field"]}

--- a/website/src/pages/preferences/sections/__tests__/DataSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/DataSection.test.jsx
@@ -109,6 +109,35 @@ afterEach(() => {
 });
 
 /**
+ * 测试目标：渲染 message 时 Section 会暴露辅助描述并建立 aria 关联。
+ * 前置条件：传入 message 与 descriptionId。
+ * 步骤：
+ *  1) 渲染 DataSection；
+ *  2) 查询 section 与描述元素。
+ * 断言：
+ *  - 描述元素的 id 与传入 descriptionId 一致；
+ *  - section 上的 aria-describedby 指向该 id。
+ * 边界/异常：
+ *  - 若缺失关联则会影响屏幕阅读器理解上下文。
+ */
+test("Given section message When rendering Then description linked for accessibility", () => {
+  render(
+    <DataSection
+      title="Data"
+      message="Control your data"
+      headingId="data-heading"
+      descriptionId="data-description"
+    />,
+  );
+
+  const section = screen.getByRole("region", { name: "Data" });
+  const description = screen.getByText("Control your data");
+
+  expect(description).toHaveAttribute("id", "data-description");
+  expect(section).toHaveAttribute("aria-describedby", "data-description");
+});
+
+/**
  * 测试目标：点击“暂停采集”会关闭历史采集开关。
  * 前置条件：采集开关默认为开启。
  * 步骤：


### PR DESCRIPTION
## Summary
- 让 DataSection 利用 message 建立 aria-describedby 关联，补全可访问性语义并消除未使用变量
- 为 DataSection 增加覆盖 aria 描述关联的单元测试

## Testing
- npm test -- DataSection
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e28bb5b98c8332bf2df07bdd3c6b59