### PR TITLE
Fix markdown polishing for heading-attached metadata labels

### DIFF
--- a/website/src/utils/__tests__/markdown.test.js
+++ b/website/src/utils/__tests__/markdown.test.js
@@ -31,4 +31,21 @@ describe("polishDictionaryMarkdown", () => {
     const input = "我们正在学习C#语言";
     expect(polishDictionaryMarkdown(input)).toBe(input);
   });
+
+  /**
+   * 测试目标：确保标题后的行内标签会被拆分到独立行，恢复 Markdown 渲染。
+   * 前置条件：输入中标题与标签紧邻且标签命中词表。
+   * 步骤：
+   *  1) 调用 polishDictionaryMarkdown 处理带标签的标题行。
+   *  2) 读取返回文本。
+   * 断言：
+   *  - 断言标题与标签之间存在换行分隔。
+   * 边界/异常：
+   *  - 验证逻辑仅影响可识别标签，不修改普通粗体标题。
+   */
+  test("separates inline metadata labels from heading lines", () => {
+    const input = "## Frequency&**Proficiency-Frequency Band**: High";
+    const output = polishDictionaryMarkdown(input);
+    expect(output).toContain("## Frequency&\n**Proficiency-Frequency Band**: High");
+  });
 });


### PR DESCRIPTION
## Summary
- split inline metadata labels from heading lines when polishing dictionary markdown
- add regression test covering headings glued to frequency metadata blocks

## Testing
- npm test -- markdown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2bd7b09a08332b434e5c8c3ed14be