### PR TITLE
Enable avatar uploads from preferences

### DIFF
--- a/website/src/hooks/__tests__/useAvatarUploader.test.js
+++ b/website/src/hooks/__tests__/useAvatarUploader.test.js
@@ -1,0 +1,194 @@
+import { jest } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react";
+
+const mockUseApi = jest.fn();
+const mockUseUser = jest.fn();
+const mockCacheBust = jest.fn();
+
+jest.unstable_mockModule("@/hooks/useApi.js", () => ({
+  useApi: mockUseApi,
+}));
+
+jest.unstable_mockModule("@/context", () => ({
+  useUser: mockUseUser,
+}));
+
+jest.unstable_mockModule("@/utils", () => ({
+  cacheBust: mockCacheBust,
+}));
+
+let useAvatarUploader;
+let AVATAR_UPLOAD_STATUS;
+
+describe("useAvatarUploader", () => {
+  beforeAll(async () => {
+    ({ default: useAvatarUploader, AVATAR_UPLOAD_STATUS } = await import(
+      "../useAvatarUploader.js"
+    ));
+  });
+
+  beforeEach(() => {
+    mockUseApi.mockReset();
+    mockUseUser.mockReset();
+    mockCacheBust.mockReset();
+    mockCacheBust.mockImplementation((url) => `${url}?cache`);
+  });
+
+  /**
+   * 测试目标：提供有效文件与用户上下文时应调用上传接口并刷新用户头像。
+   * 前置条件：users.uploadAvatar 返回包含 avatar 字段的响应。
+   * 步骤：
+   *  1) 渲染 Hook 并执行 onSelectAvatar 命令；
+   *  2) 等待 Promise 解析完成。
+   * 断言：
+   *  - uploadAvatar 接收到正确的 userId/token/file 参数；
+   *  - setUser 得到带缓存穿透参数的头像地址；
+   * 边界/异常：
+   *  - 若响应缺少 avatar 字段，setUser 不应被调用（另行覆盖）。
+   */
+  test("GivenValidFileAndUser_WhenSelectAvatar_ThenUploadsAndUpdatesUser", async () => {
+    const uploadAvatarMock = jest
+      .fn()
+      .mockResolvedValue({ avatar: "https://cdn.example.com/avatar.png" });
+    const baseUser = {
+      id: "42",
+      token: "token-123",
+      username: "Taylor",
+      avatar: "https://cdn.example.com/avatar-old.png",
+    };
+    const setUser = jest.fn();
+
+    mockUseApi.mockReturnValue({ users: { uploadAvatar: uploadAvatarMock } });
+    mockUseUser.mockReturnValue({ user: baseUser, setUser });
+
+    const { result } = renderHook(() => useAvatarUploader());
+
+    await act(async () => {
+      const didUpload = await result.current.onSelectAvatar([
+        { name: "avatar.png" },
+      ]);
+      expect(didUpload).toBe(true);
+    });
+
+    expect(uploadAvatarMock).toHaveBeenCalledWith({
+      userId: "42",
+      token: "token-123",
+      file: { name: "avatar.png" },
+    });
+    expect(mockCacheBust).toHaveBeenCalledWith(
+      "https://cdn.example.com/avatar.png",
+    );
+    expect(setUser).toHaveBeenCalledWith({
+      ...baseUser,
+      avatar: "https://cdn.example.com/avatar.png?cache",
+    });
+    expect(result.current.status).toBe(AVATAR_UPLOAD_STATUS.succeeded);
+    expect(result.current.error).toBeNull();
+  });
+
+  /**
+   * 测试目标：当未选择任何文件时不应触发上传流程。
+   * 前置条件：用户上下文可用但文件列表为空。
+   * 步骤：
+   *  1) 渲染 Hook；
+   *  2) 传入空数组执行 onSelectAvatar。
+   * 断言：
+   *  - uploadAvatar 与 setUser 均未被调用；
+   *  - 状态保持 idle。
+   * 边界/异常：
+   *  - 覆盖 files 为 null 或 undefined 的场景。
+   */
+  test("GivenNoFile_WhenSelectAvatar_ThenSkipUpload", async () => {
+    const uploadAvatarMock = jest.fn();
+    const setUser = jest.fn();
+
+    mockUseApi.mockReturnValue({ users: { uploadAvatar: uploadAvatarMock } });
+    mockUseUser.mockReturnValue({
+      user: { id: "42", token: "token-123" },
+      setUser,
+    });
+
+    const { result } = renderHook(() => useAvatarUploader());
+
+    await act(async () => {
+      const didUpload = await result.current.onSelectAvatar([]);
+      expect(didUpload).toBe(false);
+    });
+
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+    expect(setUser).not.toHaveBeenCalled();
+    expect(result.current.status).toBe(AVATAR_UPLOAD_STATUS.idle);
+    expect(result.current.error).toBeNull();
+  });
+
+  /**
+   * 测试目标：缺失用户上下文时应返回错误并记录语义化错误码。
+   * 前置条件：useUser 返回 null 用户。
+   * 步骤：
+   *  1) 渲染 Hook；
+   *  2) 传入文件执行 onSelectAvatar。
+   * 断言：
+   *  - uploadAvatar 未被调用；
+   *  - 状态为 failed 且 error.code 为 avatar-upload-missing-user。
+   * 边界/异常：
+   *  - 若未来支持游客上传，应调整此分支逻辑。
+   */
+  test("GivenMissingUser_WhenSelectAvatar_ThenFailWithSemanticError", async () => {
+    const uploadAvatarMock = jest.fn();
+
+    mockUseApi.mockReturnValue({ users: { uploadAvatar: uploadAvatarMock } });
+    mockUseUser.mockReturnValue({ user: null, setUser: jest.fn() });
+
+    const { result } = renderHook(() => useAvatarUploader());
+
+    await act(async () => {
+      const didUpload = await result.current.onSelectAvatar([
+        { name: "avatar.png" },
+      ]);
+      expect(didUpload).toBe(false);
+    });
+
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+    expect(result.current.status).toBe(AVATAR_UPLOAD_STATUS.failed);
+    expect(result.current.error?.code).toBe("avatar-upload-missing-user");
+  });
+
+  /**
+   * 测试目标：上传接口异常时应回调 onError 并保留错误对象。
+   * 前置条件：uploadAvatar 抛出错误；提供 onError 回调。
+   * 步骤：
+   *  1) 渲染 Hook，传入 onError；
+   *  2) 触发上传并捕获异常分支。
+   * 断言：
+   *  - onError 收到抛出的错误实例；
+   *  - 状态为 failed 且 setUser 未被调用。
+   * 边界/异常：
+   *  - 可在未来扩展重试机制时复用该断言。
+   */
+  test("GivenUploadError_WhenSelectAvatar_ThenPropagateFailure", async () => {
+    const uploadError = new Error("network-broken");
+    const uploadAvatarMock = jest.fn().mockRejectedValue(uploadError);
+    const setUser = jest.fn();
+    const onError = jest.fn();
+
+    mockUseApi.mockReturnValue({ users: { uploadAvatar: uploadAvatarMock } });
+    mockUseUser.mockReturnValue({
+      user: { id: "42", token: "token-123" },
+      setUser,
+    });
+
+    const { result } = renderHook(() => useAvatarUploader({ onError }));
+
+    await act(async () => {
+      const didUpload = await result.current.onSelectAvatar([
+        { name: "avatar.png" },
+      ]);
+      expect(didUpload).toBe(false);
+    });
+
+    expect(onError).toHaveBeenCalledWith(uploadError);
+    expect(result.current.status).toBe(AVATAR_UPLOAD_STATUS.failed);
+    expect(result.current.error).toBe(uploadError);
+    expect(setUser).not.toHaveBeenCalled();
+  });
+});

