### PR TITLE
Fix markdown formatting for concatenated dictionary labels

### DIFF
--- a/website/src/utils/markdown.test.js
+++ b/website/src/utils/markdown.test.js
@@ -156,6 +156,31 @@ test("polishDictionaryMarkdown expands collapsed dictionary metadata", () => {
 });
 
 /**
+ * 测试目标：验证当字段标签与上一个值直接拼接时仍能拆行、加粗并补足空格。
+ * 前置条件：构造 `EntryType:SingleWordUsageInsight:...` 等缺失分隔符的字段串。
+ * 步骤：
+ *  1) 调用 polishDictionaryMarkdown 进行格式化。
+ *  2) 对比输出与预期结构化 Markdown。
+ * 断言：
+ *  - 每个标签独占一行，值保持原语义且冒号后有空格。
+ * 边界/异常：
+ *  - 覆盖无空白串联场景，防止未来回归导致再次输出为单行文本。
+ */
+test("polishDictionaryMarkdown separates labels merged into values", () => {
+  const source =
+    "EntryType:SingleWordUsageInsight:Often used in narratives.Register:FormalExtendedNotes:Retains period usage.";
+  const result = polishDictionaryMarkdown(source);
+  expect(result).toBe(
+    [
+      "**Entry Type**: Single Word",
+      "**Usage Insight**: Often used in narratives.",
+      "**Register**: Formal",
+      "**Extended Notes**: Retains period usage.",
+    ].join("\n"),
+  );
+});
+
+/**
  * 测试目标：确保冒号补空格逻辑不会破坏 URL 语法。
  * 前置条件：输入文本包含 `http://` 链接。
  * 步骤：


### PR DESCRIPTION
## Summary
- add heuristics to split adjacent dictionary labels when LLM output omits whitespace
- reuse indentation and colon-aware handling so regenerated markdown renders with proper structure
- cover merged-label scenarios with a dedicated unit test

## Testing
- npm test -- --runTestsByPath src/utils/markdown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e299a576cc83328f2288913f7bb060