### PR TITLE
refactor: remove subscription current card

### DIFF
--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -318,9 +318,7 @@ test("Given member flag only When mapping subscription plan Then membership fall
   );
 
   expect(subscriptionSection).toBeDefined();
-  expect(subscriptionSection.componentProps.currentPlanCard.planLine).toContain(
-    translations.subscriptionPlanPlusTitle,
-  );
+  expect(subscriptionSection.componentProps.defaultSelectedPlanId).toBe("PLUS");
   const plusCard = subscriptionSection.componentProps.planCards.find(
     (card) => card.id === "PLUS",
   );

--- a/website/src/pages/preferences/sections/SubscriptionSection.jsx
+++ b/website/src/pages/preferences/sections/SubscriptionSection.jsx
@@ -19,7 +19,6 @@ function SubscriptionSection({
   title,
   headingId,
   descriptionId,
-  currentPlanCard,
   planCards,
   featureMatrix,
   visiblePlanIds,
@@ -53,19 +52,6 @@ function SubscriptionSection({
       onRedeem(redeemCode.trim());
     }
   }, [onRedeem, redeemCode]);
-
-  const handleTopAction = useCallback(
-    (action) => {
-      if (!action) {
-        return;
-      }
-      if (action.id === "redeem" && redeemInputRef.current) {
-        redeemInputRef.current.focus();
-      }
-      action.onClick?.();
-    },
-    [],
-  );
 
   const subscribeDisabled = selectedPlanId === defaultSelectedPlanId;
 
@@ -105,39 +91,6 @@ function SubscriptionSection({
           {title}
         </h3>
         <div className={styles["section-divider"]} aria-hidden="true" />
-      </div>
-      <div className={styles["subscription-current"]}>
-        <div className={styles["subscription-current-header"]}>
-          <h4 className={styles["subscription-current-title"]}>
-            {currentPlanCard.title}
-          </h4>
-          <p className={styles["subscription-current-plan"]}>
-            {currentPlanCard.planLine}
-          </p>
-        </div>
-        <p className={styles["subscription-current-meta"]}>
-          {currentPlanCard.nextRenewalLabel}
-        </p>
-        <p className={styles["subscription-current-meta"]}>
-          {currentPlanCard.regionLine}
-        </p>
-        {currentPlanCard.premiumHighlight ? (
-          <p className={styles["subscription-premium"]}>
-            {currentPlanCard.premiumHighlight}
-          </p>
-        ) : null}
-        <div className={styles["subscription-current-actions"]}>
-          {currentPlanCard.actions.map((action) => (
-            <button
-              key={action.id}
-              type="button"
-              className={styles["subscription-action"]}
-              onClick={() => handleTopAction(action)}
-            >
-              {action.label}
-            </button>
-          ))}
-        </div>
       </div>
       <div className={styles["subscription-matrix"]}>
         <div className={styles["subscription-plan-grid"]}>
@@ -257,20 +210,6 @@ SubscriptionSection.propTypes = {
   title: PropTypes.string.isRequired,
   headingId: PropTypes.string.isRequired,
   descriptionId: PropTypes.string,
-  currentPlanCard: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    planLine: PropTypes.string.isRequired,
-    nextRenewalLabel: PropTypes.string.isRequired,
-    regionLine: PropTypes.string.isRequired,
-    premiumHighlight: PropTypes.string,
-    actions: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        label: PropTypes.string.isRequired,
-        onClick: PropTypes.func,
-      }),
-    ).isRequired,
-  }).isRequired,
   planCards: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/website/src/pages/preferences/sections/__tests__/SubscriptionSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/SubscriptionSection.test.jsx
