### PR TITLE
feat: adapt settings nav for compact layout

### DIFF
--- a/website/src/components/modals/SettingsModal.jsx
+++ b/website/src/components/modals/SettingsModal.jsx
@@ -171,6 +171,7 @@ function SettingsModal({ open, onClose, initialSection }) {
             nav: preferencesStyles.tabs,
             button: preferencesStyles.tab,
             label: preferencesStyles["tab-label"],
+            labelText: preferencesStyles["tab-label-text"],
             actionButton: preferencesStyles["close-button"],
           }}
         />

--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -215,6 +215,11 @@
   text-transform: none;
 }
 
+.tab-label-text {
+  display: inline-flex;
+  align-items: center;
+}
+
 .tab-icon {
   display: inline-flex;
   align-items: center;
@@ -1209,6 +1214,42 @@
   .tab {
     min-width: 0;
     height: 100%;
+  }
+
+  /*
+   * 当 SettingsNav 报告水平布局时，仅展示图标并将标签等宽分布，
+   * 通过视觉隐藏文本保留无障碍名称由 aria-label 提供。
+   */
+  .tabs[data-orientation="horizontal"] {
+    align-items: center;
+  }
+
+  .tabs[data-orientation="horizontal"] .tab {
+    justify-content: center;
+    align-items: center;
+    padding: 12px 0;
+  }
+
+  .tabs[data-orientation="horizontal"] .tab-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .tabs[data-orientation="horizontal"] .tab-label {
+    justify-content: center;
+  }
+
+  .tabs[data-orientation="horizontal"] .tab-label-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
   }
 
   .section {

--- a/website/src/pages/preferences/index.jsx
+++ b/website/src/pages/preferences/index.jsx
@@ -131,6 +131,7 @@ function Preferences({ initialSection, renderCloseAction }) {
               nav: styles.tabs,
               button: styles.tab,
               label: styles["tab-label"],
+              labelText: styles["tab-label-text"],
               icon: styles["tab-icon"],
               actionButton: styles["close-button"],
             }}


### PR DESCRIPTION
## Summary
- switch SettingsNav to a responsive icon-only mode under the 768px breakpoint and expose orientation hints for styling
- adjust preferences styling to hide tab text in compact layout while keeping accessibility through aria labels
- extend SettingsNav tests with a matchMedia harness to cover the new horizontal, icon-only behaviour and wire classes through modal/page consumers

## Testing
- npm test -- SettingsNavPanel

------
https://chatgpt.com/codex/tasks/task_e_68e2ba19e5d88332ae139cc1d87d4de6