### PR TITLE
feat: highlight dangerous subscription action text

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -526,6 +526,8 @@
 }
 
 .subscription-action-danger {
+  /* 保持危险操作按钮的文字颜色与边框一致，强化警示语义 */
+  color: var(--color-danger);
   border-color: color-mix(in srgb, var(--color-danger) 78%, transparent);
 }
 


### PR DESCRIPTION
## Summary
- ensure the dangerous subscription management button text uses the danger color to reinforce the destructive affordance

## Testing
- npm run lint *(fails: existing warning about missing dependencies in usePreferenceSections useMemo)*
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e2b056bcf48332a3e2ee07f2f71392