### PR TITLE
Remove keyboard section description paragraph

### DIFF
--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -303,12 +303,12 @@ test("Given blank section titles When resolving modal heading Then fallback titl
 });
 
 /**
- * 测试目标：当键盘分区无描述时，应移除面板描述语义以避免空引用。
+ * 测试目标：当键盘分区未提供描述时，应移除面板描述语义以避免空引用。
  * 前置条件：使用默认翻译渲染 Hook，并激活 keyboard 分区。
  * 步骤：
  *  1) 指定 initialSectionId 为 keyboard 渲染 Hook；
  * 断言：
- *  - activeSection 的 message 为空字符串；
+ *  - activeSection 不再暴露 message 属性；
  *  - panel.descriptionId 为 undefined。
  * 边界/异常：
  *  - 若未来恢复描述，应同步更新该断言。
@@ -320,7 +320,7 @@ test("Given keyboard section without summary When rendering Then panel descripti
     }),
   );
 
-  expect(result.current.activeSection?.componentProps?.message).toBe("");
+  expect(result.current.activeSection?.componentProps?.message).toBeUndefined();
   expect(result.current.panel.descriptionId).toBeUndefined();
 });
 

--- a/website/src/pages/preferences/sections/KeyboardSection.jsx
+++ b/website/src/pages/preferences/sections/KeyboardSection.jsx
@@ -24,15 +24,13 @@ import styles from "./KeyboardSection.module.css";
 
 const composeClassName = (...tokens) => tokens.filter(Boolean).join(" ");
 
-function KeyboardSection({ title, message, headingId, descriptionId }) {
+function KeyboardSection({ title, headingId }) {
   const { t } = useLanguage();
   const { shortcuts, updateShortcut, resetShortcuts, pendingAction, errors, status } =
     useKeyboardShortcutContext();
   const [recordingAction, setRecordingAction] = useState(null);
 
   const items = useMemo(() => mergeShortcutLists(shortcuts), [shortcuts]);
-  // 键盘分区当前不展示描述文案，但保留 message 以兼容未来扩展，因此需显式判断。
-  const hasMessage = typeof message === "string" && message.trim().length > 0;
 
   const handleCaptureStart = useCallback((action) => {
     setRecordingAction(action);
@@ -95,15 +93,10 @@ function KeyboardSection({ title, message, headingId, descriptionId }) {
           {title}
         </h3>
         <div className={sectionStyles["section-divider"]} aria-hidden="true" />
-        {hasMessage ? (
-          <p id={descriptionId} className={styles.description}>
-            {message}
-          </p>
-        ) : null}
       </div>
       <div className={styles.body}>
         <div className={styles.hint}>{hint}</div>
-        <ul className={styles.list} aria-describedby={hasMessage ? descriptionId : undefined}>
+        <ul className={styles.list}>
           {items.map((item) => {
             const label = translateShortcutAction(t, item.action);
             const displayKeys = formatShortcutKeys(item.keys);
@@ -164,14 +157,7 @@ function KeyboardSection({ title, message, headingId, descriptionId }) {
 
 KeyboardSection.propTypes = {
   title: PropTypes.string.isRequired,
-  message: PropTypes.string,
   headingId: PropTypes.string.isRequired,
-  descriptionId: PropTypes.string,
-};
-
-KeyboardSection.defaultProps = {
-  message: "",
-  descriptionId: undefined,
 };
 
 export default KeyboardSection;

--- a/website/src/pages/preferences/sections/__tests__/KeyboardSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/KeyboardSection.test.jsx
@@ -58,14 +58,7 @@ test("Given focused shortcut When pressing new combo Then invokes update", async
     status: "ready",
   });
 
-  render(
-    <KeyboardSection
-      title="Keyboard"
-      message="message"
-      headingId="heading"
-      descriptionId="desc"
-    />,
-  );
+  render(<KeyboardSection title="Keyboard" headingId="heading" />);
 
   const button = screen.getByRole("button", { name: "Edit shortcut for Focus search" });
   fireEvent.click(button);
@@ -102,14 +95,7 @@ test("Given conflict error When rendering Then shows conflict message", () => {
     status: "ready",
   });
 
-  render(
-    <KeyboardSection
-      title="Keyboard"
-      message="message"
-      headingId="heading"
-      descriptionId="desc"
-    />,
-  );
+  render(<KeyboardSection title="Keyboard" headingId="heading" />);
 
   expect(screen.getByText("Conflict")).toBeInTheDocument();
 });
@@ -138,31 +124,24 @@ test("Given reset button When clicked Then triggers resetShortcuts", () => {
     status: "ready",
   });
 
-  render(
-    <KeyboardSection
-      title="Keyboard"
-      message="message"
-      headingId="heading"
-      descriptionId="desc"
-    />,
-  );
+  render(<KeyboardSection title="Keyboard" headingId="heading" />);
 
   fireEvent.click(screen.getByRole("button", { name: "Reset" }));
   expect(resetShortcuts).toHaveBeenCalledTimes(1);
 });
 
 /**
- * 测试目标：当 message 为空白时不渲染描述段落且列表不暴露 aria-describedby。
- * 前置条件：提供包含默认快捷键的上下文，并传入仅包含空白的 message。
+ * 测试目标：组件渲染时应仅暴露标题，不生成描述段落或 aria-describedby 语义。
+ * 前置条件：提供包含默认快捷键的上下文，并模拟传入 descriptionId。
  * 步骤：
  *  1) 渲染组件；
  * 断言：
- *  - DOM 中不存在 descriptionId 对应元素；
+ *  - DOM 中不存在传入 descriptionId 对应的描述元素；
  *  - 列表缺少 aria-describedby 属性。
  * 边界/异常：
- *  - 若未来恢复描述，应更新断言确保属性重新出现。
+ *  - 若未来交互重新引入描述，应同步更新断言覆盖。
  */
