### PR TITLE
Refactor loader animation for consistent timing

### DIFF
--- a/website/src/components/ui/Loader/Loader.jsx
+++ b/website/src/components/ui/Loader/Loader.jsx
@@ -2,10 +2,22 @@ import waitingFrame1 from "@/assets/waiting-frame-1.svg";
 import waitingFrame2 from "@/assets/waiting-frame-2.svg";
 import waitingFrame3 from "@/assets/waiting-frame-3.svg";
 import styles from "./Loader.module.css";
+import waitingAnimationStrategy from "./waitingAnimationStrategy.cjs";
+
+/*
+ * 策略模式：
+ *  - 背景：等待动画的节奏与素材尺寸会随品牌升级而演变，若继续在组件内直接写死常量，将导致后续变更触碰 JSX 结构。
+ *  - 方案：通过独立策略模块集中管理节奏计算，Loader 仅负责渲染逻辑，后续替换策略即可切换动画风格。
+ *  - 取舍：策略模块引入一次额外函数调用，但换取单测友好与多动画方案扩展能力。
+ */
+const WAITING_ANIMATION_STRATEGY = waitingAnimationStrategy;
 
 // 设计说明：统一声明序列帧画布尺寸，确保所有素材在等高策略下共享同一纵横比。
-const WAITING_FRAME_DIMENSIONS = Object.freeze({ width: 682, height: 454 });
+const WAITING_FRAME_DIMENSIONS = WAITING_ANIMATION_STRATEGY.canvas;
 const WAITING_FRAMES = [waitingFrame1, waitingFrame2, waitingFrame3];
+const WAITING_TIMELINE = WAITING_ANIMATION_STRATEGY.buildTimeline(
+  WAITING_FRAMES.length,
+);
 
 function Loader() {
   return (
@@ -15,8 +27,16 @@ function Loader() {
       aria-live="polite"
       aria-busy="true"
     >
-      <div className={styles.symbol} aria-hidden="true">
-        {WAITING_FRAMES.map((frameSrc) => (
+      <div
+        className={styles.symbol}
+        aria-hidden="true"
+        style={{
+          "--waiting-frame-count": WAITING_TIMELINE.frameCount,
+          "--waiting-frame-interval": WAITING_TIMELINE.interval,
+          "--waiting-animation-duration": WAITING_TIMELINE.duration,
+        }}
+      >
+        {WAITING_FRAMES.map((frameSrc, index) => (
           <img
             key={frameSrc}
             className={styles.frame}
@@ -26,6 +46,9 @@ function Loader() {
             decoding="async"
             width={WAITING_FRAME_DIMENSIONS.width}
             height={WAITING_FRAME_DIMENSIONS.height}
+            style={{
+              "--waiting-frame-delay": WAITING_TIMELINE.delays[index],
+            }}
           />
         ))}
       </div>

--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -11,7 +11,9 @@
    * 取舍：沿用三帧序列，通过统一变量控制时长与缩放范围，保持素材可插拔。
    */
   --waiting-frame-max-width: calc(var(--space-5) * 9);
-  --waiting-animation-duration: 2.4s;
+  --waiting-frame-scale-rest: 0.92;
+  --waiting-frame-scale-active: 1;
+  --waiting-frame-scale-peak: 1.04;
 }
 
 .symbol {
@@ -36,94 +38,48 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  inline-size: 100%;
-  block-size: auto;
+  inline-size: auto;
+  block-size: 100%;
+  max-inline-size: 100%;
   display: block;
   object-fit: contain;
   opacity: 0;
 
   /* 通过缩放 + 透明度营造柔和的呼吸节奏，降低帧切换突兀感。 */
-  animation-duration: var(--waiting-animation-duration);
+  animation-name: waiting-animation-frame;
+  animation-duration: var(--waiting-animation-duration, 1.5s);
   animation-timing-function: ease-in-out;
   animation-iteration-count: infinite;
-  animation-direction: alternate;
   animation-fill-mode: both;
+  animation-delay: var(--waiting-frame-delay, 0ms);
   transform-origin: center;
 
   /*
    * 居中策略：利用 50% 位移 + translate 校准基准，配合高度自适应保证三帧素材等高无拉伸。
    */
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-rest));
   will-change: opacity, transform;
 }
 
-.frame:nth-child(1) {
-  animation-name: waiting-animation-frame-one;
-}
-
-.frame:nth-child(2) {
-  animation-name: waiting-animation-frame-two;
-}
-
-.frame:nth-child(3) {
-  animation-name: waiting-animation-frame-three;
-}
-
-@keyframes waiting-animation-frame-one {
+@keyframes waiting-animation-frame {
   0% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.92);
-  }
-
-  12%,
-  24% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1.02);
+    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-active));
   }
 
-  40%,
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
-  }
-}
-
-@keyframes waiting-animation-frame-two {
-  0%,
-  28% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
-  }
-
-  38%,
-  60% {
+  20% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1.04);
+    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-peak));
   }
 
