### PR TITLE
feat: polish doubao markdown during chat streaming

### DIFF
--- a/website/src/features/chat/__tests__/assistantMessageFormatter.test.js
+++ b/website/src/features/chat/__tests__/assistantMessageFormatter.test.js
@@ -1,0 +1,48 @@
+import { createAssistantMessageFormatter } from "../createAssistantMessageFormatter.js";
+import { polishDictionaryMarkdown } from "@/utils/markdown.js";
+
+/**
+ * 测试目标：确认格式化器能够在普通对话文本中保持透传行为。
+ * 前置条件：使用默认策略集合，输入不含词典信号的片段。
+ * 步骤：
+ *  1) 依次追加两段普通文本；
+ *  2) 调用 reset 后再次追加。
+ * 断言：
+ *  - 输出等于原始拼接文本，不引入额外空白或格式化。
+ * 边界/异常：
+ *  - 验证 reset 后缓冲被清空，避免跨消息串扰。
+ */
+test("passthrough formatting for generic chat text", () => {
+  const formatter = createAssistantMessageFormatter();
+  const first = formatter.append("Hello");
+  expect(first).toBe("Hello");
+  const second = formatter.append(" world");
+  expect(second).toBe("Hello world");
+  formatter.reset();
+  const afterReset = formatter.append("**bold**");
+  expect(afterReset).toBe("**bold**");
+});
+
+/**
+ * 测试目标：确认检测到抖宝词典信号后会回溯格式化已有文本。
+ * 前置条件：默认策略集合，输入包含 Example/UsageInsight 等特征字段。
+ * 步骤：
+ *  1) 先追加标题片段，尚不足以触发策略；
+ *  2) 再追加包含 Example1 与 UsageInsight 的正文；
+ *  3) 计算 polishDictionaryMarkdown 的期望输出。
+ * 断言：
+ *  - 第二次 append 的返回值等于 polishDictionaryMarkdown(raw)。
+ * 边界/异常：
+ *  - 验证策略在识别信号前不会提前转换，确保流式过程平滑。
+ */
+test("formats doubao dictionary chunks incrementally", () => {
+  const formatter = createAssistantMessageFormatter();
+  const part1 = "## Come\n\n";
+  const part2 = "Senses\nExample1:Shecameatexactly3:15PMasscheduled.\nUsageInsight:Travel context";
+  const raw = part1 + part2;
+  const interim = formatter.append(part1);
+  expect(interim).toBe(part1);
+  const final = formatter.append(part2);
+  const expected = polishDictionaryMarkdown(raw);
+  expect(final).toBe(expected);
+});

