### PR TITLE
Stabilize settings panel height across sections

### DIFF
--- a/website/src/components/modals/SettingsPanel.jsx
+++ b/website/src/components/modals/SettingsPanel.jsx
@@ -10,8 +10,9 @@
  * 演进与TODO：
  *  - TODO: 若未来需要延迟加载，可在此扩展 loading/empty 状态插槽。
  */
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useMemo, useRef } from "react";
 import PropTypes from "prop-types";
+import useStableHeight from "@/hooks/useStableHeight.js";
 
 function SettingsPanel({
   panelId,
@@ -22,6 +23,12 @@ function SettingsPanel({
   onHeadingElementChange,
 }) {
   const headingElementRef = useRef(null);
+  const heightDependencies = useMemo(() => [panelId], [panelId]);
+  const { containerRef, style: stableHeightStyle } = useStableHeight({
+    //
+    // 采用 retain-max 策略在切换分区时锁定历史最大高度，确保面板不随内容收缩。
+    dependencies: heightDependencies,
+  });
 
   useLayoutEffect(() => {
     if (typeof document === "undefined") {
@@ -55,7 +62,14 @@ function SettingsPanel({
   }, [headingId, onHeadingElementChange]);
 
   return (
-    <div role="tabpanel" id={panelId} aria-labelledby={tabId} className={className}>
+    <div
+      role="tabpanel"
+      id={panelId}
+      aria-labelledby={tabId}
+      className={className}
+      ref={containerRef}
+      style={stableHeightStyle}
+    >
       {children}
     </div>
   );

--- a/website/src/hooks/__tests__/useStableHeight.test.jsx
+++ b/website/src/hooks/__tests__/useStableHeight.test.jsx
@@ -1,0 +1,152 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import useStableHeight from "../useStableHeight.js";
+
+function TestPanel({ dependencyKey = "general" }) {
+  const { containerRef, style } = useStableHeight({ dependencies: dependencyKey });
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="panel"
+      role="tabpanel"
+      style={style}
+    >
+      panel
+    </div>
+  );
+}
+
+describe("useStableHeight", () => {
+  let originalResizeObserver;
+  let resizeObservers;
+  let currentHeight;
+  let originalRequestAnimationFrame;
+  let originalCancelAnimationFrame;
+  let boundingClientRectSpy;
+
+  class MockResizeObserver {
+    constructor(callback) {
+      this.callback = callback;
+      resizeObservers.push(this);
+    }
+
+    observe() {}
+
+    disconnect() {}
+
+    trigger(entries = []) {
+      this.callback(entries);
+    }
+  }
+
+  beforeEach(() => {
+    resizeObservers = [];
+    currentHeight = 200;
+    originalResizeObserver = global.ResizeObserver;
+    global.ResizeObserver = MockResizeObserver;
+
+    originalRequestAnimationFrame = window.requestAnimationFrame;
+    originalCancelAnimationFrame = window.cancelAnimationFrame;
+    window.requestAnimationFrame = (callback) => {
+      callback();
+      return 1;
+    };
+    window.cancelAnimationFrame = () => {};
+
+    boundingClientRectSpy = jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function mockGetBoundingClientRect() {
+        return {
+          width: 0,
+          height: currentHeight,
+          top: 0,
+          left: 0,
+          bottom: currentHeight,
+          right: 0,
+          toJSON() {
+            return {};
+          },
+        };
+      });
+  });
+
+  afterEach(() => {
+    boundingClientRectSpy.mockRestore();
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    global.ResizeObserver = originalResizeObserver;
+  });
+
+  /**
+   * 测试目标：初次渲染时根据面板内容高度设定最小高度。
+   * 前置条件：模拟节点高度为 200px。
+   * 步骤：渲染测试面板并等待样式写入。
+   * 断言：panel.style.minHeight === "200px"。
+   * 边界/异常：测量失败场景由下个用例间接覆盖。
+   */
+  test("Given_initial_render_When_measured_Then_sets_min_height_once", async () => {
+    const { getByTestId } = render(<TestPanel dependencyKey="general" />);
+
+    const panel = getByTestId("panel");
+    await waitFor(() => {
+      expect(panel.style.minHeight).toBe("200px");
+    });
+  });
+
+  /**
+   * 测试目标：内容高度增长时更新最小高度，收缩时维持最大值。
+   * 前置条件：初始高度 200px，并监听 ResizeObserver 触发。
+   * 步骤：
+   *  1) 触发高度增长至 360px；
+   *  2) 触发高度下降至 160px；
+   *  3) 切换依赖键并增长至 420px；
+   * 断言：
+   *  - 步骤 1 后 minHeight 为 360px；
+   *  - 步骤 2 后仍为 360px；
+   *  - 步骤 3 后更新为 420px。
+   * 边界/异常：覆盖分区切换时的重新测量流程。
+   */
+  test(
+    "Given_dynamic_content_When_height_changes_Then_retains_and_expands_min_height",
+    async () => {
+      const { getByTestId, rerender } = render(
+        <TestPanel dependencyKey="general" />,
+      );
+
+      const panel = getByTestId("panel");
+      await waitFor(() => {
+        expect(panel.style.minHeight).toBe("200px");
+      });
+
+      const firstObserver = resizeObservers.at(-1);
+      expect(firstObserver).toBeTruthy();
+
+      await act(async () => {
+        currentHeight = 360;
+        firstObserver.trigger();
+      });
+      expect(panel.style.minHeight).toBe("360px");
+
+      await act(async () => {
+        currentHeight = 160;
+        firstObserver.trigger();
+      });
+      expect(panel.style.minHeight).toBe("360px");
+
+      rerender(<TestPanel dependencyKey="account" />);
+      await waitFor(() => {
+        expect(panel.style.minHeight).toBe("360px");
+      });
+
+      const secondObserver = resizeObservers.at(-1);
+      expect(secondObserver).toBeTruthy();
+
+      await act(async () => {
+        currentHeight = 420;
+        secondObserver.trigger();
+      });
+      expect(panel.style.minHeight).toBe("420px");
+    },
+  );
+});

--- a/website/src/hooks/index.js
+++ b/website/src/hooks/index.js
@@ -13,3 +13,4 @@ export {
 } from "./useEmailBinding.js";
 export { default as useIconToneController } from "./useIconToneController.js";
 export { default as useInfiniteScroll } from "./useInfiniteScroll.js";
+export { default as useStableHeight } from "./useStableHeight.js";

--- a/website/src/hooks/useStableHeight.js
+++ b/website/src/hooks/useStableHeight.js
@@ -1,0 +1,181 @@
+/**
+ * 背景：
+ *  - 偏好设置面板在切换分区时会根据内容高度收缩或扩展，导致整体布局跳动。
+ * 目的：
+ *  - 通过统一的高度管理 Hook 复用测量与固高逻辑，确保包含内容的容器在不同场景下保持稳定高度。
+ * 关键决策与取舍：
+ *  - 采用策略模式抽象高度聚合方式（当前实现保留最大值），为未来按需引入“最新值”等策略留出扩展点。
+ * 影响范围：
+ *  - 所有需要在内容变化时维持稳定高度的容器（初次应用于 SettingsPanel）。
+ * 演进与TODO：
+ *  - TODO: 视需要支持外部传入最小/最大阈值或动画过渡策略，以便在更多复杂交互中复用。
+ */
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+
+const HEIGHT_STRATEGIES = {
+  /**
+   * 将高度锁定为历史最大值，避免在内容缩小时容器回弹。
+   */
+  "retain-max": (current, next) => {
+    if (next === null) {
+      return current;
+    }
+    if (current === null) {
+      return next;
+    }
+    return Math.max(current, next);
+  },
+};
+
+const MEASUREMENT_FALLBACK = 0;
+
+/**
+ * 统一从 DOM 节点读取高度，优先使用 getBoundingClientRect，以便覆盖浮点高度场景。
+ */
+const readElementHeight = (element) => {
+  if (!element) {
+    return MEASUREMENT_FALLBACK;
+  }
+
+  if (typeof element.getBoundingClientRect === "function") {
+    const { height } = element.getBoundingClientRect();
+    if (Number.isFinite(height) && height > 0) {
+      return height;
+    }
+  }
+
+  if (typeof element.offsetHeight === "number" && element.offsetHeight > 0) {
+    return element.offsetHeight;
+  }
+
+  if (typeof element.scrollHeight === "number" && element.scrollHeight > 0) {
+    return element.scrollHeight;
+  }
+
+  return MEASUREMENT_FALLBACK;
+};
+
+const requestFrame = (callback) => {
+  if (!isBrowser) {
+    return setTimeout(callback, 0);
+  }
+  if (typeof window.requestAnimationFrame === "function") {
+    return window.requestAnimationFrame(callback);
+  }
+  return window.setTimeout(callback, 0);
+};
+
+const cancelFrame = (handle) => {
+  if (!isBrowser) {
+    clearTimeout(handle);
+    return;
+  }
+  if (typeof window.cancelAnimationFrame === "function") {
+    window.cancelAnimationFrame(handle);
+    return;
+  }
+  window.clearTimeout(handle);
+};
+
+/**
+ * 意图：将容器高度稳定在历史最大值，避免内容切换时的跳动。
+ * 输入：
+ *  - strategy: 高度聚合策略（默认 "retain-max"）。
+ *  - dependencies: 触发重新测量的依赖键集合。
+ * 输出：
+ *  - containerRef: 需绑定到目标 DOM 的 ref。
+ *  - style: 可直接应用在元素上的行内样式对象。
+ *  - stableHeight: 当前聚合后的高度值（像素）。
+ * 流程：
+ *  1) 初始化 reducer 与依赖。
+ *  2) 在 layout 阶段测量并根据策略更新高度。
+ *  3) 监听 ResizeObserver，内容变化时重新测量并聚合。
+ * 错误处理：
+ *  - DOM 缺失或测量失败时短路，保持既有高度。
+ * 复杂度：
+ *  - 时间：O(1)；空间：O(1)。
+ */
+function useStableHeight({ strategy = "retain-max", dependencies } = {}) {
+  const containerRef = useRef(null);
+  const [stableHeight, setStableHeight] = useState(null);
+
+  const reducer = useMemo(
+    () => HEIGHT_STRATEGIES[strategy] ?? HEIGHT_STRATEGIES["retain-max"],
+    [strategy],
+  );
+
+  const normalizedDependencies = useMemo(() => {
+    if (!dependencies) {
+      return [];
+    }
+    if (Array.isArray(dependencies)) {
+      return dependencies;
+    }
+    return [dependencies];
+  }, [dependencies]);
+
+  const measureAndUpdate = useCallback(() => {
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+    const nextHeight = readElementHeight(element);
+    if (!Number.isFinite(nextHeight) || nextHeight <= 0) {
+      return;
+    }
+    setStableHeight((current) => {
+      const resolved = reducer(current, nextHeight);
+      if (resolved === current || !Number.isFinite(resolved)) {
+        return current;
+      }
+      return resolved;
+    });
+  }, [reducer]);
+
+  useLayoutEffect(() => {
+    measureAndUpdate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [measureAndUpdate, ...normalizedDependencies]);
+
+  useEffect(() => {
+    if (!isBrowser || typeof ResizeObserver !== "function") {
+      return undefined;
+    }
+    const target = containerRef.current;
+    if (!target) {
+      return undefined;
+    }
+
+    let frameHandle = null;
+    const observer = new ResizeObserver(() => {
+      cancelFrame(frameHandle);
+      frameHandle = requestFrame(measureAndUpdate);
+    });
+
+    observer.observe(target);
+
+    return () => {
+      cancelFrame(frameHandle);
+      observer.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [measureAndUpdate, ...normalizedDependencies]);
+
+  const style = useMemo(() => {
+    if (!Number.isFinite(stableHeight) || stableHeight === null) {
+      return undefined;
+    }
+    const rounded = Math.max(0, Math.round(stableHeight));
+    if (rounded === 0) {
+      return undefined;
+    }
+    const value = `${rounded}px`;
+    return { minHeight: value };
+  }, [stableHeight]);
+
+  return { containerRef, style, stableHeight };
+}
+
+export default useStableHeight;


### PR DESCRIPTION
## Summary
- add a reusable `useStableHeight` hook that locks container height using a retain-max strategy and expose it through the hooks index
- apply the hook to `SettingsPanel` so tab switches reuse the tallest measured height
- cover the hook with targeted tests that simulate resize observer updates

## Testing
- npm test -- useStableHeight
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e29b281c388332b6bac44be9874a86