### PR TITLE
Remove keyboard shortcut summary copy

### DIFF
--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -4,11 +4,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const mockUseLanguage = jest.fn();
 const mockUseUser = jest.fn();
 const mockUseTheme = jest.fn();
+const mockUseKeyboardShortcutContext = jest.fn();
 
 jest.unstable_mockModule("@/context", () => ({
   useLanguage: mockUseLanguage,
   useUser: mockUseUser,
   useTheme: mockUseTheme,
+  useKeyboardShortcutContext: mockUseKeyboardShortcutContext,
+  KEYBOARD_SHORTCUT_RESET_ACTION: "__GLOBAL_RESET__",
 }));
 
 let usePreferenceSections;
@@ -140,6 +143,7 @@ beforeEach(() => {
   mockUseLanguage.mockReset();
   mockUseUser.mockReset();
   mockUseTheme.mockReset();
+  mockUseKeyboardShortcutContext.mockReset();
   translations = createTranslations();
   mockUseLanguage.mockReturnValue({ t: translations });
   mockUseUser.mockReturnValue({
@@ -292,6 +296,28 @@ test("Given blank section titles When resolving modal heading Then fallback titl
   expect(result.current.panel.modalHeadingId).toBe(
     "settings-modal-fallback-heading",
   );
+});
+
+/**
+ * 测试目标：当键盘分区无描述时，应移除面板描述语义以避免空引用。
+ * 前置条件：使用默认翻译渲染 Hook，并激活 keyboard 分区。
+ * 步骤：
+ *  1) 指定 initialSectionId 为 keyboard 渲染 Hook；
+ * 断言：
+ *  - activeSection 的 message 为空字符串；
+ *  - panel.descriptionId 为 undefined。
+ * 边界/异常：
+ *  - 若未来恢复描述，应同步更新该断言。
+ */
+test("Given keyboard section without summary When rendering Then panel description id clears", () => {
+  const { result } = renderHook(() =>
+    usePreferenceSections({
+      initialSectionId: "keyboard",
+    }),
+  );
+
+  expect(result.current.activeSection?.componentProps?.message).toBe("");
+  expect(result.current.panel.descriptionId).toBeUndefined();
 });
 
 /**

--- a/website/src/pages/preferences/sections/KeyboardSection.jsx
+++ b/website/src/pages/preferences/sections/KeyboardSection.jsx
@@ -31,6 +31,8 @@ function KeyboardSection({ title, message, headingId, descriptionId }) {
   const [recordingAction, setRecordingAction] = useState(null);
 
   const items = useMemo(() => mergeShortcutLists(shortcuts), [shortcuts]);
+  // 键盘分区当前不展示描述文案，但保留 message 以兼容未来扩展，因此需显式判断。
+  const hasMessage = typeof message === "string" && message.trim().length > 0;
 
   const handleCaptureStart = useCallback((action) => {
     setRecordingAction(action);
@@ -93,7 +95,7 @@ function KeyboardSection({ title, message, headingId, descriptionId }) {
           {title}
         </h3>
         <div className={sectionStyles["section-divider"]} aria-hidden="true" />
-        {message ? (
+        {hasMessage ? (
           <p id={descriptionId} className={styles.description}>
             {message}
           </p>
@@ -101,7 +103,7 @@ function KeyboardSection({ title, message, headingId, descriptionId }) {
       </div>
       <div className={styles.body}>
         <div className={styles.hint}>{hint}</div>
-        <ul className={styles.list} aria-describedby={descriptionId}>
+        <ul className={styles.list} aria-describedby={hasMessage ? descriptionId : undefined}>
           {items.map((item) => {
             const label = translateShortcutAction(t, item.action);
             const displayKeys = formatShortcutKeys(item.keys);
@@ -162,9 +164,14 @@ function KeyboardSection({ title, message, headingId, descriptionId }) {
 
 KeyboardSection.propTypes = {
   title: PropTypes.string.isRequired,
-  message: PropTypes.string.isRequired,
+  message: PropTypes.string,
   headingId: PropTypes.string.isRequired,
-  descriptionId: PropTypes.string.isRequired,
+  descriptionId: PropTypes.string,
+};
+
+KeyboardSection.defaultProps = {
+  message: "",
+  descriptionId: undefined,
 };
 
 export default KeyboardSection;

--- a/website/src/pages/preferences/sections/__tests__/KeyboardSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/KeyboardSection.test.jsx
@@ -150,3 +150,34 @@ test("Given reset button When clicked Then triggers resetShortcuts", () => {
   fireEvent.click(screen.getByRole("button", { name: "Reset" }));
   expect(resetShortcuts).toHaveBeenCalledTimes(1);
 });
+
+/**
+ * 测试目标：当 message 为空白时不渲染描述段落且列表不暴露 aria-describedby。
+ * 前置条件：提供包含默认快捷键的上下文，并传入仅包含空白的 message。
+ * 步骤：
+ *  1) 渲染组件；
+ * 断言：
+ *  - DOM 中不存在 descriptionId 对应元素；
+ *  - 列表缺少 aria-describedby 属性。
+ * 边界/异常：
+ *  - 若未来恢复描述，应更新断言确保属性重新出现。
+ */
+test("Given empty message When rendering Then omits description semantics", () => {
+  mockUseKeyboardShortcutContext.mockReturnValue({
+    shortcuts: [
+      { action: "FOCUS_SEARCH", keys: ["MOD", "SHIFT", "F"], defaultKeys: ["MOD", "SHIFT", "F"] },
+    ],
+    updateShortcut: jest.fn(),
+    resetShortcuts: jest.fn(),
+    pendingAction: null,
+    errors: {},
+    status: "ready",
+  });
+
+  render(
+    <KeyboardSection title="Keyboard" message="   " headingId="heading" descriptionId="desc" />,
+  );
+
+  expect(document.getElementById("desc")).toBeNull();
+  expect(screen.getByRole("list")).not.toHaveAttribute("aria-describedby");
+});

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -194,13 +194,8 @@ function usePreferenceSections({ initialSectionId }) {
     );
 
     const keyboardLabel = t.settingsTabKeyboard ?? "Keyboard shortcuts";
-    const keyboardSummary =
-      t.settingsKeyboardDescription ??
-      "Master Glancy with a curated set of command keys.";
-    const keyboardMessage = pickFirstMeaningfulString(
-      [t.settingsKeyboardDescription, t.prefKeyboardTitle],
-      keyboardSummary,
-    );
+    // 键盘分区根据最新交互规范不再展示额外描述，保留空字符串以便未来恢复时只需更新此处。
+    const keyboardMessage = "";
 
     const accountLabel =
       t.prefAccountTitle ?? t.settingsTabAccount ?? "Account";
@@ -357,7 +352,6 @@ function usePreferenceSections({ initialSectionId }) {
     changeAvatarLabel,
     fallbackValue,
     t.prefAccountTitle,
-    t.prefKeyboardTitle,
     t.prefPersonalizationTitle,
     t.settingsAccountBindingApple,
     t.settingsAccountBindingGoogle,
@@ -367,7 +361,6 @@ function usePreferenceSections({ initialSectionId }) {
     t.settingsAccountUsername,
     t.settingsDataDescription,
     t.settingsDataNotice,
-    t.settingsKeyboardDescription,
     t.settingsPersonalizationDescription,
     t.settingsTabAccount,
     t.settingsTabData,
@@ -445,9 +438,14 @@ function usePreferenceSections({ initialSectionId }) {
   const panelHeadingId = activeSection
     ? `${activeSection.id}-section-heading`
     : "";
-  const panelDescriptionId = activeSection
+  const shouldExposePanelDescription = Boolean(
+    activeSection &&
+      typeof activeSection.componentProps?.message === "string" &&
+      activeSection.componentProps.message.trim().length > 0,
+  );
+  const panelDescriptionId = shouldExposePanelDescription
     ? `${activeSection.id}-section-description`
-    : "";
+    : undefined;
 
   const resolvedModalHeadingText = pickFirstMeaningfulString(
     [activeSection?.componentProps?.title, activeSection?.label],


### PR DESCRIPTION
## Summary
- hide the keyboard shortcuts description while keeping the section props ready for future reuse
- ensure the preference hook no longer exposes an empty description identifier
- cover the no-description flow with unit tests for the section component and hook

## Testing
- npm test -- --runTestsByPath src/pages/preferences/sections/__tests__/KeyboardSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e291a0f2948332a5869c6aadd5f87a