-test("Given empty message When rendering Then omits description semantics", () => {
+test("Given keyboard section When rendering Then description semantics stay hidden", () => {
   mockUseKeyboardShortcutContext.mockReturnValue({
     shortcuts: [
       { action: "FOCUS_SEARCH", keys: ["MOD", "SHIFT", "F"], defaultKeys: ["MOD", "SHIFT", "F"] },
@@ -174,9 +153,7 @@ test("Given empty message When rendering Then omits description semantics", () =
     status: "ready",
   });
 
-  render(
-    <KeyboardSection title="Keyboard" message="   " headingId="heading" descriptionId="desc" />,
-  );
+  render(<KeyboardSection title="Keyboard" headingId="heading" descriptionId="desc" />);
 
   expect(document.getElementById("desc")).toBeNull();
   expect(screen.getByRole("list")).not.toHaveAttribute("aria-describedby");

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -194,8 +194,7 @@ function usePreferenceSections({ initialSectionId }) {
     );
 
     const keyboardLabel = t.settingsTabKeyboard ?? "Keyboard shortcuts";
-    // 键盘分区根据最新交互规范不再展示额外描述，保留空字符串以便未来恢复时只需更新此处。
-    const keyboardMessage = "";
+    // 键盘分区根据最新交互规范仅暴露标题，摘要信息交由上下文提示（hint）呈现。
 
     const accountLabel =
       t.prefAccountTitle ?? t.settingsTabAccount ?? "Account";
@@ -316,7 +315,6 @@ function usePreferenceSections({ initialSectionId }) {
         Component: KeyboardSection,
         componentProps: {
           title: keyboardLabel,
-          message: keyboardMessage,
         },
       },
       {


### PR DESCRIPTION
## Summary
- remove the keyboard preferences description paragraph and simplify the section props
- stop providing an empty keyboard message in the preference hook and update related assertions

## Testing
- npm test -- --runTestsByPath src/pages/preferences/sections/__tests__/KeyboardSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e294dd46ac83328d6c6c90c08b4db5