### PR TITLE
Remove background from subscription preferences section

### DIFF
--- a/website/src/pages/preferences/sections/SubscriptionSection.jsx
+++ b/website/src/pages/preferences/sections/SubscriptionSection.jsx
@@ -98,7 +98,7 @@ function SubscriptionSection({
     <section
       aria-labelledby={headingId}
       aria-describedby={descriptionId}
-      className={`${styles.section} ${styles["subscription-section"]}`}
+      className={`${styles.section} ${styles["section-plain"]} ${styles["subscription-section"]}`}
     >
       <div className={styles["section-header"]}>
         <h3 id={headingId} className={styles["section-title"]} tabIndex={-1}>


### PR DESCRIPTION
## Summary
- make the subscription section inherit the plain panel style so the background color is removed per design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29fde11f48332af801e11e63b247a