### PR TITLE
Remove subscription CTA from subscription preferences

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -287,8 +287,6 @@ export default {
   subscriptionRedeemTitle: "Redeem exclusive benefits",
   subscriptionRedeemPlaceholder: "Enter 16-character code",
   subscriptionRedeemButton: "Redeem now",
-  subscriptionSubscribeButtonTemplate: "Subscribe to {plan}",
-  subscriptionSubscribeButtonDisabled: "Already on this plan",
   subscriptionFeatureColumnLabel: "Feature",
   pricingFixedNote: "Pricing is pegged per region and not tied to FX rates.",
   pricingTaxIncluded: "Tax included",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -274,8 +274,6 @@ export default {
   subscriptionRedeemTitle: "兑换专享权益",
   subscriptionRedeemPlaceholder: "请输入兑换码（16 位）",
   subscriptionRedeemButton: "立即兑换",
-  subscriptionSubscribeButtonTemplate: "订阅 {plan}",
-  subscriptionSubscribeButtonDisabled: "已是当前套餐",
   subscriptionFeatureColumnLabel: "能力项",
   pricingFixedNote: "本地区价格为固定面额，不随汇率波动调整。",
   pricingTaxIncluded: "价格已含税",

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -839,7 +839,11 @@
 
 .subscription-actions {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  /*
+    说明：使用 auto-fit 可在仅保留兑换区域时铺满整行，同时保留未来扩展多个操作位的弹性；
+    若恢复额外动作，列布局会自动平均分配，无需再次调整样式。
+  */
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: var(--space-4);
 }
 
@@ -879,35 +883,6 @@
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-}
-
-.subscription-cta {
-  display: flex;
-  align-items: flex-end;
-}
-
-.subscription-cta-button {
-  width: 100%;
-  padding: 14px 18px;
-  border-radius: 16px;
-  border: none;
-  background: var(--preferences-panel-accent);
-  box-shadow: var(--preferences-panel-accent-shadow);
-  color: var(--preferences-button-contrast-text);
-  font-size: 15px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-
-.subscription-cta-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-}
-
-.subscription-cta-button:not(:disabled):hover {
-  transform: translateY(-1px);
 }
 
 .section-title {

--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -140,8 +140,6 @@ const createTranslations = (overrides = {}) => ({
   subscriptionRedeemTitle: "Redeem",
   subscriptionRedeemPlaceholder: "Code",
   subscriptionRedeemButton: "Redeem now",
-  subscriptionSubscribeButtonTemplate: "Subscribe {plan}",
-  subscriptionSubscribeButtonDisabled: "Current",
   subscriptionFeatureColumnLabel: "Feature",
   pricingFixedNote: "Fixed",
   pricingTaxIncluded: "Tax included",

--- a/website/src/pages/preferences/sections/SubscriptionSection.jsx
+++ b/website/src/pages/preferences/sections/SubscriptionSection.jsx
@@ -8,10 +8,9 @@
  * 影响范围：
  *  - 偏好设置页面与 SettingsModal 的订阅分区展示。
  * 演进与TODO：
- *  - TODO: 接入真实兑换与订阅 API 时补充加载/错误态，并与遥测打通。
+ *  - TODO: 接入真实兑换 API 时补充加载/错误态，并与遥测打通。
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import styles from "../Preferences.module.css";
 
@@ -26,17 +25,14 @@ function SubscriptionSection({
   pricingNote,
   taxNote,
   redeemCopy,
-  subscribeCopy,
   defaultSelectedPlanId,
   onRedeem,
-  onSubscribe,
   featureColumnLabel,
 }) {
   const [selectedPlanId, setSelectedPlanId] = useState(defaultSelectedPlanId);
   const [redeemCode, setRedeemCode] = useState("");
   const redeemInputRef = useRef(null);
   const planCarouselRef = useRef(null);
-  const navigate = useNavigate();
   const [isPlanRailAtStart, setIsPlanRailAtStart] = useState(true);
   const [isPlanRailAtEnd, setIsPlanRailAtEnd] = useState(false);
 
@@ -52,33 +48,6 @@ function SubscriptionSection({
       onRedeem(redeemCode.trim());
     }
   }, [onRedeem, redeemCode]);
-
-  const subscribeDisabled = selectedPlanId === defaultSelectedPlanId;
-
-  const subscribeLabel = useMemo(() => {
-    if (subscribeDisabled) {
-      return subscribeCopy.disabledLabel;
-    }
-    const selectedPlanLabel = planLabels[selectedPlanId] ?? selectedPlanId;
-    return subscribeCopy.template.replace("{plan}", selectedPlanLabel);
-  }, [
-    subscribeDisabled,
-    subscribeCopy.disabledLabel,
-    subscribeCopy.template,
-    planLabels,
-    selectedPlanId,
-  ]);
-
-  const handleSubscribe = useCallback(() => {
-    if (subscribeDisabled) {
-      return;
-    }
-    if (onSubscribe) {
-      onSubscribe(selectedPlanId);
-      return;
-    }
-    navigate("/subscription", { state: { plan: selectedPlanId } });
-  }, [navigate, onSubscribe, selectedPlanId, subscribeDisabled]);
 
   /**
    * 意图：复用单一的滚动同步逻辑，让横向滑动的套餐列表在不同视口下保持导航按钮状态正确。
@@ -275,16 +244,6 @@ function SubscriptionSection({
             </button>
           </div>
         </div>
-        <div className={styles["subscription-cta"]}>
-          <button
-            type="button"
-            className={styles["subscription-cta-button"]}
-            onClick={handleSubscribe}
-            disabled={subscribeDisabled}
-          >
-            {subscribeLabel}
-          </button>
-        </div>
       </div>
     </section>
   );
@@ -322,20 +281,14 @@ SubscriptionSection.propTypes = {
     placeholder: PropTypes.string.isRequired,
     buttonLabel: PropTypes.string.isRequired,
   }).isRequired,
-  subscribeCopy: PropTypes.shape({
-    template: PropTypes.string.isRequired,
-    disabledLabel: PropTypes.string.isRequired,
-  }).isRequired,
   defaultSelectedPlanId: PropTypes.string.isRequired,
   onRedeem: PropTypes.func,
-  onSubscribe: PropTypes.func,
   featureColumnLabel: PropTypes.string.isRequired,
 };
 
 SubscriptionSection.defaultProps = {
   descriptionId: undefined,
   onRedeem: undefined,
-  onSubscribe: undefined,
 };
 
 export default SubscriptionSection;

--- a/website/src/pages/preferences/sections/__tests__/subscriptionBlueprint.test.js
+++ b/website/src/pages/preferences/sections/__tests__/subscriptionBlueprint.test.js
@@ -39,8 +39,6 @@ const createTranslations = (overrides = {}) => ({
   subscriptionRedeemTitle: "Redeem",
   subscriptionRedeemPlaceholder: "Code",
   subscriptionRedeemButton: "Redeem now",
-  subscriptionSubscribeButtonTemplate: "Subscribe {plan}",
-  subscriptionSubscribeButtonDisabled: "Current plan",
   subscriptionFeatureColumnLabel: "Feature",
   pricingFixedNote: "Fixed pricing",
   pricingTaxIncluded: "Tax included",
@@ -78,7 +76,6 @@ test("Given amount placeholders When building plan cards Then price lines interp
     translations: createTranslations(),
     user: createUser(),
     onRedeem: jest.fn(),
-    onSubscribe: jest.fn(),
   });
 
   const plusCard = props.planCards.find((plan) => plan.id === "PLUS");
@@ -88,6 +85,7 @@ test("Given amount placeholders When building plan cards Then price lines interp
   plusCard.priceLines.forEach((line) => {
     expect(line.includes("{")).toBe(false);
   });
+  expect(props.subscribeCopy).toBeUndefined();
 });
 
 /**
@@ -110,7 +108,6 @@ test("Given missing templates When building plan cards Then fallback formatting 
     }),
     user: createUser(),
     onRedeem: jest.fn(),
-    onSubscribe: jest.fn(),
   });
 
   const plusCard = props.planCards.find((plan) => plan.id === "PLUS");

--- a/website/src/pages/preferences/sections/subscriptionBlueprint.js
+++ b/website/src/pages/preferences/sections/subscriptionBlueprint.js
@@ -6,9 +6,9 @@
  * 关键决策与取舍：
  *  - 采用建造者模式集中整理文案与格式化逻辑，组件保持纯展示；拒绝在组件内硬编码套餐或数值。
  * 影响范围：
- *  - Preferences 页及 SettingsModal 中的订阅分区，未来扩展兑换与订阅流程时亦可复用本构造器。
+ *  - Preferences 页及 SettingsModal 中的订阅分区，未来扩展兑换流程时亦可复用本构造器。
  * 演进与TODO：
- *  - TODO: 接入真实兑换/订阅 API 后，将 onRedeem/onSubscribe 替换为实际动作，并补充状态管理。
+ *  - TODO: 接入真实兑换 API 后，将 onRedeem 替换为实际动作，并补充状态管理。
  */
 import {
   PLAN_SEQUENCE,
@@ -564,12 +564,7 @@ const buildFeatureMatrix = ({ blueprint, visiblePlanIds, pricing }) =>
     }, {}),
   }));
 
