### PR TITLE
Fix preference sections dependencies and button state selectors

### DIFF
--- a/website/src/components/Profile/UsernameEditor/UsernameEditor.module.css
+++ b/website/src/components/Profile/UsernameEditor/UsernameEditor.module.css
@@ -68,7 +68,7 @@
   transform: none;
 }
 
-.button:not(:disabled):focus-visible {
+.button:where(:not(:disabled)):focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px
     color-mix(
@@ -79,7 +79,7 @@
   transform: translateY(-1px);
 }
 
-.button:not(:disabled):hover {
+.button:where(:not(:disabled)):hover {
   transform: translateY(-1px);
   border-color: color-mix(
     in srgb,
@@ -93,7 +93,7 @@
   );
 }
 
-.button:not(:disabled):active {
+.button:where(:not(:disabled)):active {
   transform: translateY(0);
   box-shadow: none;
 }


### PR DESCRIPTION
## Summary
- memoize the preference account field display values to keep section data dependencies accurate
- adjust the username editor button state selectors to satisfy stylelint specificity rules

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e2b67e8cd88332ae069ca7608197b8