### PR TITLE
feat: enable username editing in preferences account panel

### DIFF
--- a/website/src/components/Profile/UsernameEditor/index.jsx
+++ b/website/src/components/Profile/UsernameEditor/index.jsx
@@ -107,6 +107,7 @@ function resolveErrorMessage(t, error) {
 
 function UsernameEditor({
   username,
+  emptyDisplayValue,
   className = "",
   inputClassName = "",
   buttonClassName = "",
@@ -201,7 +202,11 @@ function UsernameEditor({
         ? t.saving
         : t.saveUsernameButton;
 
-  const inputValue = mode === MODES.VIEW ? value : draft;
+  const viewValue =
+    mode === MODES.VIEW && (!value || value.trim().length === 0)
+      ? emptyDisplayValue ?? ""
+      : value;
+  const inputValue = mode === MODES.VIEW ? viewValue : draft;
   const isButtonDisabled = mode === MODES.SAVING;
 
   return (
@@ -238,6 +243,7 @@ function UsernameEditor({
 
 UsernameEditor.propTypes = {
   username: PropTypes.string,
+  emptyDisplayValue: PropTypes.string,
   className: PropTypes.string,
   inputClassName: PropTypes.string,
   buttonClassName: PropTypes.string,

--- a/website/src/components/Profile/__tests__/UsernameEditor.test.jsx
+++ b/website/src/components/Profile/__tests__/UsernameEditor.test.jsx
@@ -18,7 +18,9 @@ const t = {
 };
 
 function renderEditor(props = {}) {
-  return render(<UsernameEditor username="taylor" t={t} {...props} />);
+  return render(
+    <UsernameEditor username="taylor" emptyDisplayValue="Not set" t={t} {...props} />,
+  );
 }
 
 describe("UsernameEditor", () => {
@@ -42,6 +44,7 @@ describe("UsernameEditor", () => {
     const input = screen.getByPlaceholderText("Enter username");
 
     expect(input).toBeDisabled();
+    expect(input).toHaveValue("taylor");
 
     fireEvent.click(button);
     expect(input).not.toBeDisabled();
@@ -110,5 +113,37 @@ describe("UsernameEditor", () => {
     expect(error).toBeInTheDocument();
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(input).toHaveClass(styles.input, styles["input-invalid"]);
+  });
+
+  /**
+   * 测试目标：当用户名为空时应展示占位值且进入编辑后清空输入。
+   * 前置条件：传入 username 为空字符串，并提供 emptyDisplayValue。
+   * 步骤：
+   *  1) 渲染组件并验证查看态显示占位文本；
+   *  2) 点击按钮进入编辑态；
+   *  3) 验证输入框被清空。
+   * 断言：
+   *  - 查看态 input value 为占位值；
+   *  - 编辑态 input value 为空字符串。
+   * 边界/异常：
+   *  - 若缺失 emptyDisplayValue，应维持空字符串（由默认逻辑覆盖）。
+   */
+  test("renders empty display value while keeping edit draft clean", () => {
+    render(
+      <UsernameEditor
+        username=""
+        emptyDisplayValue="Not set"
+        t={t}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Change username" });
+    const input = screen.getByDisplayValue("Not set");
+    expect(input).toBeDisabled();
+
+    fireEvent.click(button);
+    const editableInput = screen.getByPlaceholderText("Enter username");
+    expect(editableInput).toHaveValue("");
   });
 });

--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -6,6 +6,7 @@ const mockUseUser = jest.fn();
 const mockUseTheme = jest.fn();
 const mockUseKeyboardShortcutContext = jest.fn();
 const mockUseAvatarUploader = jest.fn();
+const mockUseUsersApi = jest.fn();
 
 jest.unstable_mockModule("@/context", () => ({
   useLanguage: mockUseLanguage,
@@ -18,6 +19,10 @@ jest.unstable_mockModule("@/context", () => ({
 jest.unstable_mockModule("@/hooks/useAvatarUploader.js", () => ({
   __esModule: true,
   default: mockUseAvatarUploader,
+}));
+
+jest.unstable_mockModule("@/api/users.js", () => ({
+  useUsersApi: mockUseUsersApi,
 }));
 
 let usePreferenceSections;
@@ -54,7 +59,6 @@ const createTranslations = (overrides = {}) => ({
   settingsAccountPhone: "Phone",
   settingsTabAccount: "Account",
   prefKeyboardTitle: "Shortcut playbook",
-  settingsManageProfile: "Manage profile",
   changeAvatar: "Change avatar",
   settingsAccountBindingTitle: "Connected accounts",
   settingsAccountBindingApple: "Apple",
@@ -142,6 +146,14 @@ const createTranslations = (overrides = {}) => ({
   pricingFixedNote: "Fixed",
   pricingTaxIncluded: "Tax included",
   pricingTaxExcluded: "Tax excluded",
+  usernamePlaceholder: "Enter username",
+  changeUsernameButton: "Change username",
+  saveUsernameButton: "Save username",
+  saving: "Saving...",
+  usernameValidationEmpty: "Username cannot be empty",
+  usernameValidationTooShort: "Username must be at least {{min}} characters",
+  usernameValidationTooLong: "Username must be at most {{max}} characters",
+  usernameUpdateFailed: "Unable to update username",
   ...overrides,
 });
 
@@ -151,15 +163,19 @@ beforeEach(() => {
   mockUseTheme.mockReset();
   mockUseKeyboardShortcutContext.mockReset();
   mockUseAvatarUploader.mockReset();
+  mockUseUsersApi.mockReset();
   translations = createTranslations();
   mockUseLanguage.mockReturnValue({ t: translations });
   mockUseUser.mockReturnValue({
     user: {
+      id: "user-1",
       username: "amy",
       email: "amy@example.com",
       plan: "plus",
       isPro: true,
+      token: "token-123",
     },
+    setUser: jest.fn(),
   });
   mockUseTheme.mockReturnValue({ theme: "light", setTheme: jest.fn() });
   mockUseKeyboardShortcutContext.mockReturnValue({
@@ -172,6 +188,9 @@ beforeEach(() => {
     status: "idle",
     error: null,
     reset: jest.fn(),
+  });
+  mockUseUsersApi.mockReturnValue({
+    updateUsername: jest.fn().mockResolvedValue({ username: "amy" }),
   });
 });
 
@@ -232,6 +251,9 @@ test("Given default sections When reading blueprint Then general leads navigatio
     "function",
   );
   expect(accountSection.componentProps.identity.isUploading).toBe(false);
+  expect(
+    typeof accountSection.componentProps.fields[0].renderValue,
+  ).toBe("function");
   expect(accountSection.componentProps.bindings.title).toBe(
     translations.settingsAccountBindingTitle,
   );

--- a/website/src/pages/preferences/sections/AccountSection.jsx
+++ b/website/src/pages/preferences/sections/AccountSection.jsx
@@ -109,24 +109,29 @@ function AccountSection({ title, fields, headingId, identity, bindings }) {
             </button>
           </div>
         </div>
-        {fields.map((field) => (
-          <div key={field.id} className={styles["detail-row"]}>
-            <dt className={styles["detail-label"]}>{field.label}</dt>
-            <dd className={styles["detail-value"]}>{field.value}</dd>
-            <div className={styles["detail-action"]}>
-              {field.action ? (
-                <button
-                  type="button"
-                  className={`${styles["avatar-trigger"]} ${styles["detail-action-button"]}`}
-                  aria-disabled={field.action.disabled}
-                  disabled={field.action.disabled}
-                >
-                  {field.action.label}
-                </button>
-              ) : null}
+        {fields.map((field) => {
+          const renderValue = field.renderValue;
+          return (
+            <div key={field.id} className={styles["detail-row"]}>
+              <dt className={styles["detail-label"]}>{field.label}</dt>
+              <dd className={styles["detail-value"]}>
+                {typeof renderValue === "function" ? renderValue(field) : field.value}
+              </dd>
+              <div className={styles["detail-action"]}>
+                {field.action ? (
+                  <button
+                    type="button"
+                    className={`${styles["avatar-trigger"]} ${styles["detail-action-button"]}`}
+                    aria-disabled={field.action.disabled}
+                    disabled={field.action.disabled}
+                  >
+                    {field.action.label}
+                  </button>
+                ) : null}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </dl>
       {bindings ? (
         <div className={styles.bindings} aria-live="polite">
@@ -164,6 +169,7 @@ AccountSection.propTypes = {
       id: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
+      renderValue: PropTypes.func,
       action: PropTypes.shape({
         id: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,


### PR DESCRIPTION
## Summary
- integrate the reusable UsernameEditor into the preferences account section with API-backed submission logic and renderer support for account fields
- enhance UsernameEditor to surface fallback display values while idle so empty usernames remain legible in view mode
- extend preferences and account section test suites to cover username editing, renderer handling, and validation feedback

## Testing
- npm test -- --runTestsByPath src/components/Profile/__tests__/UsernameEditor.test.jsx src/pages/preferences/sections/__tests__/AccountSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js src/__tests__/Preferences.test.jsx


------
https://chatgpt.com/codex/tasks/task_e_68e2a7b8d01c8332b726ed82ca1a3157