@@ -22,17 +22,6 @@ const baseProps = {
   title: "Subscription",
   headingId: "subscription-heading",
   descriptionId: undefined,
-  currentPlanCard: {
-    title: "Current plan",
-    planLine: "Plus · Monthly",
-    nextRenewalLabel: "Next: 2025-01-01",
-    regionLine: "Region: CN · CNY",
-    premiumHighlight: null,
-    actions: [
-      { id: "manage", label: "Manage" },
-      { id: "redeem", label: "Redeem" },
-    ],
-  },
   planCards: [
     {
       id: "FREE",

--- a/website/src/pages/preferences/sections/subscriptionBlueprint.js
+++ b/website/src/pages/preferences/sections/subscriptionBlueprint.js
@@ -596,79 +596,9 @@ export function buildSubscriptionSectionProps({
     pricing,
   });
 
-  const hasBillingCycle =
-    currentPlanId !== "FREE" &&
-    typeof subscriptionMeta.billingCycle === "string";
-  const billingCycle = hasBillingCycle
-    ? safeString(
-        subscriptionMeta.billingCycle === "yearly"
-          ? t.subscriptionBillingCycleYearly
-          : t.subscriptionBillingCycleMonthly,
-        FALLBACK_VALUE,
-      )
-    : FALLBACK_VALUE;
-
-  const currentPlanCopy = planCopy[currentPlanId] ?? { title: currentPlanId };
-  const planLine =
-    billingCycle && billingCycle !== FALLBACK_VALUE
-      ? `${currentPlanCopy.title} · ${billingCycle}`
-      : currentPlanCopy.title;
-  const nextRenewalLabel = subscriptionMeta.nextRenewalDate
-    ? formatWithTemplate(
-        safeString(t.subscriptionNextRenewalTemplate, "下次扣费：{value}"),
-        subscriptionMeta.nextRenewalDate,
-      )
-    : FALLBACK_VALUE;
-  const regionLabel = subscriptionMeta.regionLabel ?? pricing.regionLabel;
-  const regionLine = formatWithTemplate(
-    safeString(t.subscriptionRegionLineTemplate, "地区：{value}"),
-    regionLabel
-      ? `${regionLabel} · ${pricing.currency}`
-      : `${pricing.currency}`,
-  );
-
-  const premiumHighlight =
-    currentPlanId === "PREMIUM"
-      ? safeString(t.subscriptionPremiumHighlight, "已解锁最高级配额与优先级")
-      : null;
-
   const taxNote = pricing.taxIncluded
     ? safeString(t.pricingTaxIncluded, "价格已含税")
     : safeString(t.pricingTaxExcluded, "价格不含税");
-
-  const currentTitle = safeString(t.subscriptionCurrentTitle, "当前订阅");
-
-  const actions = [
-    {
-      id: "manage",
-      label: safeString(t.subscriptionActionManage, "管理订阅"),
-      onClick:
-        typeof onSubscribe === "function"
-          ? () => onSubscribe(currentPlanId)
-          : undefined,
-    },
-    {
-      id: "upgrade",
-      label: safeString(t.subscriptionActionUpgrade, "升级"),
-      onClick: undefined,
-    },
-    {
-      id: "downgrade",
-      label: safeString(t.subscriptionActionDowngrade, "降级"),
-      onClick: undefined,
-    },
-    {
-      id: "change-region",
-      label: safeString(t.subscriptionActionChangeRegion, "切换地区"),
-      onClick: undefined,
-    },
-    {
-      id: "redeem",
-      label: safeString(t.subscriptionActionRedeem, "兑换码"),
-      onClick:
-        typeof onRedeem === "function" ? () => onRedeem("focus") : undefined,
-    },
-  ];
 
   const redeemCopy = {
     title: safeString(t.subscriptionRedeemTitle, "兑换专享权益"),
@@ -692,14 +622,6 @@ export function buildSubscriptionSectionProps({
   return {
     title: safeString(t.settingsTabSubscription, "订阅"),
     featureColumnLabel: safeString(t.subscriptionFeatureColumnLabel, "能力项"),
-    currentPlanCard: {
-      title: currentTitle,
-      planLine,
-      nextRenewalLabel,
-      regionLine,
-      premiumHighlight,
-      actions,
-    },
     planCards,
     featureMatrix,
     visiblePlanIds,


### PR DESCRIPTION
## Summary
- remove the current subscription header card from the preferences subscription section
- simplify the subscription blueprint and related tests to reflect the streamlined layout

## Testing
- npm run test -- --runTestsByPath src/pages/preferences/sections/__tests__/SubscriptionSection.test.jsx src/pages/preferences/__tests__/usePreferenceSections.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2aea4cf58833280e9f452a1e5949b