-  72%,
-  100% {
+  33% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.94);
-  }
-}
-
-@keyframes waiting-animation-frame-three {
-  0%,
-  60% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.88);
-  }
-
-  76%,
-  88% {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1.06);
+    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-rest));
   }
 
   100% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.98);
+    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-rest));
   }
 }
 

--- a/website/src/components/ui/Loader/__tests__/waitingAnimationStrategy.test.js
+++ b/website/src/components/ui/Loader/__tests__/waitingAnimationStrategy.test.js
@@ -1,0 +1,26 @@
+/**
+ * 测试目标：验证等待动画策略输出统一节奏与尺寸，确保组件渲染时素材等高且 0.5 秒轮换。
+ * 前置条件：使用默认策略模块，不注入额外参数。
+ * 步骤：
+ *  1) 动态导入策略对象。
+ *  2) 调用 buildTimeline 生成三帧时间线。
+ * 断言：
+ *  - frameIntervalMs 恒为 500ms，对应 0.5 秒节奏。
+ *  - durationFor 返回 1500ms，总时长为帧数 * 间隔。
+ *  - delays 序列为 ["0ms", "-500ms", "-1000ms"]，保证依次触发。
+ *  - canvas 高度恒定，保障素材等高呈现。
+ * 边界/异常：
+ *  - 若帧数非法应抛出 TypeError，本用例不覆盖异常路径。
+ */
+test("GivenStrategy_WhenTimelineGenerated_ThenRespectUniformIntervalAndCanvas", async () => {
+  const { default: strategy } = await import("../waitingAnimationStrategy.cjs");
+
+  expect(strategy.frameIntervalMs).toBe(500);
+  expect(strategy.canvas.height).toBe(454);
+
+  const timeline = strategy.buildTimeline(3);
+  expect(strategy.durationFor(3)).toBe("1500ms");
+  expect(timeline.interval).toBe("500ms");
+  expect(timeline.duration).toBe("1500ms");
+  expect(timeline.delays).toEqual(["0ms", "-500ms", "-1000ms"]);
+});

--- a/website/src/components/ui/Loader/waitingAnimationStrategy.cjs
+++ b/website/src/components/ui/Loader/waitingAnimationStrategy.cjs
@@ -1,0 +1,70 @@
+/**
+ * 背景：
+ *  - 等待动画存在多套素材与节奏，历史实现将帧间隔写死在组件内，难以切换。
+ * 目的：
+ *  - 以策略模式封装动画时间线，集中管理节奏、尺寸与延迟逻辑。
+ * 关键决策与取舍：
+ *  - 选择 CommonJS 导出，便于在 Jest 环境下直接复用并编写单测。
+ *  - 暂不引入第三方动画库，保持零依赖与易于调试。
+ * 影响范围：
+ *  - Loader 组件与测试共享该策略对象，减少重复配置。
+ * 演进与TODO：
+ *  - TODO：支持根据主题动态切换不同节奏策略。
+ */
+const FRAME_INTERVAL_MS = 500;
+
+const CANVAS_DIMENSIONS = Object.freeze({
+  width: 682,
+  height: 454,
+});
+
+function assertFrameIndex(frameIndex) {
+  if (!Number.isInteger(frameIndex) || frameIndex < 0) {
+    throw new TypeError("frameIndex 必须是非负整数");
+  }
+}
+
+function assertFrameCount(frameCount) {
+  if (!Number.isInteger(frameCount) || frameCount <= 0) {
+    throw new TypeError("frameCount 必须是正整数");
+  }
+}
+
+function formatMilliseconds(value) {
+  return `${value}ms`;
+}
+
+function computeDelay(frameIndex) {
+  assertFrameIndex(frameIndex);
+  if (frameIndex === 0) {
+    return "0ms";
+  }
+  const offset = frameIndex * FRAME_INTERVAL_MS * -1;
+  return formatMilliseconds(offset);
+}
+
+function computeDuration(frameCount) {
+  assertFrameCount(frameCount);
+  return formatMilliseconds(frameCount * FRAME_INTERVAL_MS);
+}
+
+function buildTimeline(frameCount) {
+  const duration = computeDuration(frameCount);
+  const delays = Array.from({ length: frameCount }, (_, index) => computeDelay(index));
+  return {
+    frameCount,
+    interval: formatMilliseconds(FRAME_INTERVAL_MS),
+    duration,
+    delays,
+  };
+}
+
+const WAITING_ANIMATION_STRATEGY = Object.freeze({
+  frameIntervalMs: FRAME_INTERVAL_MS,
+  canvas: CANVAS_DIMENSIONS,
+  delayFor: computeDelay,
+  durationFor: computeDuration,
+  buildTimeline,
+});
+
+module.exports = WAITING_ANIMATION_STRATEGY;


### PR DESCRIPTION
## Summary
- refactor the loader component to drive frame animation via a shared strategy so each frame renders at uniform height and timing
- add a reusable strategy module with accompanying unit test to guarantee 500ms alternation and consistent canvas sizing

## Testing
- npm test -- waitingAnimationStrategy
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e2a15ca880833299c201b72e70ca78