--- a/website/src/hooks/index.js
+++ b/website/src/hooks/index.js
@@ -13,3 +13,4 @@ export {
 } from "./useEmailBinding.js";
 export { default as useIconToneController } from "./useIconToneController.js";
 export { default as useInfiniteScroll } from "./useInfiniteScroll.js";
+export { default as useAvatarUploader } from "./useAvatarUploader.js";

--- a/website/src/hooks/useAvatarUploader.js
+++ b/website/src/hooks/useAvatarUploader.js
@@ -1,0 +1,129 @@
+/**
+ * 背景：
+ *  - 更换头像入口散落在 Profile 页面与偏好设置模块，缺乏统一的上传策略，导致重复逻辑与状态管理困难。
+ * 目的：
+ *  - 抽象为可复用的头像上传 Hook，通过统一的命令式接口协调文件选择、接口调用与用户态更新。
+ * 关键决策与取舍：
+ *  - 采用命令模式：向外暴露 onSelectAvatar 作为单一入口命令，内部封装上传流程，便于未来接入不同存储后端；
+ *  - 提供状态机（idle/uploading/succeeded/failed）而非简单布尔值，兼顾后续提示与按钮节流需求；
+ *  - 拒绝在 Hook 内直接触发提示组件，改由调用方根据状态自行处理，保持表现层可插拔。
+ * 影响范围：
+ *  - 偏好设置与其他头像入口可共享上传流程，用户 Store 在上传成功后立即同步最新头像。
+ * 演进与TODO：
+ *  - TODO: 后续可在 onSuccess/onError 中注入全局提示，或在状态机上扩展重试与进度反馈。
+ */
+import { useCallback, useMemo, useState } from "react";
+import { useApi } from "@/hooks/useApi.js";
+import { useUser } from "@/context";
+import { cacheBust } from "@/utils";
+
+export const AVATAR_UPLOAD_STATUS = Object.freeze({
+  idle: "idle",
+  uploading: "uploading",
+  succeeded: "succeeded",
+  failed: "failed",
+});
+
+const normalizeFiles = (files) => {
+  if (!files) {
+    return [];
+  }
+  if (typeof files[Symbol.iterator] === "function") {
+    return Array.from(files);
+  }
+  if (typeof files.length === "number") {
+    return Array.from({ length: files.length }, (_, index) => files[index]);
+  }
+  return Array.isArray(files) ? files : [files];
+};
+
+/**
+ * 意图：统一处理头像文件上传并在成功后刷新用户上下文。
+ * 输入：
+ *  - options.onSuccess?: 上传成功后的回调；
+ *  - options.onError?: 上传失败后的回调；
+ * 输出：
+ *  - 状态机对象（status/error/isUploading）与 onSelectAvatar 命令。
+ * 流程：
+ *  1) 解析文件列表并筛选首个有效文件；
+ *  2) 校验用户上下文后调用上传接口；
+ *  3) 成功时刷新用户头像、更新状态机，失败时记录错误并回调。
+ * 错误处理：缺失文件或用户信息时直接失败并生成语义化错误码。
+ * 复杂度：O(1) —— 仅对有限文件列表与常量状态进行操作。
+ */
+export default function useAvatarUploader({ onSuccess, onError } = {}) {
+  const api = useApi();
+  const { users } = api ?? {};
+  const userStore = useUser();
+  const { user, setUser } = userStore ?? {};
+  const [status, setStatus] = useState(AVATAR_UPLOAD_STATUS.idle);
+  const [error, setError] = useState(null);
+
+  const reset = useCallback(() => {
+    setStatus(AVATAR_UPLOAD_STATUS.idle);
+    setError(null);
+  }, []);
+
+  const onSelectAvatar = useCallback(
+    async (filesLike) => {
+      const [file] = normalizeFiles(filesLike).filter(Boolean);
+      if (!file) {
+        return false;
+      }
+
+      if (!user || !user.id || !user.token) {
+        const missingUserError = new Error("avatar-upload-missing-user");
+        missingUserError.code = "avatar-upload-missing-user";
+        setStatus(AVATAR_UPLOAD_STATUS.failed);
+        setError(missingUserError);
+        if (typeof onError === "function") {
+          onError(missingUserError);
+        }
+        return false;
+      }
+
+      setStatus(AVATAR_UPLOAD_STATUS.uploading);
+      setError(null);
+
+      try {
+        if (!users || typeof users.uploadAvatar !== "function") {
+          throw new Error("avatar-upload-missing-client");
+        }
+
+        const response = await users.uploadAvatar({
+          userId: user.id,
+          token: user.token,
+          file,
+        });
+        const nextAvatar = response?.avatar ? cacheBust(response.avatar) : null;
+        if (nextAvatar && typeof setUser === "function") {
+          setUser({ ...user, avatar: nextAvatar });
+        }
+        setStatus(AVATAR_UPLOAD_STATUS.succeeded);
+        if (typeof onSuccess === "function") {
+          onSuccess({ avatar: nextAvatar, response });
+        }
+        return true;
+      } catch (uploadError) {
+        setStatus(AVATAR_UPLOAD_STATUS.failed);
+        setError(uploadError);
+        if (typeof onError === "function") {
+          onError(uploadError);
+        }
+        return false;
+      }
+    },
+    [onError, onSuccess, setUser, user, users],
+  );
+
+  const state = useMemo(
+    () => ({
+      status,
+      error,
+      isUploading: status === AVATAR_UPLOAD_STATUS.uploading,
+    }),
+    [error, status],
+  );
+
+  return { ...state, onSelectAvatar, reset };
+}

