### PR TITLE
feat: randomize loader waiting animation

### DIFF
--- a/website/src/components/ui/Loader/Loader.jsx
+++ b/website/src/components/ui/Loader/Loader.jsx
@@ -1,8 +1,10 @@
+import { useMemo } from "react";
 import waitingFrame1 from "@/assets/waiting-frame-1.svg";
 import waitingFrame2 from "@/assets/waiting-frame-2.svg";
 import waitingFrame3 from "@/assets/waiting-frame-3.svg";
 import styles from "./Loader.module.css";
 import waitingAnimationStrategy from "./waitingAnimationStrategy.cjs";
+import useWaitingFrameCycle from "./useWaitingFrameCycle";
 
 /*
  * 策略模式：
@@ -17,22 +19,27 @@ const WAITING_FRAME_DIMENSIONS = WAITING_ANIMATION_STRATEGY.canvas;
 const WAITING_FRAME_ASPECT_RATIO = Number(
   (WAITING_FRAME_DIMENSIONS.width / WAITING_FRAME_DIMENSIONS.height).toFixed(6),
 );
-const WAITING_FRAMES = [waitingFrame1, waitingFrame2, waitingFrame3];
-const WAITING_TIMELINE = WAITING_ANIMATION_STRATEGY.buildTimeline(
-  WAITING_FRAMES.length,
-);
-
-// 语义化映射：统一导出 CSS 自定义属性，避免在 JSX 中散落常量格式化逻辑。
-// 节奏同步：高度与节奏变量同时暴露给样式层，以保证 1.5 秒轮换时三帧素材保持绝对等高与柔和渐变。
-const WAITING_SYMBOL_STYLE = Object.freeze({
-  "--waiting-frame-count": WAITING_TIMELINE.frameCount,
-  "--waiting-frame-interval": WAITING_TIMELINE.interval,
-  "--waiting-animation-duration": WAITING_TIMELINE.duration,
+const WAITING_FRAMES = Object.freeze([
+  waitingFrame1,
+  waitingFrame2,
+  waitingFrame3,
+]);
+const WAITING_SYMBOL_STYLE_BASE = Object.freeze({
   "--waiting-frame-height": `min(65vh, ${WAITING_FRAME_DIMENSIONS.height}px)`,
   "--waiting-frame-aspect-ratio": WAITING_FRAME_ASPECT_RATIO,
 });
 
 function Loader() {
+  const { currentFrame, handleCycleComplete, cycleDurationMs } =
+    useWaitingFrameCycle(WAITING_FRAMES);
+  const waitingSymbolStyle = useMemo(
+    () => ({
+      ...WAITING_SYMBOL_STYLE_BASE,
+      "--waiting-fill-duration": `${cycleDurationMs}ms`,
+    }),
+    [cycleDurationMs],
+  );
+
   return (
     <div
       className={styles.loader}
@@ -43,23 +50,29 @@ function Loader() {
       <div
         className={styles.symbol}
         aria-hidden="true"
-        style={WAITING_SYMBOL_STYLE}
+        style={waitingSymbolStyle}
       >
-        {WAITING_FRAMES.map((frameSrc, index) => (
+        <div className={styles.frame}>
           <img
-            key={frameSrc}
-            className={styles.frame}
-            src={frameSrc}
+            className={styles["frame-base"]}
+            src={currentFrame}
             alt=""
             loading="lazy"
             decoding="async"
             width={WAITING_FRAME_DIMENSIONS.width}
             height={WAITING_FRAME_DIMENSIONS.height}
-            style={{
-              "--waiting-frame-delay": WAITING_TIMELINE.delays[index],
-            }}
           />
-        ))}
+          <img
+            className={styles["frame-overlay"]}
+            src={currentFrame}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            width={WAITING_FRAME_DIMENSIONS.width}
+            height={WAITING_FRAME_DIMENSIONS.height}
+            onAnimationIteration={handleCycleComplete}
+          />
+        </div>
       </div>
       <span className={styles.label}>Loading…</span>
     </div>

--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -11,9 +11,6 @@
    * 取舍：沿用三帧序列，通过统一变量控制时长与缩放范围，保持素材可插拔。
    */
   --waiting-frame-max-width: calc(var(--space-5) * 9);
-  --waiting-frame-scale-rest: 0.92;
-  --waiting-frame-scale-active: 1;
-  --waiting-frame-scale-peak: 1.04;
 }
 
 .symbol {
@@ -25,13 +22,14 @@
   );
   block-size: var(--waiting-frame-height);
   aspect-ratio: var(--waiting-frame-aspect-ratio);
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   /*
    * 设计对齐：等待动画素材需裸呈不带底板，因此移除背景、圆角、阴影等装饰性元素。
    * 影响：后续若需恢复容器化呈现，可改为引入独立包裹层，避免污染素材本身。
-   * 等高策略：通过 height 自定义属性约束容器尺寸，确保三帧素材在任何节奏下保持绝对高度一致。
+   * 等高策略：通过 height 自定义属性约束容器尺寸，确保不同帧在任何节奏下保持绝对高度一致。
    */
   background: none;
   border: none;
