### PR TITLE
Fix stylelint violations in keyboard preferences module

### DIFF
--- a/website/src/pages/preferences/sections/KeyboardSection.module.css
+++ b/website/src/pages/preferences/sections/KeyboardSection.module.css
@@ -122,11 +122,6 @@
     box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-:global(:root[data-theme="light"]) .reset {
-  color: #ffffff;
-  background: #10121a;
-}
-
 .reset:hover {
   transform: translateY(-1px);
 }
@@ -140,4 +135,9 @@
   cursor: not-allowed;
   opacity: 0.6;
   transform: none;
+}
+
+:global(:root[data-theme="light"]) .reset {
+  color: #fff;
+  background: #10121a;
 }


### PR DESCRIPTION
## Summary
- shorten the light theme reset button color hex to follow the color length rule
- reorder reset state selectors ahead of the theme-specific override to satisfy no-descending-specificity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e28fb3b5c483329ba81e8c1e90fd3e