### PR TITLE
Refine loader animation with fade pulse

### DIFF
--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -4,14 +4,16 @@
   inline-size: 100%;
   min-block-size: var(--vh);
   padding: var(--space-4);
-  background: transparent;
+  background: none;
 
   /*
-   * 背景：等待页动画从矩形波动升级为三帧往返的 SVG 序列。
-   * 取舍：通过变量固定最大宽度与节奏，让后续更换素材时只需替换帧图。
+   * 背景：等待序列切换为单帧缩放与渐隐组合动画，去除原先的填充底色，避免与页面主题冲突。
+   * 取舍：继续复用三帧 SVG 资源，通过延迟错峰制造节奏感；新增缩放上下限以统一后续动效自定义。
    */
   --waiting-frame-max-width: calc(var(--space-5) * 9);
   --waiting-animation-duration: 2.4s;
+  --waiting-scale-min: 0.9;
+  --waiting-scale-max: 1.05;
 }
 
 .symbol {
@@ -20,12 +22,14 @@
   aspect-ratio: 682 / 454;
   display: grid;
   place-items: center;
+  background: none;
   border-radius: var(--radius-xl);
   box-shadow: var(
     --loader-symbol-shadow,
     0 24px 48px color-mix(in srgb, var(--shadow-color) 35%, transparent)
   );
   isolation: isolate; /* 确保帧间叠加时阴影不受混合干扰。 */
+  overflow: hidden; /* 缩放动画不再外溢至容器外部，保持构图干净。 */
 }
 
 .frame {
@@ -36,64 +40,51 @@
   display: block;
   object-fit: contain;
   opacity: 0;
+  transform: scale(var(--waiting-scale-min));
+  animation-name: waiting-frame;
   animation-duration: var(--waiting-animation-duration);
   animation-timing-function: ease-in-out;
   animation-iteration-count: infinite;
-  animation-direction: alternate;
   animation-fill-mode: both;
-  will-change: opacity;
-}
-
-.frame:nth-child(1) {
-  animation-name: waiting-animation-frame-one;
+  will-change: opacity, transform;
 }
 
 .frame:nth-child(2) {
-  animation-name: waiting-animation-frame-two;
+  animation-delay: calc(var(--waiting-animation-duration) / 3);
 }
 
 .frame:nth-child(3) {
-  animation-name: waiting-animation-frame-three;
+  animation-delay: calc(var(--waiting-animation-duration) / 3 * 2);
 }
 
-@keyframes waiting-animation-frame-one {
-  0%,
-  24% {
-    opacity: 1;
-  }
-
-  40%,
-  100% {
-    opacity: 0;
-  }
+.frame:nth-child(1) {
+  animation-delay: 0s;
 }
 
-@keyframes waiting-animation-frame-two {
-  0%,
-  28% {
+@keyframes waiting-frame {
+  0% {
     opacity: 0;
+    transform: scale(var(--waiting-scale-min));
   }
 
-  38%,
-  62% {
+  20% {
     opacity: 1;
+    transform: scale(1);
   }
 
-  72%,
+  50% {
+    opacity: 0.5;
+    transform: scale(var(--waiting-scale-max));
+  }
+
+  80% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
   100% {
     opacity: 0;
-  }
-}
-
-@keyframes waiting-animation-frame-three {
-  0%,
-  60% {
-    opacity: 0;
-  }
-
-  76%,
-  100% {
-    opacity: 1;
+    transform: scale(var(--waiting-scale-min));
   }
 }
 
@@ -107,6 +98,14 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frame {
+    animation: none;
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @media (width <= 480px) {


### PR DESCRIPTION
## Summary
- remove the loader backdrop fill and constrain the symbol container to stay transparent
- switch the frame animation to a scale-and-fade pulse while staggering frames for a continuous loop
- add a reduced-motion fallback that shows a static frame for accessibility

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e29149642c833289767e565954b054