### PR TITLE
Fix subscription pricing interpolation and button contrast

### DIFF
--- a/website/src/components/modals/SettingsModal.module.css
+++ b/website/src/components/modals/SettingsModal.module.css
@@ -11,6 +11,8 @@
   --preferences-panel-shadow: 0 24px 60px rgb(0 0 0 / 45%);
   --preferences-panel-accent: linear-gradient(135deg, #5a8bff, #4c6fff);
   --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 35%);
+  --preferences-button-contrast-bg: var(--neutral-950);
+  --preferences-button-contrast-text: var(--neutral-0);
   --modal-surface: var(--preferences-panel-bg);
   --modal-color: var(--preferences-panel-text);
   --modal-shadow: var(--preferences-panel-shadow);
@@ -40,6 +42,8 @@
     0 18px 42px rgb(31 35 43 / 16%)
   );
   --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 22%);
+  --preferences-button-contrast-bg: var(--neutral-950);
+  --preferences-button-contrast-text: var(--neutral-0);
 }
 
 .close-button {

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -26,6 +26,8 @@
   --preferences-panel-surface: rgb(255 255 255 / 6%);
   --preferences-panel-accent: linear-gradient(135deg, #5a8bff, #4c6fff);
   --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 35%);
+  --preferences-button-contrast-bg: var(--neutral-950);
+  --preferences-button-contrast-text: var(--neutral-0);
 
   width: min(720px, 100%);
   padding: 44px;
@@ -43,6 +45,8 @@
   --preferences-panel-ring: var(--sidebar-input-ring, #cfd4e2);
   --preferences-panel-surface: rgb(15 17 21 / 6%);
   --preferences-panel-accent-shadow: 0 12px 24px rgb(76 111 255 / 22%);
+  --preferences-button-contrast-bg: var(--neutral-950);
+  --preferences-button-contrast-text: var(--neutral-0);
 }
 
 .header {
@@ -622,8 +626,8 @@
   padding: 12px 16px;
   border-radius: 14px;
   border: none;
-  background: var(--preferences-panel-text);
-  color: var(--night-elevated, #0f1115);
+  background: var(--preferences-button-contrast-bg);
+  color: var(--preferences-button-contrast-text);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -719,8 +723,8 @@
   padding: 10px 18px;
   border-radius: 14px;
   border: none;
-  background: var(--preferences-panel-text);
-  color: var(--night-elevated, #0f1115);
+  background: var(--preferences-button-contrast-bg);
+  color: var(--preferences-button-contrast-text);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -738,7 +742,7 @@
   border: none;
   background: var(--preferences-panel-accent);
   box-shadow: var(--preferences-panel-accent-shadow);
-  color: white;
+  color: var(--preferences-button-contrast-text);
   font-size: 15px;
   font-weight: 600;
   cursor: pointer;

--- a/website/src/pages/preferences/sections/__tests__/subscriptionBlueprint.test.js
+++ b/website/src/pages/preferences/sections/__tests__/subscriptionBlueprint.test.js
@@ -1,0 +1,123 @@
+import { jest } from "@jest/globals";
+
+let buildSubscriptionSectionProps;
+
+beforeAll(async () => {
+  ({ buildSubscriptionSectionProps } = await import(
+    "../subscriptionBlueprint.js"
+  ));
+});
+
+const createTranslations = (overrides = {}) => ({
+  subscriptionCurrentTitle: "Current subscription",
+  subscriptionPlanFreeTitle: "Free",
+  subscriptionPlanFreeSummary: "Free summary",
+  subscriptionPlanFreeCta: "Stay free",
+  subscriptionPlanPlusTitle: "Plus",
+  subscriptionPlanPlusSummary: "Plus summary",
+  subscriptionPlanPlusCta: "Upgrade Plus",
+  subscriptionPlanProTitle: "Pro",
+  subscriptionPlanProSummary: "Pro summary",
+  subscriptionPlanProCta: "Upgrade Pro",
+  subscriptionPlanPremiumTitle: "Premium",
+  subscriptionPlanPremiumSummary: "Premium summary",
+  subscriptionPlanPremiumCta: "Premium locked",
+  subscriptionPlanCurrentBadge: "Current",
+  subscriptionPlanSelectedBadge: "Selected",
+  subscriptionPlanLockedBadge: "Locked",
+  subscriptionPlanFreePrice: "Free",
+  subscriptionPriceMonthly: "{amount}/m",
+  subscriptionPriceYearly: "{amount}/y",
+  subscriptionPriceYearlyWithEquivalent: "{amount} ({equivalent}/m)",
+  subscriptionBillingCycleMonthly: "Monthly",
+  subscriptionBillingCycleYearly: "Yearly",
+  subscriptionNextRenewalTemplate: "Next: {value}",
+  subscriptionRegionLineTemplate: "Region: {value}",
+  subscriptionPremiumHighlight: "Premium highlight",
+  subscriptionActionManage: "Manage",
+  subscriptionActionRedeem: "Redeem",
+  subscriptionRedeemTitle: "Redeem",
+  subscriptionRedeemPlaceholder: "Code",
+  subscriptionRedeemButton: "Redeem now",
+  subscriptionSubscribeButtonTemplate: "Subscribe {plan}",
+  subscriptionSubscribeButtonDisabled: "Current plan",
+  subscriptionFeatureColumnLabel: "Feature",
+  pricingFixedNote: "Fixed pricing",
+  pricingTaxIncluded: "Tax included",
+  pricingTaxExcluded: "Tax excluded",
+  settingsTabSubscription: "Subscription",
+  ...overrides,
+});
+
+const createUser = (overrides = {}) => ({
+  username: "amy",
+  subscription: {
+    planId: "FREE",
+    billingCycle: "monthly",
+    regionLabel: "US · USD",
+    nextRenewalDate: "2025-01-01",
+    ...overrides,
+  },
+});
+
+/**
+ * 测试目标：包含 {amount}/{equivalent} 占位符的文案在构建套餐卡片时被正确替换。
+ * 前置条件：使用默认定价配置与含占位符的翻译文案。
+ * 步骤：
+ *  1) 调用 buildSubscriptionSectionProps 构建订阅分区 props。
+ *  2) 读取 PLUS 套餐的价格行。
+ * 断言：
+ *  - 月付与年付文案均不再包含花括号。
+ *  - 月付文案格式为 "$2.49/m"。
+ *  - 年付折算文案格式为 "$24.99/y ($2.08/m)"。
+ * 边界/异常：
+ *  - 若 pricing 配置缺失数值则回退为占位符（由 fallback 逻辑覆盖）。
+ */
+test("Given amount placeholders When building plan cards Then price lines interpolate", () => {
+  const props = buildSubscriptionSectionProps({
+    translations: createTranslations(),
+    user: createUser(),
+    onRedeem: jest.fn(),
+    onSubscribe: jest.fn(),
+  });
+
+  const plusCard = props.planCards.find((plan) => plan.id === "PLUS");
+  expect(plusCard).toBeDefined();
+  expect(plusCard.priceLines).toContain("$2.49/m");
+  expect(plusCard.priceLines).toContain("$24.99/y ($2.08/m)");
+  plusCard.priceLines.forEach((line) => {
+    expect(line.includes("{")).toBe(false);
+  });
+});
+
+/**
+ * 测试目标：当翻译文案缺失模板时，数值格式化仍能提供兜底展示。
+ * 前置条件：移除 subscriptionPriceMonthly/Yearly 模板。
+ * 步骤：
+ *  1) 传入不含模板的翻译对象构建 props。
+ *  2) 读取 PLUS 套餐的价格行。
+ * 断言：
+ *  - 月付与年付均退化为格式化货币字符串。
+ * 边界/异常：
+ *  - 若货币符号缺失则使用默认 "—"（由 normalizeDisplayValue 保障）。
+ */
+test("Given missing templates When building plan cards Then fallback formatting applies", () => {
+  const props = buildSubscriptionSectionProps({
+    translations: createTranslations({
+      subscriptionPriceMonthly: "",
+      subscriptionPriceYearly: "",
+      subscriptionPriceYearlyWithEquivalent: "",
+    }),
+    user: createUser(),
+    onRedeem: jest.fn(),
+    onSubscribe: jest.fn(),
+  });
+
+  const plusCard = props.planCards.find((plan) => plan.id === "PLUS");
+  expect(plusCard).toBeDefined();
+  expect(plusCard.priceLines).toContain("$2.49/月");
+  expect(plusCard.priceLines).toContain("$24.99/年");
+  plusCard.priceLines.forEach((line) => {
+    expect(line.includes("{")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure subscription pricing templates interpolate {amount}/{equivalent} placeholders via a shared formatter and add regression tests
- align subscription action buttons with high-contrast tokens so black surfaces use white text in both light and dark themes

## Testing
- npm test -- --runTestsByPath src/pages/preferences/sections/__tests__/subscriptionBlueprint.test.js src/pages/preferences/sections/__tests__/SubscriptionSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a87c92c08332a1ecbaac4ac15533