-export function buildSubscriptionSectionProps({
-  translations,
-  user,
-  onRedeem,
-  onSubscribe,
-}) {
+export function buildSubscriptionSectionProps({ translations, user, onRedeem }) {
   const t = translations ?? {};
   const userProfile = user ?? {};
   const subscriptionMeta = userProfile.subscription ?? {};
@@ -606,14 +601,6 @@ export function buildSubscriptionSectionProps({
     buttonLabel: safeString(t.subscriptionRedeemButton, "立即兑换"),
   };
 
-  const subscribeCopy = {
-    template: safeString(t.subscriptionSubscribeButtonTemplate, "订阅 {plan}"),
-    disabledLabel: safeString(
-      t.subscriptionSubscribeButtonDisabled,
-      "已是当前套餐",
-    ),
-  };
-
   const pricingNote = safeString(
     t.pricingFixedNote,
     "本地区价格为固定面额，不随汇率波动调整。",
@@ -632,9 +619,7 @@ export function buildSubscriptionSectionProps({
     pricingNote,
     taxNote,
     redeemCopy,
-    subscribeCopy,
     defaultSelectedPlanId: currentPlanId,
     onRedeem,
-    onSubscribe,
   };
 }


### PR DESCRIPTION
## Summary
- remove the subscription CTA flow from SubscriptionSection and the associated blueprint/translations so the redeem form is the sole action
- tighten the subscription actions layout now that only the redeem form remains, keeping auto-fit styling for future extensibility

## Testing
- npm test -- SubscriptionSection
- npm test -- subscriptionBlueprint
- npm test -- usePreferenceSections

------
https://chatgpt.com/codex/tasks/task_e_68e2ba53ffc883328f8b58aa31a0baf9