@@ -41,61 +39,56 @@
 }
 
 .frame {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  inline-size: auto;
+  position: relative;
+  inline-size: 100%;
   block-size: 100%;
-  max-inline-size: calc(var(--waiting-frame-aspect-ratio) * var(--waiting-frame-height));
-  display: block;
-  object-fit: contain;
-  opacity: 0;
-
-  /* 通过缩放 + 透明度营造柔和的呼吸节奏，降低帧切换突兀感。 */
-  animation-name: waiting-animation-frame;
-  animation-duration: var(--waiting-animation-duration, 4.5s);
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
-  animation-fill-mode: both;
-  animation-delay: var(--waiting-frame-delay, 0ms);
-  transform-origin: center;
-
-  /*
-   * 居中策略：利用 50% 位移 + translate 校准基准，配合高度自适应保证三帧素材等高无拉伸。
-   */
-  transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-rest));
-  will-change: opacity, transform;
+  max-inline-size: calc(
+    var(--waiting-frame-aspect-ratio) * var(--waiting-frame-height)
+  );
 }
 
-@keyframes waiting-animation-frame {
+.frame-base,
+.frame-overlay {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  inline-size: auto;
+  block-size: 100%;
+  display: block;
+  object-fit: contain;
+}
+
+.frame-base {
+  z-index: 1;
+}
+
+.frame-overlay {
+  z-index: 2;
+  transform-origin: 50% 100%;
+  animation-name: waiting-fill-cycle;
+  animation-duration: var(--waiting-fill-duration, 1500ms);
+  animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
+  animation-iteration-count: infinite;
+  animation-fill-mode: both;
+  filter: grayscale(1) brightness(1.8);
+  opacity: 1;
+  will-change: transform, opacity;
+}
+
+@keyframes waiting-fill-cycle {
   0% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-rest));
-  }
-
-  8% {
-    opacity: 0.45;
-    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-rest));
-  }
-
-  16% {
+    transform: scaleY(1);
     opacity: 1;
-    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-active));
   }
 
-  26% {
+  65% {
+    transform: scaleY(1);
     opacity: 1;
-    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-peak));
-  }
-
-  33.333% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-active));
   }
 
   100% {
+    transform: scaleY(0);
     opacity: 0;
-    transform: translate(-50%, -50%) scale(var(--waiting-frame-scale-rest));
   }
 }
 

--- a/website/src/components/ui/Loader/__tests__/useWaitingFrameCycle.test.js
+++ b/website/src/components/ui/Loader/__tests__/useWaitingFrameCycle.test.js
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+import useWaitingFrameCycle from "../useWaitingFrameCycle";
+
+/**
+ * 测试目标：验证等待帧 Hook 能根据随机数生成器输出正确的初始帧，并在动画迭代后切换素材。
+ * 前置条件：提供包含三帧素材的数组以及可控的随机函数序列。
+ * 步骤：
+ *  1) 通过 renderHook 渲染 useWaitingFrameCycle，并注入自定义随机序列。
+ *  2) 读取初始 currentFrame，模拟动画迭代事件。
+ * 断言：
+ *  - 初始帧与随机序列首个值匹配；
+ *  - handleCycleComplete 被调用后返回新的帧且不与上一帧重复。
+ * 边界/异常：
+ *  - 随机函数命中上一帧索引时，Hook 应回退到下一合法帧。
+ */
+describe("useWaitingFrameCycle", () => {
+  const frames = ["frame-a.svg", "frame-b.svg", "frame-c.svg"];
+
+  it("GivenRandomSequence_WhenInitialised_ThenUsesFirstRandomValue", () => {
+    const randomValues = [0.6];
+    const { result } = renderHook(() =>
+      useWaitingFrameCycle(frames, {
+        random: () => randomValues.shift() ?? 0,
+      }),
+    );
+
+    expect(result.current.currentFrame).toBe("frame-b.svg");
+  });
+
+  it("GivenAnimationIteration_WhenRandomRepeatsIndex_ThenFallsBackToNextFrame", () => {
+    const randomValues = [0.4, 0.4];
+    const { result } = renderHook(() =>
+      useWaitingFrameCycle(frames, {
+        random: () => randomValues.shift() ?? 0,
+      }),
+    );
+
+    expect(result.current.currentFrame).toBe("frame-b.svg");
+
+    act(() => {
+      result.current.handleCycleComplete();
+    });
+
+    expect(result.current.currentFrame).toBe("frame-c.svg");
+  });
+
+  it("GivenSingleFramePool_WhenIterating_ThenKeepsReturningSameFrame", () => {
+    const singleFrame = ["only-frame.svg"];
+    const { result } = renderHook(() =>
+      useWaitingFrameCycle(singleFrame, {
+        random: () => 0.9,
+      }),
+    );
+
+    expect(result.current.currentFrame).toBe("only-frame.svg");
+
+    act(() => {
+      result.current.handleCycleComplete();
+    });
+
+    expect(result.current.currentFrame).toBe("only-frame.svg");
+  });
+});

