### PR TITLE
Fix preference sections lint warnings

### DIFF
--- a/website/src/components/Profile/UsernameEditor/UsernameEditor.module.css
+++ b/website/src/components/Profile/UsernameEditor/UsernameEditor.module.css
@@ -68,6 +68,17 @@
   transform: none;
 }
 
+.button:not(:disabled):focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px
+    color-mix(
+      in srgb,
+      var(--preferences-panel-ring, var(--primary-bg, #2c3540)) 45%,
+      transparent
+    );
+  transform: translateY(-1px);
+}
+
 .button:not(:disabled):hover {
   transform: translateY(-1px);
   border-color: color-mix(
@@ -82,18 +93,7 @@
   );
 }
 
-.button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px
-    color-mix(
-      in srgb,
-      var(--preferences-panel-ring, var(--primary-bg, #2c3540)) 45%,
-      transparent
-    );
-  transform: translateY(-1px);
-}
-
-.button:active {
+.button:not(:disabled):active {
   transform: translateY(0);
   box-shadow: none;
 }

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -494,11 +494,9 @@ function usePreferenceSections({ initialSectionId }) {
     accountBindingsTitle,
     fallbackValue,
     t.settingsAccountAvatarLabel,
-    t.settingsAccountDefaultPhoneCode,
     t.settingsAccountEmailUnbind,
     t.settingsAccountEmailUnbindAction,
     t.settingsAccountPhoneRebindAction,
-    t.settingsManageProfile,
     handleUsernameFailure,
     handleUsernameSubmit,
     usernameEditorTranslations,
@@ -523,9 +521,9 @@ function usePreferenceSections({ initialSectionId }) {
     handleAvatarSelection,
     isAvatarUploading,
     sanitizedUsername,
-    user?.email,
-    user?.phone,
-    user?.username,
+    usernameValue,
+    emailValue,
+    phoneValue,
   ]);
 
   const [activeSectionId, setActiveSectionId] = useState(() =>


### PR DESCRIPTION
## Summary
- add missing computed values to the preference sections memo dependency list and drop unused keys
- gate UsernameEditor state styles behind :not(:disabled) to satisfy no-descending-specificity

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e2b3f4778c83328e87adaef0ed64fa