### PR TITLE
Add configurable profile personalization sections

### DIFF
--- a/backend/src/main/java/com/glancy/backend/dto/ProfileSectionDto.java
+++ b/backend/src/main/java/com/glancy/backend/dto/ProfileSectionDto.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * 背景：
+ *  - 个性化资料需要承载多个自定义区块，但历史实现缺乏统一结构导致解析分散。
+ * 目的：
+ *  - 以不可变 record 描述区块元数据与子项集合，便于前端动态渲染与后端校验。
+ * 关键决策与取舍：
+ *  - 使用 {@link JsonIgnoreProperties} 容忍未知字段，保障老版本客户端在扩展字段时仍可写入；
+ *  - 子项集合以 `List` 表示，保持顺序语义，支持 UI 按预设顺序展示。
+ * 影响范围：
+ *  - `UserProfileRequest`/`UserProfileResponse` 按此结构编解码 JSON。
+ * 演进与TODO：
+ *  - TODO: 若后续引入区块级别的可见性控制，可在此增加特性标识。
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProfileSectionDto(
+    /** 区块业务标识，与前端 Schema 对应 */
+    String id,
+    /** 区块展示标题，允许自定义 */
+    String title,
+    /** 区块内的子项集合 */
+    List<ProfileSectionItemDto> items
+) {}

--- a/backend/src/main/java/com/glancy/backend/dto/ProfileSectionItemDto.java
+++ b/backend/src/main/java/com/glancy/backend/dto/ProfileSectionItemDto.java
@@ -1,0 +1,26 @@
+package com.glancy.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * 背景：
+ *  - 个性化画像的自定义区块此前以自由 JSON 存储，缺乏结构化契约，导致前后端难以演进。
+ * 目的：
+ *  - 以不可变 record 承载区块内的子项，为后续字段扩展提供稳定的序列化结构。
+ * 关键决策与取舍：
+ *  - 采用 record 提供只读语义，并保留 {@link JsonIgnoreProperties} 以容忍遗留客户端冗余字段；
+ *  - 字段命名以业务语义为先，避免硬编码 UI 细节。
+ * 影响范围：
+ *  - `UserProfileRequest`/`UserProfileResponse` 在序列化时复用该结构。
+ * 演进与TODO：
+ *  - TODO: 如需支持多类型输入控件，可在此补充类型与校验元数据。
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProfileSectionItemDto(
+    /** 子项业务标识，用于与前端 Schema 对齐 */
+    String id,
+    /** 子项展示标题，允许用户自定义 */
+    String label,
+    /** 用户填写的值，允许为空 */
+    String value
+) {}

--- a/backend/src/main/java/com/glancy/backend/dto/UserProfileRequest.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserProfileRequest.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
 
 /**
  * 背景：
@@ -17,14 +18,20 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record UserProfileRequest(
+    /** 用户最高学历或教育背景描述 */
+    String education,
     /** 用户当前的职业角色描述 */
     String job,
     /** 用户填写的兴趣标签，使用分隔符拆分 */
     String interest,
     /** 学习或使用目标说明 */
     String goal,
+    /** 当前能力或熟练度自评 */
+    String currentAbility,
     /** 每日词汇目标，单位：个 */
     Integer dailyWordTarget,
     /** 对未来规划或学习节奏的补充描述 */
-    String futurePlan
+    String futurePlan,
+    /** 自定义区块内容，支持配置化扩展 */
+    List<ProfileSectionDto> customSections
 ) {}

--- a/backend/src/main/java/com/glancy/backend/dto/UserProfileResponse.java
+++ b/backend/src/main/java/com/glancy/backend/dto/UserProfileResponse.java
@@ -12,19 +12,27 @@ package com.glancy.backend.dto;
  * 演进与TODO：
  *  - TODO: 若支持多画像版本，应在此引入版本标记或单独的 view model。
  */
+import java.util.List;
+
 public record UserProfileResponse(
     /** 画像主键标识 */
     Long id,
     /** 对应的用户主键 */
     Long userId,
+    /** 用户最高学历或教育背景描述 */
+    String education,
     /** 用户当前职业角色 */
     String job,
     /** 用户兴趣标签原文 */
     String interest,
     /** 用户学习目标描述 */
     String goal,
+    /** 当前能力或熟练度自评 */
+    String currentAbility,
     /** 用户自定义的每日词汇目标，单位：个 */
     Integer dailyWordTarget,
     /** 用户未来学习或规划描述 */
-    String futurePlan
+    String futurePlan,
+    /** 自定义区块内容，按配置顺序返回 */
+    List<ProfileSectionDto> customSections
 ) {}

