### PR TITLE
Fix stylelint spacing issue in loader module CSS

### DIFF
--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -37,6 +37,7 @@
   display: block;
   object-fit: contain;
   opacity: 0;
+
   /* 通过缩放 + 透明度营造柔和的呼吸节奏，降低帧切换突兀感。 */
   animation-duration: var(--waiting-animation-duration);
   animation-timing-function: ease-in-out;


### PR DESCRIPTION
## Summary
- add the missing empty line before the loader frame animation comment to satisfy stylelint expectations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2946dbd7483328ee49941a1cdbd15