--- a/website/src/features/chat/createAssistantMessageFormatter.js
+++ b/website/src/features/chat/createAssistantMessageFormatter.js
@@ -1,0 +1,90 @@
+/**
+ * 背景：
+ *  - 抖宝模型在词典模式下输出的 Markdown 为紧凑字段串，缺乏换行与空格，导致前端渲染层无法识别结构。
+ * 目的：
+ *  - 引入可扩展的格式化器工厂，对助手流式输出按策略进行预处理，恢复 Markdown 层级与可读性。
+ * 关键决策与取舍：
+ *  - 采用“策略模式”封装不同模型/内容类型的格式化逻辑，当前实现内置抖宝词典策略与透传策略。
+ *  - 相比直接在组件中硬编码判断，该方式便于后续扩展其他模型格式或在测试中注入自定义策略。
+ * 影响范围：
+ *  - ChatView 等消费助手回复的界面将统一通过格式化器输出内容；
+ *  - 新增策略只需注册到工厂，无需侵入调用方。
+ * 演进与TODO：
+ *  - 后续可引入配置驱动策略选择或接入 A/B 开关，支持灰度验证不同格式化方案。
+ */
+import { polishDictionaryMarkdown } from "@/utils";
+
+const FALLBACK_STRATEGY = {
+  matches() {
+    return true;
+  },
+  format(text) {
+    return text;
+  },
+};
+
+function createDoubaoDictionaryStrategy() {
+  return {
+    matches(text) {
+      if (!text || text.length < 20) {
+        return false;
+      }
+      const signals = [
+        /\bSenses\b/i,
+        /\bExample\d*:/,
+        /\bUsageInsight:/,
+        /\bRegister:/,
+        /\bEntryType:/,
+      ];
+      return signals.some((pattern) => pattern.test(text));
+    },
+    format(text) {
+      return polishDictionaryMarkdown(text);
+    },
+  };
+}
+
+/**
+ * 意图：提供可复用的助手消息格式化器，按流式片段累计原始文本并执行匹配策略。
+ * 输入：可选的自定义策略列表（按优先级排列）。
+ * 输出：暴露 append 与 reset 方法，供上层在流式读取时增量格式化。
+ * 流程：
+ *  1) 累积原始 chunk 至内部缓冲；
+ *  2) 选取首个 matches 的策略（默认透传策略兜底）；
+ *  3) 返回策略格式化后的文本，用于即时渲染。
+ * 错误处理：策略抛错时沿用原文本，避免阻断主流程。
+ * 复杂度：每次 append 线性扫描策略列表，整体 O(n * m)（n 为策略数，m 为文本长度），现阶段可接受。
+ */
+export function createAssistantMessageFormatter({ strategies } = {}) {
+  const availableStrategies = strategies ?? [createDoubaoDictionaryStrategy(), FALLBACK_STRATEGY];
+  let buffer = "";
+
+  function applyStrategies(text) {
+    for (const strategy of availableStrategies) {
+      try {
+        if (strategy.matches(text)) {
+          return strategy.format(text);
+        }
+      } catch (error) {
+        console.error("[assistantFormatter] strategy failed", error);
+      }
+    }
+    return text;
+  }
+
+  return {
+    append(chunk) {
+      if (chunk) {
+        buffer += chunk;
+      }
+      return applyStrategies(buffer);
+    },
+    reset() {
+      buffer = "";
+    },
+  };
+}
+
+export function __internal__createDoubaoDictionaryStrategy() {
+  return createDoubaoDictionaryStrategy();
+}

--- a/website/src/pages/chat/ChatView.jsx
+++ b/website/src/pages/chat/ChatView.jsx
@@ -1,15 +1,21 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import ChatInput from "@/components/ui/ChatInput";
 import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
 import { streamChatMessage } from "@/api/chat.js";
 import { DEFAULT_MODEL } from "@/config";
 import { useLanguage } from "@/context";
+import { createAssistantMessageFormatter } from "@/features/chat/createAssistantMessageFormatter.js";
 import styles from "./ChatView.module.css";
 
 export default function ChatView({ streamFn = streamChatMessage }) {
   const { t } = useLanguage();
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
+  const formatterRef = useRef();
+
+  if (!formatterRef.current) {
+    formatterRef.current = createAssistantMessageFormatter();
+  }
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -18,17 +24,23 @@ export default function ChatView({ streamFn = streamChatMessage }) {
     setInput("");
 
     let firstChunk = true;
+    const formatter = formatterRef.current;
+    formatter.reset();
     for await (const chunk of streamFn({
       model: DEFAULT_MODEL,
       messages: [...messages, userMessage],
     })) {
+      const formatted = formatter.append(chunk);
       if (firstChunk) {
-        setMessages((prev) => [...prev, { role: "assistant", content: chunk }]);
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: formatted },
+        ]);
         firstChunk = false;
       } else {
         setMessages((prev) => {
           const last = { ...prev.at(-1) };
-          last.content += chunk;
+          last.content = formatted;
           return [...prev.slice(0, -1), last];
         });
       }


### PR DESCRIPTION
## Summary
- introduce a strategy-based assistant message formatter that polishes Doubao dictionary markdown while preserving generic chat output
- plug the formatter into ChatView so streamed assistant chunks are normalized before rendering
- cover the formatter with incremental streaming tests to protect future regressions

## Testing
- npm test -- assistantMessageFormatter

------
https://chatgpt.com/codex/tasks/task_e_68e2a0fcdda88332b5ca0d33aee5b9b1