### PR TITLE
Update avatar label translations

### DIFF
--- a/website/src/__tests__/Preferences.test.jsx
+++ b/website/src/__tests__/Preferences.test.jsx
@@ -10,7 +10,7 @@ const mockLanguage = {
   prefAccountTitle: "Account",
   prefTablistLabel: "Preference sections",
   settingsAccountDescription: "Details that travel with your workspace.",
-  settingsAccountAvatarLabel: "Change avatar",
+  settingsAccountAvatarLabel: "Avatar",
   settingsAccountUsername: "Username",
   settingsAccountEmail: "Email",
   settingsAccountPhone: "Phone",
@@ -37,6 +37,11 @@ jest.unstable_mockModule("@/context", () => ({
   useLanguage: () => ({ t: mockLanguage }),
   useUser: () => ({ user: mockUser }),
   useTheme: () => ({ theme: "light", setTheme: jest.fn() }),
+  useKeyboardShortcutContext: () => ({
+    register: jest.fn(),
+    unregister: jest.fn(),
+  }),
+  KEYBOARD_SHORTCUT_RESET_ACTION: "__GLOBAL_RESET__",
 }));
 
 jest.unstable_mockModule("@/components/ui/Avatar", () => ({
@@ -91,7 +96,7 @@ test("GivenUserContext_WhenSwitchingToAccountTab_ThenAccountFieldsVisible", asyn
   ).toBeInTheDocument();
   expect(
     within(activePanel).getAllByText(mockLanguage.settingsAccountAvatarLabel),
-  ).toHaveLength(2);
+  ).toHaveLength(1);
   expect(within(activePanel).getAllByText(mockUser.username)).toHaveLength(2);
   expect(within(activePanel).getByText(mockUser.email)).toBeInTheDocument();
   expect(within(activePanel).getByText("+1 111")).toBeInTheDocument();

--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -101,7 +101,7 @@ export default {
   settingsTabAccount: "Account",
   settingsAccountDescription:
     "Review and safeguard the basics that identify you in Glancy.",
-  settingsAccountAvatarLabel: "Change avatar",
+  settingsAccountAvatarLabel: "Avatar",
   settingsManageProfile: "Manage profile",
   settingsAccountUsername: "Username",
   settingsAccountEmail: "Email",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -92,7 +92,7 @@ export default {
   settingsEraseHistory: "清除历史",
   settingsTabAccount: "账号",
   settingsAccountDescription: "梳理与你账户相关的基础身份信息。",
-  settingsAccountAvatarLabel: "更换头像",
+  settingsAccountAvatarLabel: "头像",
   settingsManageProfile: "更换用户名",
   settingsAccountUsername: "用户名",
   settingsAccountEmail: "邮箱",

--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -4,11 +4,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const mockUseLanguage = jest.fn();
 const mockUseUser = jest.fn();
 const mockUseTheme = jest.fn();
+const mockUseKeyboardShortcutContext = jest.fn();
 
 jest.unstable_mockModule("@/context", () => ({
   useLanguage: mockUseLanguage,
   useUser: mockUseUser,
   useTheme: mockUseTheme,
+  useKeyboardShortcutContext: mockUseKeyboardShortcutContext,
+  KEYBOARD_SHORTCUT_RESET_ACTION: "__GLOBAL_RESET__",
 }));
 
 let usePreferenceSections;
@@ -140,6 +143,7 @@ beforeEach(() => {
   mockUseLanguage.mockReset();
   mockUseUser.mockReset();
   mockUseTheme.mockReset();
+  mockUseKeyboardShortcutContext.mockReset();
   translations = createTranslations();
   mockUseLanguage.mockReturnValue({ t: translations });
   mockUseUser.mockReturnValue({
@@ -151,6 +155,10 @@ beforeEach(() => {
     },
   });
   mockUseTheme.mockReturnValue({ theme: "light", setTheme: jest.fn() });
+  mockUseKeyboardShortcutContext.mockReturnValue({
+    register: jest.fn(),
+    unregister: jest.fn(),
+  });
 });
 
 /**

--- a/website/src/pages/preferences/sections/AccountSection.jsx
+++ b/website/src/pages/preferences/sections/AccountSection.jsx
@@ -44,12 +44,15 @@ function AccountSection({
   );
 
   const normalizedIdentity = useMemo(
-    () => ({
-      label: identity?.label ?? identity?.changeLabel ?? title,
-      displayName: identity?.displayName ?? "",
-      changeLabel: identity?.changeLabel ?? "Change avatar",
-      avatarAlt: identity?.avatarAlt ?? title,
-    }),
+    () => {
+      const fallbackLabel = identity?.changeLabel ?? "Avatar";
+      return {
+        label: identity?.label ?? fallbackLabel,
+        displayName: identity?.displayName ?? "",
+        changeLabel: identity?.changeLabel ?? "Change avatar",
+        avatarAlt: identity?.avatarAlt ?? title,
+      };
+    },
     [
       identity?.avatarAlt,
       identity?.changeLabel,

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -252,7 +252,7 @@ function usePreferenceSections({ initialSectionId }) {
     ];
 
     const accountIdentity = {
-      label: t.settingsAccountAvatarLabel ?? changeAvatarLabel,
+      label: t.settingsAccountAvatarLabel ?? "Avatar",
       displayName: usernameValue,
       changeLabel: changeAvatarLabel,
       avatarAlt: accountLabel,


### PR DESCRIPTION
## Summary
- rename the account avatar label copy to "Avatar"/"头像" across the i18n resources and fallbacks
- keep the avatar action copy unchanged while adjusting AccountSection identity normalization to default to the neutral label
- refresh the preferences test doubles to cover keyboard shortcut context exports and align the expectations with the new label usage

## Testing
- npm test -- --runTestsByPath src/__tests__/Preferences.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js src/pages/preferences/sections/__tests__/AccountSection.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e2920557408332b1d38dc0980a3a82