--- a/website/src/components/ui/Loader/useWaitingFrameCycle.js
+++ b/website/src/components/ui/Loader/useWaitingFrameCycle.js
@@ -1,0 +1,87 @@
+/**
+ * 背景：
+ *  - 等待动画从序列帧轮播升级为“随机抽帧 + 填充”状态，需要有状态地控制素材切换时机。
+ * 目的：
+ *  - 封装成 Hook，集中处理素材池、随机策略与 React 生命周期，避免在 Loader 组件中散落副作用。
+ * 关键决策与取舍：
+ *  - 采用状态模式思路：Hook 内部维护当前帧索引与响应动画迭代事件的转换函数，保持组件层纯展示。
+ *  - 提供可注入的随机函数，便于单测时复现确定性场景，同时保证默认实现零依赖。
+ * 影响范围：
+ *  - Loader 组件通过该 Hook 接收当前帧与迭代回调；未来若引入更多素材池或节奏策略，可在 Hook 内扩展。
+ * 演进与TODO：
+ *  - TODO：支持基于用户偏好/主题的素材分组与加权随机，提供更贴合语境的等待体验。
+ */
+import { useCallback, useMemo, useRef, useState } from "react";
+import waitingAnimationStrategy from "./waitingAnimationStrategy.cjs";
+
+const { frameIntervalMs: WAITING_CYCLE_INTERVAL_MS } = waitingAnimationStrategy;
+
+function assertValidFrames(frames) {
+  if (!Array.isArray(frames) || frames.length === 0) {
+    throw new TypeError("frames 至少需要包含一项可用资源");
+  }
+}
+
+function clampIndex(candidateIndex, poolSize) {
+  if (candidateIndex < 0) {
+    return 0;
+  }
+  if (candidateIndex >= poolSize) {
+    return poolSize - 1;
+  }
+  return candidateIndex;
+}
+
+function selectNextIndex(poolSize, randomFn, previousIndex) {
+  if (poolSize === 1) {
+    return 0;
+  }
+  const raw = randomFn();
+  const candidateIndex = clampIndex(Math.floor(raw * poolSize), poolSize);
+  if (candidateIndex !== previousIndex) {
+    return candidateIndex;
+  }
+  return (candidateIndex + 1) % poolSize;
+}
+
+function createInitialState(frames, randomFn) {
+  const initialIndex = selectNextIndex(frames.length, randomFn, -1);
+  return {
+    frameIndex: initialIndex,
+    frameSrc: frames[initialIndex],
+  };
+}
+
+function deriveNextState(frames, randomFn, previousIndex) {
+  const nextIndex = selectNextIndex(frames.length, randomFn, previousIndex);
+  return {
+    frameIndex: nextIndex,
+    frameSrc: frames[nextIndex],
+  };
+}
+
+export default function useWaitingFrameCycle(frames, options = {}) {
+  assertValidFrames(frames);
+  const framePool = useMemo(() => frames.slice(), [frames]);
+  const randomRef = useRef(options.random ?? Math.random);
+  const randomFn = randomRef.current;
+
+  const [state, setState] = useState(() =>
+    createInitialState(framePool, randomFn),
+  );
+
+  const handleCycleComplete = useCallback(() => {
+    setState((previous) =>
+      deriveNextState(framePool, randomFn, previous.frameIndex),
+    );
+  }, [framePool, randomFn]);
+
+  return useMemo(
+    () => ({
+      currentFrame: state.frameSrc,
+      handleCycleComplete,
+      cycleDurationMs: WAITING_CYCLE_INTERVAL_MS,
+    }),
+    [handleCycleComplete, state.frameSrc],
+  );
+}


### PR DESCRIPTION
## Summary
- replace the sequential loader frames with a random single-frame cycle that fades from grey to black before reselecting a frame
- encapsulate frame rotation logic in a dedicated hook and add focused unit coverage

## Testing
- npm test -- useWaitingFrameCycle

------
https://chatgpt.com/codex/tasks/task_e_68e2b96090d483329b1e3772b94089af