### PR TITLE
style: align username editor input with panel design

### DIFF
--- a/website/src/components/Profile/UsernameEditor/UsernameEditor.module.css
+++ b/website/src/components/Profile/UsernameEditor/UsernameEditor.module.css
@@ -14,20 +14,105 @@
 }
 
 .input {
+  /**
+   * 背景：
+   *  - 原输入框沿用纯文本样式，缺失圆角边框与立体层次，破坏了偏好设置面板的视觉节奏。
+   * 目的：
+   *  - 与设置面板的控件体系对齐，复用面板语义令牌构建统一的圆角、描边与阴影体系。
+   * 关键取舍：
+   *  - 选择通过 CSS 自定义属性复用面板令牌，避免在组件内硬编码颜色；
+   *  - 未额外引入新组件，保持 UsernameEditor 的状态机职责纯粹，将样式改动限定在视觉层。
+   */
   flex: 1;
-  border: none;
-  background: none;
-  color: inherit;
+  min-height: 40px;
+  padding: 10px 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid
+    color-mix(in srgb, var(--preferences-panel-border, #2f3744) 65%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, rgb(255 255 255 / 10%)) 94%,
+    transparent
+  );
+  color: var(--preferences-panel-text, inherit);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
+  box-shadow: 0 12px 28px -22px rgb(15 23 42 / 65%);
+}
+
+.input::placeholder {
+  color: color-mix(
+    in srgb,
+    var(--preferences-panel-muted, rgb(120 130 145)) 88%,
+    transparent
+  );
 }
 
 .input:disabled {
   cursor: default;
   opacity: 1;
+  color: color-mix(
+    in srgb,
+    var(--preferences-panel-muted, rgb(120 130 145)) 92%,
+    transparent
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-border, #2f3744) 45%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, rgb(255 255 255 / 10%)) 86%,
+    transparent
+  );
+  box-shadow: none;
+}
+
+.input:not(:disabled):focus-visible {
+  outline: none;
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, #4c6fff) 65%,
+    transparent
+  );
+  box-shadow:
+    0 12px 28px -22px rgb(15 23 42 / 65%),
+    0 0 0 3px color-mix(
+      in srgb,
+      var(--preferences-panel-ring, #4c6fff) 45%,
+      transparent
+    );
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, rgb(255 255 255 / 10%)) 98%,
+    transparent
+  );
+}
+
+.input:not(:disabled):hover {
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, #4c6fff) 45%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, rgb(255 255 255 / 10%)) 96%,
+    transparent
+  );
 }
 
 .input-invalid {
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-danger) 70%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-danger) 70%, transparent),
+    0 12px 28px -22px rgb(15 23 42 / 65%);
   border-radius: var(--radius-lg);
+  border-color: color-mix(in srgb, var(--color-danger) 65%, transparent);
   background: color-mix(in srgb, var(--color-danger) 8%, transparent);
   transition: box-shadow 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- restyle the username editor input to use the same rounded border, padding, and surface tokens as the surrounding preferences controls
- refine disabled, hover, focus, and invalid states to keep accessibility focus rings and consistent elevation cues

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e2b6f333d083329df5ab239d13f46d