--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -5,6 +5,7 @@ const mockUseLanguage = jest.fn();
 const mockUseUser = jest.fn();
 const mockUseTheme = jest.fn();
 const mockUseKeyboardShortcutContext = jest.fn();
+const mockUseAvatarUploader = jest.fn();
 
 jest.unstable_mockModule("@/context", () => ({
   useLanguage: mockUseLanguage,
@@ -12,6 +13,11 @@ jest.unstable_mockModule("@/context", () => ({
   useTheme: mockUseTheme,
   useKeyboardShortcutContext: mockUseKeyboardShortcutContext,
   KEYBOARD_SHORTCUT_RESET_ACTION: "__GLOBAL_RESET__",
+}));
+
+jest.unstable_mockModule("@/hooks/useAvatarUploader.js", () => ({
+  __esModule: true,
+  default: mockUseAvatarUploader,
 }));
 
 let usePreferenceSections;
@@ -144,6 +150,7 @@ beforeEach(() => {
   mockUseUser.mockReset();
   mockUseTheme.mockReset();
   mockUseKeyboardShortcutContext.mockReset();
+  mockUseAvatarUploader.mockReset();
   translations = createTranslations();
   mockUseLanguage.mockReturnValue({ t: translations });
   mockUseUser.mockReturnValue({
@@ -158,6 +165,13 @@ beforeEach(() => {
   mockUseKeyboardShortcutContext.mockReturnValue({
     register: jest.fn(),
     unregister: jest.fn(),
+  });
+  mockUseAvatarUploader.mockReturnValue({
+    onSelectAvatar: jest.fn(),
+    isUploading: false,
+    status: "idle",
+    error: null,
+    reset: jest.fn(),
   });
 });
 
@@ -214,6 +228,10 @@ test("Given default sections When reading blueprint Then general leads navigatio
   expect(accountSection.componentProps.identity.avatarAlt).toBe(
     translations.prefAccountTitle,
   );
+  expect(typeof accountSection.componentProps.identity.onSelectAvatar).toBe(
+    "function",
+  );
+  expect(accountSection.componentProps.identity.isUploading).toBe(false);
   expect(accountSection.componentProps.bindings.title).toBe(
     translations.settingsAccountBindingTitle,
   );

--- a/website/src/pages/preferences/sections/AccountSection.jsx
+++ b/website/src/pages/preferences/sections/AccountSection.jsx
@@ -18,13 +18,7 @@ import styles from "../Preferences.module.css";
 
 const AVATAR_SIZE = 72;
 
-function AccountSection({
-  title,
-  fields,
-  headingId,
-  identity,
-  bindings,
-}) {
+function AccountSection({ title, fields, headingId, identity, bindings }) {
   const avatarInputId = useId();
   const avatarInputRef = useRef(null);
   const handleAvatarTrigger = useCallback(() => {
@@ -43,24 +37,23 @@ function AccountSection({
     [identity],
   );
 
-  const normalizedIdentity = useMemo(
-    () => {
-      const fallbackLabel = identity?.changeLabel ?? "Avatar";
-      return {
-        label: identity?.label ?? fallbackLabel,
-        displayName: identity?.displayName ?? "",
-        changeLabel: identity?.changeLabel ?? "Change avatar",
-        avatarAlt: identity?.avatarAlt ?? title,
-      };
-    },
-    [
-      identity?.avatarAlt,
-      identity?.changeLabel,
-      identity?.displayName,
-      identity?.label,
-      title,
-    ],
-  );
+  const normalizedIdentity = useMemo(() => {
+    const fallbackLabel = identity?.changeLabel ?? "Avatar";
+    return {
+      label: identity?.label ?? fallbackLabel,
+      displayName: identity?.displayName ?? "",
+      changeLabel: identity?.changeLabel ?? "Change avatar",
+      avatarAlt: identity?.avatarAlt ?? title,
+      isUploading: Boolean(identity?.isUploading),
+    };
+  }, [
+    identity?.avatarAlt,
+    identity?.changeLabel,
+    identity?.displayName,
+    identity?.label,
+    identity?.isUploading,
+    title,
+  ]);
 
   return (
     <section
@@ -108,6 +101,8 @@ function AccountSection({
             <button
               type="button"
               className={`${styles["avatar-trigger"]} ${styles["detail-action-button"]}`}
+              aria-disabled={normalizedIdentity.isUploading}
+              disabled={normalizedIdentity.isUploading}
               onClick={handleAvatarTrigger}
             >
               {normalizedIdentity.changeLabel}
@@ -183,6 +178,7 @@ AccountSection.propTypes = {
     changeLabel: PropTypes.string.isRequired,
     avatarAlt: PropTypes.string,
     onSelectAvatar: PropTypes.func,
+    isUploading: PropTypes.bool,
   }).isRequired,
   bindings: PropTypes.shape({
     title: PropTypes.string.isRequired,

--- a/website/src/pages/preferences/sections/__tests__/AccountSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/AccountSection.test.jsx
@@ -45,6 +45,7 @@ test("GivenIdentityRow_WhenRendered_ThenLabelAvatarAndActionArranged", () => {
         changeLabel: "更换头像",
         avatarAlt: "Taylor 的头像",
         onSelectAvatar: jest.fn(),
+        isUploading: false,
       }}
       bindings={baseBindings}
     />,
@@ -73,5 +74,40 @@ test("GivenIdentityRow_WhenRendered_ThenLabelAvatarAndActionArranged", () => {
   expect(actionColumn).toContainElement(actionButton);
   expect(actionButton).toBeEnabled();
 
-  expect(container.querySelectorAll("input[type=\"file\"]")).toHaveLength(1);
+  expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
+});
+
+/**
+ * 测试目标：当上传进行中时，按钮应禁用且 aria-disabled 为 true。
+ * 前置条件：传入 identity.isUploading 为 true。
+ * 步骤：
+ *  1) 渲染组件；
+ *  2) 查询“更换头像”按钮。
+ * 断言：
+ *  - 按钮被禁用；
+ *  - aria-disabled 属性为 "true"。
+ * 边界/异常：
+ *  - 上传完成后应重新启用（由主流程测试覆盖）。
+ */
+test("GivenUploadingIdentity_WhenRendered_ThenChangeButtonDisabled", () => {
+  render(
+    <AccountSection
+      title="Account"
+      headingId="account-heading"
+      fields={[]}
+      identity={{
+        label: "头像",
+        displayName: "Taylor",
+        changeLabel: "更换头像",
+        avatarAlt: "Taylor 的头像",
+        onSelectAvatar: jest.fn(),
+        isUploading: true,
+      }}
+      bindings={baseBindings}
+    />,
+  );
+
+  const actionButton = screen.getByRole("button", { name: "更换头像" });
+  expect(actionButton).toBeDisabled();
+  expect(actionButton).toHaveAttribute("aria-disabled", "true");
 });

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -19,6 +19,7 @@ import KeyboardSection from "./sections/KeyboardSection.jsx";
 import PersonalizationSection from "./sections/PersonalizationSection.jsx";
 import SubscriptionSection from "./sections/SubscriptionSection.jsx";
 import { buildSubscriptionSectionProps } from "./sections/subscriptionBlueprint.js";
+import useAvatarUploader from "@/hooks/useAvatarUploader.js";
 
 const FALLBACK_MODAL_HEADING_ID = "settings-modal-fallback-heading";
 
@@ -102,7 +103,7 @@ const formatPhoneDisplay = (
     return withCode;
   }
 
-  const [, code,, numberPart] = match;
+  const [, code, , numberPart] = match;
   const digits = numberPart.replace(/[^0-9]/g, "");
   if (!digits) {
     return code;
@@ -130,6 +131,8 @@ function usePreferenceSections({ initialSectionId }) {
   const { t } = useLanguage();
   const userStore = useUser();
   const { user } = userStore ?? {};
+  const { onSelectAvatar, isUploading: isAvatarUploading } =
+    useAvatarUploader();
 
   const headingId = "settings-heading";
   const description = t.prefDescription ?? "";
@@ -250,6 +253,8 @@ function usePreferenceSections({ initialSectionId }) {
       displayName: usernameValue,
       changeLabel: changeAvatarLabel,
       avatarAlt: accountLabel,
+      onSelectAvatar,
+      isUploading: isAvatarUploading,
     };
 
     const accountBindings = {
@@ -366,6 +371,8 @@ function usePreferenceSections({ initialSectionId }) {
     t.settingsTabKeyboard,
     t.settingsTabPersonalization,
     subscriptionSection,
+    onSelectAvatar,
+    isAvatarUploading,
     user?.email,
     user?.phone,
     user?.username,


### PR DESCRIPTION
## Summary
- add a reusable `useAvatarUploader` hook to centralize avatar upload handling and user store updates
- wire the preferences account section to trigger the uploader and gate the change-avatar button while uploading
- expand the test suite for the new hook and updated preferences wiring

## Testing
- npm test -- --runTestsByPath src/hooks/__tests__/useAvatarUploader.test.js src/pages/preferences/sections/__tests__/AccountSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js
- npx prettier -w src/hooks/useAvatarUploader.js src/hooks/__tests__/useAvatarUploader.test.js src/hooks/index.js src/pages/preferences/usePreferenceSections.js src/pages/preferences/sections/AccountSection.jsx src/pages/preferences/sections/__tests__/AccountSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js
- npx eslint --fix src/hooks/useAvatarUploader.js src/hooks/__tests__/useAvatarUploader.test.js src/hooks/index.js src/pages/preferences/usePreferenceSections.js src/pages/preferences/sections/AccountSection.jsx src/pages/preferences/sections/__tests__/AccountSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e29ac7d30083328ed507da28dd5457