--- a/backend/src/main/java/com/glancy/backend/entity/UserProfile.java
+++ b/backend/src/main/java/com/glancy/backend/entity/UserProfile.java
@@ -21,11 +21,23 @@ public class UserProfile {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
+    private String education;
+
     private String job;
+
     private String interest;
+
     private String goal;
+
+    @Column(name = "current_ability", length = 1024)
+    private String currentAbility;
+
     private Integer dailyWordTarget;
 
     @Column(length = 1024)
     private String futurePlan;
+
+    @Lob
+    @Column(name = "custom_sections")
+    private String customSections;
 }

--- a/backend/src/main/java/com/glancy/backend/service/profile/ProfileSectionCodec.java
+++ b/backend/src/main/java/com/glancy/backend/service/profile/ProfileSectionCodec.java
@@ -1,0 +1,129 @@
+package com.glancy.backend.service.profile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glancy.backend.dto.ProfileSectionDto;
+import com.glancy.backend.dto.ProfileSectionItemDto;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * 背景：
+ *  - 自定义区块以 JSON 字符串持久化，需要在服务层提供统一的编解码逻辑。
+ * 目的：
+ *  - 通过适配器模式集中处理 JSON ↔ DTO 转换，避免在服务层散落序列化细节。
+ * 关键决策与取舍：
+ *  - 复用 Spring 管理的 {@link ObjectMapper}，保持全局序列化配置一致；
+ *  - 在清洗阶段剔除空白字段，保证落库数据紧凑且语义明确。
+ * 影响范围：
+ *  - `UserProfileService` 依赖此组件在保存与读取时转换自定义区块。
+ * 演进与TODO：
+ *  - TODO: 后续可在此扩展 Schema 校验或版本控制能力。
+ */
+@Component
+public class ProfileSectionCodec {
+
+    private static final Logger log = LoggerFactory.getLogger(ProfileSectionCodec.class);
+
+    private static final TypeReference<List<ProfileSectionDto>> SECTION_LIST_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+
+    public ProfileSectionCodec(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 将数据库中的 JSON 字符串转换为不可变的区块列表。
+     */
+    public List<ProfileSectionDto> decode(String json) {
+        if (!StringUtils.hasText(json)) {
+            return List.of();
+        }
+        try {
+            List<ProfileSectionDto> sections = objectMapper.readValue(json, SECTION_LIST_TYPE);
+            if (CollectionUtils.isEmpty(sections)) {
+                return List.of();
+            }
+            return sections
+                .stream()
+                .filter(Objects::nonNull)
+                .map(ProfileSectionCodec::sanitizeSection)
+                .filter(section -> section.id() != null)
+                .toList();
+        } catch (JsonProcessingException ex) {
+            log.error("Failed to decode profile custom sections", ex);
+            throw new IllegalStateException("无法解析个性化自定义区块", ex);
+        }
+    }
+
+    /**
+     * 将区块列表编码为 JSON 字符串，供实体持久化使用。
+     */
+    public String encode(List<ProfileSectionDto> sections) {
+        if (CollectionUtils.isEmpty(sections)) {
+            return null;
+        }
+        List<ProfileSectionDto> sanitized = sections
+            .stream()
+            .filter(Objects::nonNull)
+            .map(ProfileSectionCodec::sanitizeSection)
+            .filter(section -> section.id() != null)
+            .toList();
+        if (sanitized.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(sanitized);
+        } catch (JsonProcessingException ex) {
+            log.error("Failed to encode profile custom sections", ex);
+            throw new IllegalStateException("无法保存个性化自定义区块", ex);
+        }
+    }
+
+    private static ProfileSectionDto sanitizeSection(ProfileSectionDto section) {
+        String id = normalizeKey(section.id());
+        String title = normalizeText(section.title());
+        List<ProfileSectionItemDto> items = sanitizeItems(section.items());
+        return new ProfileSectionDto(id, title, items);
+    }
+
+    private static List<ProfileSectionItemDto> sanitizeItems(List<ProfileSectionItemDto> items) {
+        if (CollectionUtils.isEmpty(items)) {
+            return List.of();
+        }
+        return items
+            .stream()
+            .filter(Objects::nonNull)
+            .map(item ->
+                new ProfileSectionItemDto(
+                    normalizeKey(item.id()),
+                    normalizeText(item.label()),
+                    normalizeText(item.value())
+                )
+            )
+            .filter(item -> item.id() != null)
+            .toList();
+    }
+
+    private static String normalizeKey(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private static String normalizeText(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
+++ b/backend/src/test/java/com/glancy/backend/controller/UserProfileControllerTest.java
@@ -7,9 +7,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glancy.backend.dto.ProfileSectionDto;
+import com.glancy.backend.dto.ProfileSectionItemDto;
 import com.glancy.backend.dto.UserProfileRequest;
 import com.glancy.backend.dto.UserProfileResponse;
 import com.glancy.backend.service.UserProfileService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -56,10 +59,37 @@ class UserProfileControllerTest {
      */
     @Test
     void saveProfile() throws Exception {
-        UserProfileResponse resp = new UserProfileResponse(1L, 2L, "dev", "code", "learn", 15, "exchange study");
+        List<ProfileSectionDto> customSections = List.of(
+            new ProfileSectionDto(
+                "learning-plan",
+                "Plan",
+                List.of(new ProfileSectionItemDto("milestone", "Milestone", "Complete 50 words"))
+            )
+        );
+        UserProfileResponse resp = new UserProfileResponse(
+            1L,
+            2L,
+            "Bachelor",
+            "dev",
+            "code",
+            "learn",
+            "B2",
+            15,
+            "exchange study",
+            customSections
+        );
         when(userProfileService.saveProfile(eq(2L), any(UserProfileRequest.class))).thenReturn(resp);
 
-        UserProfileRequest req = new UserProfileRequest("dev", "code", "learn", 15, "exchange study");
+        UserProfileRequest req = new UserProfileRequest(
+            "Bachelor",
+            "dev",
+            "code",
+            "learn",
+            "B2",
+            15,
+            "exchange study",
+            customSections
+        );
 
         when(userService.authenticateToken("tkn")).thenReturn(2L);
 
@@ -85,7 +115,18 @@ class UserProfileControllerTest {
      */
     @Test
     void getProfile() throws Exception {
-        UserProfileResponse resp = new UserProfileResponse(1L, 2L, "dev", "code", "learn", 15, "exchange study");
+        UserProfileResponse resp = new UserProfileResponse(
+            1L,
+            2L,
+            "Bachelor",
+            "dev",
+            "code",
+            "learn",
+            "B2",
+            15,
+            "exchange study",
+            List.of()
+        );
         when(userProfileService.getProfile(2L)).thenReturn(resp);
 
         when(userService.authenticateToken("tkn")).thenReturn(2L);

--- a/backend/src/test/java/com/glancy/backend/service/UserProfileServiceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/UserProfileServiceTest.java
@@ -2,12 +2,15 @@ package com.glancy.backend.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.glancy.backend.dto.ProfileSectionDto;
+import com.glancy.backend.dto.ProfileSectionItemDto;
 import com.glancy.backend.dto.UserProfileRequest;
 import com.glancy.backend.dto.UserProfileResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.repository.UserProfileRepository;
 import com.glancy.backend.repository.UserRepository;
 import io.github.cdimascio.dotenv.Dotenv;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,7 +18,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@SpringBootTest(
+    properties = {
+        "oss.endpoint=http://localhost",
+        "oss.bucket=test-bucket",
+        "oss.access-key-id=dummy",
+        "oss.access-key-secret=dummy",
+        "oss.verify-location=false"
+    }
+)
 @Transactional
 class UserProfileServiceTest {
 
@@ -44,18 +55,18 @@ class UserProfileServiceTest {
     }
 
     /**
-     * 测试目标：验证保存后再次读取画像时字段保持一致且默认 ID 被写入。
+     * 测试目标：验证保存后再次读取画像时学历、职业、兴趣、目标、当前能力与自定义区块保持一致。
      * 前置条件：
      *  - 新增一个用户实体；
-     *  - 使用包含职业、兴趣、目标与学习计划的请求记录。
+     *  - 请求记录包含学历、职业、兴趣、目标、当前能力与单个自定义区块。
      * 步骤：
      *  1) 调用 `saveProfile` 持久化请求；
      *  2) 调用 `getProfile` 再次读取；
-     *  3) 对比两次响应。
+     *  3) 对比两次响应的关键字段和值。
      * 断言：
      *  - 保存响应包含非空 ID；
      *  - 读取响应与保存响应字段一致；
-     *  - 用户 ID 一致。
+     *  - 自定义区块的标识与值未丢失。
      * 边界/异常：
      *  - 若请求字段为空，实体应保存 null 并在读取时回传（此用例未覆盖）。
      */
@@ -68,17 +79,41 @@ class UserProfileServiceTest {
         user.setPhone("111");
         userRepository.save(user);
 
-        UserProfileRequest req = new UserProfileRequest("dev", "code", "learn", 15, "exchange study");
+        UserProfileRequest req = new UserProfileRequest(
+            "本科",
+            "dev",
+            "code",
+            "learn",
+            "B2",
+            15,
+            "exchange study",
+            List.of(
+                new ProfileSectionDto(
+                    "learning-plan",
+                    "学习计划",
+                    List.of(new ProfileSectionItemDto("milestone", "里程碑", "完成 100 词"))
+                )
+            )
+        );
         UserProfileResponse saved = userProfileService.saveProfile(user.getId(), req);
 
         assertNotNull(saved.id());
+        assertEquals("本科", saved.education());
         assertEquals("dev", saved.job());
         assertEquals("code", saved.interest());
+        assertEquals("B2", saved.currentAbility());
+        assertEquals(1, saved.customSections().size());
+        assertEquals("learning-plan", saved.customSections().get(0).id());
+        assertEquals("milestone", saved.customSections().get(0).items().get(0).id());
 
         UserProfileResponse fetched = userProfileService.getProfile(user.getId());
         assertEquals(saved.id(), fetched.id());
         assertEquals(saved.job(), fetched.job());
         assertEquals(user.getId(), fetched.userId());
+        assertEquals("本科", fetched.education());
+        assertEquals("B2", fetched.currentAbility());
+        assertEquals(1, fetched.customSections().size());
+        assertEquals("完成 100 词", fetched.customSections().get(0).items().get(0).value());
     }
 
     /**
@@ -88,7 +123,8 @@ class UserProfileServiceTest {
      * 断言：
      *  - 响应 ID 为空；
      *  - userId 等于请求的用户主键；
-     *  - 画像文本字段为 null。
+     *  - 画像文本字段为 null；
+     *  - 自定义区块返回空集合。
      * 边界/异常：若后续提供默认占位文案，应在服务层集中处理（当前保持 null）。
      */
     @Test
@@ -103,6 +139,8 @@ class UserProfileServiceTest {
         UserProfileResponse fetched = userProfileService.getProfile(user.getId());
         assertNull(fetched.id());
         assertNull(fetched.job());
+        assertNull(fetched.education());
+        assertTrue(fetched.customSections().isEmpty());
         assertEquals(user.getId(), fetched.userId());
     }
 }

--- a/website/src/components/Profile/CustomSection/CustomSection.module.css
+++ b/website/src/components/Profile/CustomSection/CustomSection.module.css
@@ -1,0 +1,66 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 82%, transparent);
+}
+
+.header {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+
+.icon {
+  color: var(--primary-bg);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-strong);
+}
+
+.description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.items {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.input,
+.multiline {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
+  background: color-mix(in srgb, var(--color-surface-muted) 80%, transparent);
+  color: var(--color-text-primary);
+  font-size: 0.95rem;
+}
+
+.multiline {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.input:focus,
+.multiline:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--primary-bg) 60%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-bg) 20%, transparent);
+}

--- a/website/src/components/Profile/CustomSection/index.jsx
+++ b/website/src/components/Profile/CustomSection/index.jsx
@@ -1,0 +1,134 @@
+import PropTypes from "prop-types";
+import FormField from "@/components/form/FormField.jsx";
+import ThemeIcon from "@/components/ui/Icon";
+import styles from "./CustomSection.module.css";
+
+const resolveTranslation = (t, key, fallback) => {
+  if (!key) return fallback ?? "";
+  const segments = key.split(".");
+  let current = t;
+  for (const segment of segments) {
+    if (current && typeof current === "object" && segment in current) {
+      current = current[segment];
+    } else {
+      current = null;
+      break;
+    }
+  }
+  if (typeof current === "string") {
+    return current;
+  }
+  return fallback ?? "";
+};
+
+export default function ProfileCustomSection({ section, onItemChange, t }) {
+  const title =
+    section.title ?? resolveTranslation(t, section.definition?.titleKey, "");
+  const description = resolveTranslation(
+    t,
+    section.definition?.descriptionKey,
+    "",
+  );
+
+  return (
+    <section className={styles.section} aria-labelledby={`${section.id}-title`}>
+      <header className={styles.header}>
+        {section.definition?.icon ? (
+          <ThemeIcon
+            name={section.definition.icon}
+            width={20}
+            height={20}
+            className={styles.icon}
+            aria-hidden="true"
+          />
+        ) : null}
+        <div className={styles.meta}>
+          <h3 id={`${section.id}-title`} className={styles.title}>
+            {title || section.id}
+          </h3>
+          {description ? (
+            <p className={styles.description}>{description}</p>
+          ) : null}
+        </div>
+      </header>
+      <div className={styles.items}>
+        {section.items.map((item) => {
+          const label = resolveTranslation(
+            t,
+            item.definition?.labelKey,
+            item.label || "",
+          );
+          const placeholder = resolveTranslation(
+            t,
+            item.definition?.placeholderKey,
+            "",
+          );
+          const id = `${section.id}-${item.id}`;
+          return (
+            <FormField key={id} label={label} id={id}>
+              {item.definition?.multiline ? (
+                <textarea
+                  id={id}
+                  className={styles.multiline}
+                  value={item.value}
+                  placeholder={placeholder}
+                  rows={4}
+                  onChange={(event) =>
+                    onItemChange(section.id, item.id, event.target.value)
+                  }
+                />
+              ) : (
+                <input
+                  id={id}
+                  className={styles.input}
+                  value={item.value}
+                  placeholder={placeholder}
+                  onChange={(event) =>
+                    onItemChange(section.id, item.id, event.target.value)
+                  }
+                />
+              )}
+            </FormField>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+const itemDefinitionShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  labelKey: PropTypes.string,
+  placeholderKey: PropTypes.string,
+  multiline: PropTypes.bool,
+});
+
+const itemShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  definition: itemDefinitionShape.isRequired,
+  label: PropTypes.string,
+  value: PropTypes.string,
+});
+
+const sectionDefinitionShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  titleKey: PropTypes.string,
+  descriptionKey: PropTypes.string,
+  items: PropTypes.arrayOf(itemDefinitionShape).isRequired,
+});
+
+ProfileCustomSection.propTypes = {
+  section: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    definition: sectionDefinitionShape.isRequired,
+    items: PropTypes.arrayOf(itemShape).isRequired,
+  }).isRequired,
+  onItemChange: PropTypes.func.isRequired,
+  t: PropTypes.object,
+};
+
+ProfileCustomSection.defaultProps = {
+  t: {},
+};

--- a/website/src/config/profileSections.js
+++ b/website/src/config/profileSections.js
@@ -1,0 +1,80 @@
+/**
+ * 背景：
+ *  - 个性化资料页需要稳定的配置来描述自定义区块，避免在页面内硬编码字段。
+ * 目的：
+ *  - 提供可扩展的 Schema，定义区块标识、图标、文案 key 及输入类型，供渲染逻辑复用。
+ * 关键决策与取舍：
+ *  - 采用配置驱动的方式描述区块，并为每个子项提供占位符与多行输入开关；
+ *  - Schema 被 `Object.freeze`，确保运行时不可被意外修改。
+ * 影响范围：
+ *  - Profile 页面与相关 Hook 依赖该配置渲染自定义区块。
+ * 演进与TODO：
+ *  - TODO: 如需支持更多输入类型，可在子项上扩展 `inputType` 或 `options` 元数据。
+ */
+export const PROFILE_CUSTOM_SECTIONS_SCHEMA = Object.freeze([
+  Object.freeze({
+    id: "learning-plan",
+    icon: "flag",
+    titleKey: "customSections.learningPlan.title",
+    descriptionKey: "customSections.learningPlan.description",
+    items: Object.freeze([
+      Object.freeze({
+        id: "milestone",
+        labelKey: "customSections.learningPlan.items.milestone.label",
+        placeholderKey:
+          "customSections.learningPlan.items.milestone.placeholder",
+        multiline: true,
+      }),
+      Object.freeze({
+        id: "cadence",
+        labelKey: "customSections.learningPlan.items.cadence.label",
+        placeholderKey: "customSections.learningPlan.items.cadence.placeholder",
+        multiline: false,
+      }),
+    ]),
+  }),
+  Object.freeze({
+    id: "resource-preference",
+    icon: "library",
+    titleKey: "customSections.resourcePreference.title",
+    descriptionKey: "customSections.resourcePreference.description",
+    items: Object.freeze([
+      Object.freeze({
+        id: "primary",
+        labelKey: "customSections.resourcePreference.items.primary.label",
+        placeholderKey:
+          "customSections.resourcePreference.items.primary.placeholder",
+        multiline: false,
+      }),
+      Object.freeze({
+        id: "secondary",
+        labelKey: "customSections.resourcePreference.items.secondary.label",
+        placeholderKey:
+          "customSections.resourcePreference.items.secondary.placeholder",
+        multiline: false,
+      }),
+    ]),
+  }),
+  Object.freeze({
+    id: "practice-scenarios",
+    icon: "command-line",
+    titleKey: "customSections.practiceScenarios.title",
+    descriptionKey: "customSections.practiceScenarios.description",
+    items: Object.freeze([
+      Object.freeze({
+        id: "real-world",
+        labelKey: "customSections.practiceScenarios.items.realWorld.label",
+        placeholderKey:
+          "customSections.practiceScenarios.items.realWorld.placeholder",
+        multiline: true,
+      }),
+      Object.freeze({
+        id: "collaboration",
+        labelKey: "customSections.practiceScenarios.items.collaboration.label",
+        placeholderKey:
+          "customSections.practiceScenarios.items.collaboration.placeholder",
+        multiline: true,
+      }),
+    ]),
+  }),
+]);

--- a/website/src/hooks/__tests__/useProfileSections.test.js
+++ b/website/src/hooks/__tests__/useProfileSections.test.js
@@ -1,0 +1,113 @@
+import { renderHook, act } from "@testing-library/react";
+import { useProfileSections } from "@/hooks/useProfileSections.js";
+
+const schema = [
+  {
+    id: "section-a",
+    icon: "flag",
+    titleKey: "section.a.title",
+    descriptionKey: "section.a.desc",
+    items: [
+      {
+        id: "item-a",
+        labelKey: "section.a.item.a",
+        placeholderKey: "section.a.item.a.placeholder",
+        multiline: false,
+      },
+    ],
+  },
+  {
+    id: "section-b",
+    icon: "library",
+    titleKey: "section.b.title",
+    descriptionKey: null,
+    items: [
+      {
+        id: "item-b",
+        labelKey: "section.b.item.b",
+        placeholderKey: "section.b.item.b.placeholder",
+        multiline: true,
+      },
+    ],
+  },
+];
+
+/**
+ * 测试目标：验证 useProfileSections 在初始化时会将 Schema 与初始值合并，并能更新指定子项。
+ * 前置条件：
+ *  - 传入包含两个区块的 Schema；
+ *  - 初始数据仅为第一个区块提供值。
+ * 步骤：
+ *  1) 渲染 Hook；
+ *  2) 调用 updateItem 更新第一个区块的值；
+ *  3) 读取最新状态。
+ * 断言：
+ *  - 初始状态保留传入的值；
+ *  - updateItem 之后值被更新；
+ *  - 未提供初始值的区块以空字符串作为默认值。
+ * 边界/异常：
+ *  - 若传入未知区块，应被保留（此用例未覆盖）。
+ */
+test("GivenInitialData_WhenUpdateItem_ThenSectionValueUpdates", () => {
+  const initialSections = [
+    {
+      id: "section-a",
+      title: "Custom",
+      items: [{ id: "item-a", value: "hello" }],
+    },
+  ];
+  const { result } = renderHook(() =>
+    useProfileSections({ schema, initialSections }),
+  );
+
+  expect(result.current.sections[0].items[0].value).toBe("hello");
+  expect(result.current.sections[1].items[0].value).toBe("");
+
+  act(() => {
+    result.current.updateItem("section-a", "item-a", "updated");
+  });
+
+  expect(result.current.sections[0].items[0].value).toBe("updated");
+});
+
+/**
+ * 测试目标：验证 resetSections 会重建状态且 toPayload 会输出经过裁剪的值。
+ * 前置条件：
+ *  - 初始数据为空；
+ *  - 调用 resetSections 提供新的区块值。
+ * 步骤：
+ *  1) 渲染 Hook；
+ *  2) 调用 resetSections 并传入带有空白字符的值；
+ *  3) 读取 toPayload 输出。
+ * 断言：
+ *  - 状态被重置为新值；
+ *  - toPayload 输出的值已去除首尾空格；
+ *  - 空字符串被转换为 null。
+ * 边界/异常：
+ *  - 若 future 扩展其他字段，需同步更新序列化逻辑（此用例未覆盖）。
+ */
+test("GivenReset_WhenSerialize_ThenPayloadIsTrimmed", () => {
+  const { result } = renderHook(() => useProfileSections({ schema }));
+
+  act(() => {
+    result.current.resetSections([
+      {
+        id: "section-a",
+        title: "  Title  ",
+        items: [{ id: "item-a", value: "  value  " }],
+      },
+      {
+        id: "section-b",
+        title: null,
+        items: [{ id: "item-b", value: "   " }],
+      },
+    ]);
+  });
+
+  expect(result.current.sections[0].items[0].value).toBe("  value  ");
+
+  const payload = result.current.toPayload();
+  expect(payload[0].title).toBe("Title");
+  expect(payload[0].items[0].value).toBe("value");
+  expect(payload[1].items[0].value).toBeNull();
+});

--- a/website/src/hooks/useProfileSections.js
+++ b/website/src/hooks/useProfileSections.js
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useState } from "react";
+import { PROFILE_CUSTOM_SECTIONS_SCHEMA } from "@/config/profileSections.js";
+
+/**
+ * 背景：
+ *  - Profile 页面需要统一的状态管理来支撑配置化的自定义区块。
+ * 目的：
+ *  - 封装区块的初始化、重置与序列化逻辑，使页面组件只关注布局。
+ * 关键决策与取舍：
+ *  - 通过 hook 内部维护不可变的区块结构，提供最小化的更新接口；
+ *  - 遇到未知区块时仍保留，以兼容未来扩展。
+ * 影响范围：
+ *  - Profile 页面调用该 hook 渲染区块，并在保存时生成后端所需 payload。
+ * 演进与TODO：
+ *  - TODO: 支持区块标题编辑或动态增删区块时，可在此扩展对应接口。
+ */
+
+const buildSectionState = (schema, initialSections = []) => {
+  const schemaById = new Map();
+  for (const section of schema) {
+    if (!section?.id) continue;
+    schemaById.set(section.id, section);
+  }
+
+  const initialById = new Map();
+  for (const section of initialSections ?? []) {
+    if (!section?.id) continue;
+    initialById.set(section.id, section);
+  }
+
+  const result = [];
+  for (const section of schemaById.values()) {
+    const initial = initialById.get(section.id);
+    const initialItems = new Map();
+    if (initial?.items) {
+      for (const item of initial.items) {
+        if (!item?.id) continue;
+        initialItems.set(item.id, item);
+      }
+    }
+    result.push({
+      id: section.id,
+      title: initial?.title ?? null,
+      definition: section,
+      items: section.items.map((itemDef) => {
+        const initialItem = initialItems.get(itemDef.id);
+        return {
+          id: itemDef.id,
+          definition: itemDef,
+          label: initialItem?.label ?? null,
+          value: initialItem?.value ?? "",
+        };
+      }),
+    });
+  }
+
+  for (const section of initialSections ?? []) {
+    if (!section?.id || schemaById.has(section.id)) continue;
+    const orphanItems = (section.items ?? []).filter((item) => item?.id);
+    result.push({
+      id: section.id,
+      title: section.title ?? null,
+      definition: {
+        id: section.id,
+        icon: null,
+        titleKey: null,
+        descriptionKey: null,
+        items: orphanItems.map((item) => ({
+          id: item.id,
+          labelKey: null,
+          placeholderKey: null,
+          multiline: false,
+        })),
+      },
+      items: orphanItems.map((item) => ({
+        id: item.id,
+        definition: {
+          id: item.id,
+          labelKey: null,
+          placeholderKey: null,
+          multiline: false,
+        },
+        label: item.label ?? null,
+        value: item.value ?? "",
+      })),
+    });
+  }
+
+  return result;
+};
+
+const normalizeText = (value) => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export function useProfileSections({
+  schema = PROFILE_CUSTOM_SECTIONS_SCHEMA,
+  initialSections = [],
+} = {}) {
+  const memoizedSchema = useMemo(() => schema, [schema]);
+  const [sections, setSections] = useState(() =>
+    buildSectionState(memoizedSchema, initialSections),
+  );
+
+  const resetSections = useCallback(
+    (nextSections = []) => {
+      setSections(buildSectionState(memoizedSchema, nextSections));
+    },
+    [memoizedSchema],
+  );
+
+  const updateItem = useCallback((sectionId, itemId, value) => {
+    setSections((prev) =>
+      prev.map((section) => {
+        if (section.id !== sectionId) {
+          return section;
+        }
+        return {
+          ...section,
+          items: section.items.map((item) =>
+            item.id === itemId
+              ? {
+                  ...item,
+                  value,
+                }
+              : item,
+          ),
+        };
+      }),
+    );
+  }, []);
+
+  const toPayload = useCallback(
+    () =>
+      sections.map((section) => ({
+        id: section.id,
+        title: normalizeText(section.title),
+        items: section.items.map((item) => ({
+          id: item.id,
+          label: normalizeText(item.label),
+          value: normalizeText(item.value),
+        })),
+      })),
+    [sections],
+  );
+
+  return { sections, updateItem, resetSections, toPayload };
+}

--- a/website/src/i18n/profile/en.js
+++ b/website/src/i18n/profile/en.js
@@ -45,4 +45,57 @@ export default {
     "Please request a verification code before submitting.",
   emailCodeMismatch:
     "Please use the email that received the verification code.",
+  educationLabel: "Education",
+  educationPlaceholder: "e.g. Bachelor's in Computer Science",
+  educationHelp: "Helps mentors understand your theoretical background.",
+  jobLabel: "Occupation",
+  jobPlaceholder: "e.g. Product Manager / Graduate Student",
+  jobHelp: "Share your daily context to customise practice scenarios.",
+  currentAbilityLabel: "Current ability",
+  currentAbilityPlaceholder: "e.g. IELTS 6.5 / Confident in business demos",
+  currentAbilityHelp: "Describe your proficiency so we can match difficulty.",
+  customSections: {
+    learningPlan: {
+      title: "Learning plan",
+      description: "Capture milestones and rhythms to drive timely nudges.",
+      items: {
+        milestone: {
+          label: "Key milestone",
+          placeholder: "e.g. Deliver industry deck by week 4",
+        },
+        cadence: {
+          label: "Study cadence",
+          placeholder: "e.g. 1 hour on weekdays, weekend retrospectives",
+        },
+      },
+    },
+    resourcePreference: {
+      title: "Resource preference",
+      description: "Tell us which formats energise you most.",
+      items: {
+        primary: {
+          label: "Primary resource",
+          placeholder: "e.g. Podcasts / meeting minutes",
+        },
+        secondary: {
+          label: "Secondary resource",
+          placeholder: "e.g. Original books / video courses",
+        },
+      },
+    },
+    practiceScenarios: {
+      title: "Practice scenarios",
+      description: "Describe where you'll apply the skill in real life.",
+      items: {
+        realWorld: {
+          label: "Real-world setting",
+          placeholder: "e.g. Weekly product sync",
+        },
+        collaboration: {
+          label: "Collaboration partners",
+          placeholder: "e.g. Global design team",
+        },
+      },
+    },
+  },
 };

--- a/website/src/i18n/profile/zh.js
+++ b/website/src/i18n/profile/zh.js
@@ -42,4 +42,57 @@ export default {
   emailCodeRequired: "请输入验证码。",
   emailCodeNotRequested: "请先获取验证码，再提交换绑。",
   emailCodeMismatch: "请使用收到验证码的邮箱地址完成换绑。",
+  educationLabel: "学历",
+  educationPlaceholder: "如：本科 / 计算机科学",
+  educationHelp: "用于帮助导师快速了解你的理论基础。",
+  jobLabel: "职业",
+  jobPlaceholder: "如：产品经理 / 在读研究生",
+  jobHelp: "告诉我们你的日常语境，便于定制练习场景。",
+  currentAbilityLabel: "当前能力",
+  currentAbilityPlaceholder: "如：雅思 6.5 / 能进行商务演示",
+  currentAbilityHelp: "描述你对语言或技能的掌握程度，便于匹配内容难度。",
+  customSections: {
+    learningPlan: {
+      title: "学习计划",
+      description: "记录阶段性目标和节奏，系统会据此安排提醒。",
+      items: {
+        milestone: {
+          label: "关键里程碑",
+          placeholder: "例如：第 4 周完成行业演示稿",
+        },
+        cadence: {
+          label: "学习节奏",
+          placeholder: "如：工作日 1 小时，周末复盘",
+        },
+      },
+    },
+    resourcePreference: {
+      title: "资源偏好",
+      description: "说明你更喜欢的学习素材或形式。",
+      items: {
+        primary: {
+          label: "首选资源",
+          placeholder: "如：播客 / 会议纪要",
+        },
+        secondary: {
+          label: "备选资源",
+          placeholder: "如：原版书籍 / 视频课程",
+        },
+      },
+    },
+    practiceScenarios: {
+      title: "实践场景",
+      description: "描述你将在何种场合使用语言或技能。",
+      items: {
+        realWorld: {
+          label: "真实场景",
+          placeholder: "如：每周产品例会",
+        },
+        collaboration: {
+          label: "协作对象",
+          placeholder: "如：海外设计团队",
+        },
+      },
+    },
+  },
 };

--- a/website/src/pages/profile/Profile.module.css
+++ b/website/src/pages/profile/Profile.module.css
@@ -66,6 +66,11 @@
   text-align: center;
 }
 
+.identity {
+  display: grid;
+  gap: var(--space-3);
+}
+
 .basic {
   display: grid;
   gap: var(--space-3);
@@ -76,11 +81,26 @@
   height: 20px;
 }
 
-.basic input {
+.identity input,
+.identity textarea,
+.basic input,
+.basic textarea {
   padding: 12px 16px;
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
   background: color-mix(in srgb, var(--color-surface-alt) 80%, transparent);
+}
+
+.identity textarea,
+.basic textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- extend user profile DTOs and entity to capture education, current ability, and configurable custom sections
- add a dedicated codec plus service updates and controller/service tests to persist structured custom sections
- implement configuration-driven profile sections on the frontend with a reusable hook, UI component, translations, and tests

## Testing
- mvn test -Dtest=UserProfileServiceTest,UserProfileControllerTest
- npm run lint
- npm run lint:css
- npm run test -- useProfileSections

------
https://chatgpt.com/codex/tasks/task_e_68e29cdcc4dc8332baf478a1f07c0ea5