### PR TITLE
feat: support configurable ChatInput width

### DIFF
--- a/website/src/components/ui/ChatInput/ChatInput.module.css
+++ b/website/src/components/ui/ChatInput/ChatInput.module.css
@@ -4,10 +4,16 @@
    * 取舍：优先消费 Layout 集中下发的 --docker-row-width/--docker-row-max-width，
    *       既保证搜索态与动作态的等宽，又在脱离 docker 时回落到 SearchBox 默认宽度。
    */
-  width: var(--docker-row-width, min(100%, var(--sb-max-width)));
+  width: var(
+    --docker-row-width,
+    var(--chat-input-shell-width, var(--sb-shell-width, 100%))
+  );
   display: flex;
   justify-content: center;
-  max-width: var(--docker-row-max-width, var(--sb-max-width));
+  max-width: var(
+    --docker-row-max-width,
+    var(--chat-input-shell-max, var(--sb-max-width))
+  );
   margin-inline: auto;
 }
 
@@ -31,7 +37,7 @@
     --sidebar-hover-bg,
     color-mix(in srgb, var(--sidebar-panel, var(--sb-surface)) 94%, white 6%)
   );
-  --sb-shell-width: 100%;
+  --sb-shell-width: var(--chat-input-shell-width, 100%);
   --padding-y: 0;
   --slot-gap: 0;
 

--- a/website/src/components/ui/ChatInput/__tests__/ChatInput.test.jsx
+++ b/website/src/components/ui/ChatInput/__tests__/ChatInput.test.jsx
@@ -1,0 +1,64 @@
+import { render } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+const mockActionInput = jest.fn(() => <div data-testid="searchbar" />);
+
+jest.unstable_mockModule("../ChatInput.module.css", () => ({
+  default: {},
+}));
+
+jest.unstable_mockModule("../ActionInput", () => ({
+  default: mockActionInput,
+}));
+
+jest.unstable_mockModule("../parts", () => ({
+  ActionButton: () => null,
+}));
+
+jest.unstable_mockModule("@/utils/markdown.js", () => ({}));
+jest.unstable_mockModule("@/utils/language.js", () => ({}));
+
+let ChatInput;
+
+beforeAll(async () => {
+  ({ default: ChatInput } = await import("../index.jsx"));
+});
+
+afterEach(() => {
+  mockActionInput.mockClear();
+});
+
+/**
+ * 测试目标：自定义 maxWidth 时应向壳层注入 CSS 变量以放宽 SearchBox 宽度。
+ * 前置条件：渲染 ChatInput，提供最小交互 Props 并设置 maxWidth=960。
+ * 步骤：
+ *  1) 渲染组件后获取容器与 SearchBox 节点。
+ *  2) 读取容器 style 中的相关 CSS 自定义属性。
+ * 断言：
+ *  - --chat-input-shell-max === 960px。
+ *  - --chat-input-shell-width === min(100%, 960px)。
+ * 边界/异常：
+ *  - 若变量缺失则说明宽度拓展未生效，应提醒布局层补充配置。
+ */
+test("GivenCustomMaxWidth_WhenRenderingChatInput_ThenExposeShellVariables", () => {
+  const { container, getByTestId } = render(
+    <ChatInput
+      maxWidth={960}
+      value="hello"
+      onChange={() => {}}
+      onSubmit={jest.fn()}
+      onVoice={jest.fn()}
+    />,
+  );
+
+  const shell = container.firstElementChild;
+  expect(shell).not.toBeNull();
+
+  const searchBox = getByTestId("searchbar");
+  expect(searchBox).not.toBeNull();
+
+  expect(shell?.style.getPropertyValue("--chat-input-shell-max")).toBe("960px");
+  expect(shell?.style.getPropertyValue("--chat-input-shell-width")).toBe(
+    "min(100%, 960px)",
+  );
+});

--- a/website/src/components/ui/ChatInput/index.jsx
+++ b/website/src/components/ui/ChatInput/index.jsx
@@ -1,13 +1,66 @@
+import PropTypes from "prop-types";
+
 import ActionInput from "./ActionInput";
 import styles from "./ChatInput.module.css";
 
-function ChatInput(props) {
+const normalizeCssDimension = (value) => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? `${value}px` : undefined;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  return undefined;
+};
+
+function ChatInput({ maxWidth, style: styleProp, ...actionInputProps }) {
+  const normalizedMaxWidth = normalizeCssDimension(maxWidth);
+  const hasCustomShellWidth =
+    styleProp &&
+    Object.prototype.hasOwnProperty.call(
+      styleProp,
+      "--chat-input-shell-width",
+    );
+
+  // 通过自定义属性传递壳层宽度/最大宽度，交由布局层统一控制并保持 SearchBox 一致节奏。
+  const cssVariables =
+    normalizedMaxWidth === undefined
+      ? undefined
+      : {
+          "--chat-input-shell-max": normalizedMaxWidth,
+          ...(!hasCustomShellWidth && normalizedMaxWidth !== "auto"
+            ? { "--chat-input-shell-width": `min(100%, ${normalizedMaxWidth})` }
+            : {}),
+        };
+
+  const mergedStyle =
+    cssVariables || styleProp
+      ? { ...(cssVariables ?? {}), ...(styleProp ?? {}) }
+      : undefined;
+
   return (
-    <div className={styles.container}>
-      <ActionInput {...props} />
+    <div className={styles.container} style={mergedStyle}>
+      <ActionInput {...actionInputProps} />
     </div>
   );
 }
+
+ChatInput.propTypes = {
+  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  style: PropTypes.object,
+};
+
+ChatInput.defaultProps = {
+  maxWidth: undefined,
+  style: undefined,
+};
 
 export default ChatInput;
 export { ActionInput };

--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -157,6 +157,7 @@ export default function DictionaryExperience() {
             onVoice={handleVoice}
             placeholder={chatInputPlaceholder}
             maxRows={5}
+            maxWidth="var(--docker-row-max-width, var(--sb-max-width))"
             sourceLanguage={dictionarySourceLanguage}
             sourceLanguageOptions={sourceLanguageOptions}
             sourceLanguageLabel={dictionarySourceLanguageLabel}

--- a/website/src/pages/chat/ChatView.jsx
+++ b/website/src/pages/chat/ChatView.jsx
@@ -71,6 +71,7 @@ export default function ChatView({ streamFn = streamChatMessage }) {
         placeholder={t.chatPlaceholder}
         sendLabel={t.sendButton}
         maxRows={5}
+        maxWidth="var(--layout-content-max, 960px)"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- allow ChatInput to expose configurable shell width and max width via CSS variables and a new maxWidth prop
- update chat and dictionary surfaces to opt into the wider shell limits
- add a focused ChatInput test covering the new width propagation helpers

## Testing
- npm run lint
- npm run test -- src/components/ui/ChatInput/__tests__/ChatInput.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e2a3c192f8833285940c46c2846975