### PR TITLE
Display normalized dictionary terms in sidebar history

### DIFF
--- a/website/src/components/Sidebar/HistoryListView.jsx
+++ b/website/src/components/Sidebar/HistoryListView.jsx
@@ -28,7 +28,7 @@ function HistoryListView({ items, onSelect, onNavigate }) {
         return (
           <li key={item.termKey} className={styles.item} role="presentation">
             <NavItem
-              label={item.term}
+              label={item.displayTerm ?? item.term}
               onClick={() => {
                 if (typeof onSelect === "function") {
                   onSelect(item);
@@ -36,8 +36,8 @@ function HistoryListView({ items, onSelect, onNavigate }) {
               }}
               className={styles.entryButton}
               /*
-               * 背景：搜索记录需要完整呈现用户输入，避免记忆成本。
-               * 取舍：启用 NavItem 的多行模式，让排版与数据长度解耦，不影响其他入口。
+               * 背景：搜索记录需展示模型识别后的规范词形，以保持历史与查询结果一致。
+               * 取舍：仍保留多行模式，确保较长词形在视觉上完整展示且不影响其他入口。
                */
               allowMultilineLabel
               ref={navigationBindings.ref}
@@ -55,6 +55,7 @@ HistoryListView.propTypes = {
     PropTypes.shape({
       termKey: PropTypes.string.isRequired,
       term: PropTypes.string.isRequired,
+      displayTerm: PropTypes.string,
       latestVersionId: PropTypes.string,
     }),
   ),

--- a/website/src/components/Sidebar/__tests__/HistoryListView.test.jsx
+++ b/website/src/components/Sidebar/__tests__/HistoryListView.test.jsx
@@ -157,6 +157,35 @@ describe("HistoryListView", () => {
   });
 
   /**
+   * 测试目标：当传入 displayTerm 时，组件应优先展示规范词形。
+   * 前置条件：items 中包含 term 与 displayTerm 不同的项。
+   * 步骤：
+   *  1) 渲染组件并传入带 displayTerm 的列表。
+   *  2) 查询渲染按钮的可访问名称。
+   * 断言：
+   *  - 按钮名称为 displayTerm；
+   *  - 原 term 不作为可访问名称出现。
+   * 边界/异常：
+   *  - 若 displayTerm 缺失，应继续显示 term（其他用例覆盖）。
+   */
+  test("Given_display_term_When_present_Then_prefers_canonical_label", () => {
+    const onNavigate = jest.fn(() => ({}));
+    const items = [
+      {
+        termKey: "term-1",
+        term: "studdent",
+        displayTerm: "student",
+        latestVersionId: "v1",
+      },
+    ];
+
+    render(<HistoryListView items={items} onNavigate={onNavigate} />);
+
+    expect(screen.getByRole("button", { name: "student" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "studdent" })).not.toBeInTheDocument();
+  });
+
+  /**
    * 测试目标：验证历史词条启用 NavItem 的多行模式以完整展示文本。
    * 前置条件：提供包含长词条的列表，并渲染默认视图。
    * 步骤：

--- a/website/src/components/Sidebar/hooks/useSidebarHistory.js
+++ b/website/src/components/Sidebar/hooks/useSidebarHistory.js
@@ -12,13 +12,80 @@
  *  - 未来可在此 Hook 扩展分页、过滤或空状态配置，并通过返回值暴露给展示层。
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { shallow } from "zustand/shallow";
 import { useHistory, useUser } from "@/context";
+import { useWordStore } from "@/store";
+
+const sanitizeTerm = (value) => {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  return trimmed;
+};
+
+/**
+ * 意图：以适配器模式将词条缓存中的规范词形映射到历史项，用于侧边栏展示。
+ * 输入：历史项、wordStore 暴露的 getEntry/getRecord 访问器。
+ * 输出：用于展示的规范词形字符串，若无法解析则返回空串。
+ * 流程：
+ *  1) 优先读取词条版本（getEntry）对应的 term；
+ *  2) 其次回退到缓存元数据或任一包含 term 的版本；
+ *  3) 若仍未命中，则退回历史项原始 term。
+ * 错误处理：缺失访问器或字段时返回空串，调用方负责回退；
+ * 复杂度：O(1)。
+ */
+const resolveDisplayTerm = (item, getEntry, getRecord) => {
+  if (!item) return "";
+
+  const preferredEntry =
+    typeof getEntry === "function"
+      ? getEntry(item.termKey, item.latestVersionId ?? undefined)
+      : null;
+  const entryTerm = sanitizeTerm(preferredEntry?.term);
+  if (entryTerm) {
+    return entryTerm;
+  }
+
+  const record =
+    typeof getRecord === "function" ? getRecord(item.termKey) : null;
+  if (record) {
+    const metadataTerm = sanitizeTerm(record.metadata?.term);
+    if (metadataTerm) {
+      return metadataTerm;
+    }
+
+    if (Array.isArray(record.versions)) {
+      const matchedVersion = record.versions.find((version) => {
+        if (!version) return false;
+        if (item.latestVersionId) {
+          return (
+            String(version.id) === String(item.latestVersionId) &&
+            sanitizeTerm(version.term)
+          );
+        }
+        return Boolean(sanitizeTerm(version.term));
+      });
+      const versionTerm = sanitizeTerm(matchedVersion?.term);
+      if (versionTerm) {
+        return versionTerm;
+      }
+    }
+  }
+
+  return sanitizeTerm(item.term);
+};
 
 export default function useSidebarHistory({ onSelectHistory } = {}) {
   const { history, loadHistory, loadMoreHistory, error, hasMore, isLoading } =
     useHistory();
   const { user } = useUser();
   const [errorMessage, setErrorMessage] = useState("");
+  const { getEntry, getRecord } = useWordStore(
+    (state) => ({
+      getEntry: state.getEntry,
+      getRecord: state.getRecord,
+    }),
+    shallow,
+  );
 
   useEffect(() => {
     if (!user?.token) return;
@@ -30,7 +97,23 @@ export default function useSidebarHistory({ onSelectHistory } = {}) {
     setErrorMessage(error);
   }, [error]);
 
-  const items = useMemo(() => history ?? [], [history]);
+  const items = useMemo(() => {
+    if (!Array.isArray(history)) {
+      return [];
+    }
+
+    let hasAdaptedTerm = false;
+    const adapted = history.map((item) => {
+      const canonicalTerm = resolveDisplayTerm(item, getEntry, getRecord);
+      if (canonicalTerm && canonicalTerm !== item.term) {
+        hasAdaptedTerm = true;
+        return { ...item, displayTerm: canonicalTerm };
+      }
+      return item;
+    });
+
+    return hasAdaptedTerm ? adapted : history;
+  }, [getEntry, getRecord, history]);
 
   const itemRefs = useRef([]);
 


### PR DESCRIPTION
## Summary
- adapt sidebar history data using the word cache so items expose canonical display terms
- render canonical terms in the history list and extend unit tests to cover the new behaviour

## Testing
- npm test -- --runTestsByPath src/components/Sidebar/__tests__/HistoryListView.test.jsx src/components/Sidebar/__tests__/useSidebarHistory.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b3dd11188332b6e9b055162c9d5f