### PR TITLE
refactor: redesign loader animation with frame reveal

### DIFF
--- a/website/src/components/ui/Loader/Loader.jsx
+++ b/website/src/components/ui/Loader/Loader.jsx
@@ -5,12 +5,13 @@ import waitingFrame3 from "@/assets/waiting-frame-3.svg";
 import styles from "./Loader.module.css";
 import waitingAnimationStrategy from "./waitingAnimationStrategy.cjs";
 import useWaitingFrameCycle from "./useWaitingFrameCycle";
+import useFrameReveal from "./useFrameReveal";
 
 /*
  * 策略模式：
- *  - 背景：等待动画的节奏与素材尺寸会随品牌升级而演变，若继续在组件内直接写死常量，将导致后续变更触碰 JSX 结构。
- *  - 方案：通过独立策略模块集中管理节奏计算，Loader 仅负责渲染逻辑，后续替换策略即可切换动画风格。
- *  - 取舍：策略模块引入一次额外函数调用，但换取单测友好与多动画方案扩展能力。
+ *  - 背景：等待动画节奏与素材会随品牌升级调整；若在组件中硬编码展示逻辑，将在每次换素材时触碰 JSX 结构。
+ *  - 方案：保留独立策略模块负责画布尺寸与节奏，Loader 聚焦呈现并复用 Hook 提供的帧调度；当节奏变动时仅需替换策略。
+ *  - 取舍：策略模块带来一次额外的函数调用，但换取了更高的可测性与扩展性，符合“童子军军规”。
  */
 const WAITING_ANIMATION_STRATEGY = waitingAnimationStrategy;
 
@@ -24,21 +25,36 @@ const WAITING_FRAMES = Object.freeze([
   waitingFrame2,
   waitingFrame3,
 ]);
+
+// 设计取舍：33vh 为视觉规范要求的显示高度，同时保留像素级上限避免 SVG 溢出。
 const WAITING_SYMBOL_STYLE_BASE = Object.freeze({
-  "--waiting-frame-height": `min(65vh, ${WAITING_FRAME_DIMENSIONS.height}px)`,
+  "--waiting-frame-height": `min(33vh, ${WAITING_FRAME_DIMENSIONS.height}px)`,
   "--waiting-frame-aspect-ratio": WAITING_FRAME_ASPECT_RATIO,
 });
+const WAITING_REVEAL_DURATION_RATIO = 0.65; // 经验值：色彩过渡占节奏 65%，避免突兀闪烁。
+
+function composeFrameClassName(isRevealed) {
+  const baseClassName = styles["frame-image"];
+  if (!isRevealed) {
+    return baseClassName;
+  }
+  return `${baseClassName} ${styles["frame-image-revealed"]}`;
+}
 
 function Loader() {
-  const { currentFrame, handleCycleComplete, cycleDurationMs } =
+  const { currentFrame, cycleDurationMs } =
     useWaitingFrameCycle(WAITING_FRAMES);
-  const waitingSymbolStyle = useMemo(
-    () => ({
+  const isRevealed = useFrameReveal(currentFrame);
+
+  const waitingSymbolStyle = useMemo(() => {
+    const revealDuration = Math.round(
+      cycleDurationMs * WAITING_REVEAL_DURATION_RATIO,
+    );
+    return {
       ...WAITING_SYMBOL_STYLE_BASE,
-      "--waiting-fill-duration": `${cycleDurationMs}ms`,
-    }),
-    [cycleDurationMs],
-  );
+      "--waiting-reveal-duration": `${revealDuration}ms`,
+    };
+  }, [cycleDurationMs]);
 
   return (
     <div
@@ -54,23 +70,13 @@ function Loader() {
       >
         <div className={styles.frame}>
           <img
-            className={styles["frame-base"]}
+            className={composeFrameClassName(isRevealed)}
             src={currentFrame}
             alt=""
             loading="lazy"
             decoding="async"
             width={WAITING_FRAME_DIMENSIONS.width}
             height={WAITING_FRAME_DIMENSIONS.height}
-          />
-          <img
-            className={styles["frame-overlay"]}
-            src={currentFrame}
-            alt=""
-            loading="lazy"
-            decoding="async"
-            width={WAITING_FRAME_DIMENSIONS.width}
-            height={WAITING_FRAME_DIMENSIONS.height}
-            onAnimationIteration={handleCycleComplete}
           />
         </div>
       </div>

--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -2,22 +2,15 @@
   display: grid;
   place-items: center;
   inline-size: 100%;
-  min-block-size: var(--vh);
+  min-block-size: var(--vh, 100vh);
   padding: var(--space-4);
   background: transparent;
-
-  /*
-   * 背景：等待动画需改为缩放渐隐效果，避免出现底色遮挡与突兀闪烁。
-   * 取舍：沿用三帧序列，通过统一变量控制时长与缩放范围，保持素材可插拔。
-   */
-  --waiting-frame-max-width: calc(var(--space-5) * 9);
 }
 
 .symbol {
   position: relative;
   inline-size: min(
     80vw,
-    var(--waiting-frame-max-width),
     calc(var(--waiting-frame-aspect-ratio) * var(--waiting-frame-height))
   );
   block-size: var(--waiting-frame-height);
@@ -25,12 +18,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-
-  /*
-   * 设计对齐：等待动画素材需裸呈不带底板，因此移除背景、圆角、阴影等装饰性元素。
-   * 影响：后续若需恢复容器化呈现，可改为引入独立包裹层，避免污染素材本身。
-   * 等高策略：通过 height 自定义属性约束容器尺寸，确保不同帧在任何节奏下保持绝对高度一致。
-   */
   background: none;
   border: none;
   box-shadow: none;
@@ -42,54 +29,19 @@
   position: relative;
   inline-size: 100%;
   block-size: 100%;
-  max-inline-size: calc(
-    var(--waiting-frame-aspect-ratio) * var(--waiting-frame-height)
-  );
 }
 
-.frame-base,
-.frame-overlay {
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  inline-size: auto;
+.frame-image {
+  inline-size: 100%;
   block-size: 100%;
   display: block;
   object-fit: contain;
+  filter: grayscale(1) brightness(1.2);
+  transition: filter var(--waiting-reveal-duration, 900ms) ease-out;
 }
 
-.frame-base {
-  z-index: 1;
-}
-
-.frame-overlay {
-  z-index: 2;
-  transform-origin: 50% 100%;
-  animation-name: waiting-fill-cycle;
-  animation-duration: var(--waiting-fill-duration, 1500ms);
-  animation-timing-function: cubic-bezier(0.37, 0, 0.63, 1);
-  animation-iteration-count: infinite;
-  animation-fill-mode: both;
-  filter: grayscale(1) brightness(1.8);
-  opacity: 1;
-  will-change: transform, opacity;
-}
-
-@keyframes waiting-fill-cycle {
-  0% {
-    transform: scaleY(1);
-    opacity: 1;
-  }
-
-  65% {
-    transform: scaleY(1);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scaleY(0);
-    opacity: 0;
-  }
+.frame-image-revealed {
+  filter: grayscale(0) brightness(1);
 }
 
 .label {
@@ -108,7 +60,6 @@
   .symbol {
     inline-size: min(
       90vw,
-      calc(var(--space-5) * 7),
       calc(var(--waiting-frame-aspect-ratio) * var(--waiting-frame-height))
     );
   }

--- a/website/src/components/ui/Loader/__tests__/useFrameReveal.test.js
+++ b/website/src/components/ui/Loader/__tests__/useFrameReveal.test.js
@@ -1,0 +1,64 @@
+import { jest } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react";
+import useFrameReveal from "../useFrameReveal";
+
+/**
+ * 测试目标：验证灰度到黑色的过渡 Hook 能在帧切换时重置并于下一次绘制标记为展示态。
+ * 前置条件：通过伪造的 requestAnimationFrame / cancelAnimationFrame 控制调度。
+ * 步骤：
+ *  1) 渲染 Hook，并记录 requestAnimationFrame 回调；
+ *  2) 触发帧切换，验证状态重置；
+ *  3) 手动执行回调，确认状态恢复为已展示。
+ * 断言：
+ *  - 初始状态为 false；
+ *  - 回调执行后状态切换为 true；
+ *  - 帧切换时会调用 cancelAnimationFrame 清理旧任务。
+ * 边界/异常：
+ *  - 若 requestAnimationFrame 不可用应回退至立即展示，当前未覆盖该分支。
+ */
+describe("useFrameReveal", () => {
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+  const originalCancelAnimationFrame = global.cancelAnimationFrame;
+
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+    global.cancelAnimationFrame = originalCancelAnimationFrame;
+    jest.clearAllMocks();
+  });
+
+  it("GivenFrameToken_WhenAnimationFrameRuns_ThenMarksAsRevealed", () => {
+    let storedCallback;
+    const raf = jest.fn((callback) => {
+      storedCallback = callback;
+      return 7;
+    });
+    const cancel = jest.fn();
+    global.requestAnimationFrame = raf;
+    global.cancelAnimationFrame = cancel;
+
+    const { result, rerender } = renderHook(
+      ({ token }) => useFrameReveal(token),
+      {
+        initialProps: { token: "frame-a" },
+      },
+    );
+
+    expect(result.current).toBe(false);
+    expect(typeof storedCallback).toBe("function");
+
+    act(() => {
+      storedCallback();
+    });
+
+    expect(result.current).toBe(true);
+
+    rerender({ token: "frame-b" });
+
+    expect(result.current).toBe(false);
+    expect(cancel).toHaveBeenCalledWith(7);
+  });
+});

--- a/website/src/components/ui/Loader/useFrameReveal.js
+++ b/website/src/components/ui/Loader/useFrameReveal.js
@@ -1,0 +1,34 @@
+/**
+ * 背景：
+ *  - 等待动画的唯一动态效果是素材由灰转黑，需要与序列帧切换解耦，避免 Loader 组件同时维护帧与过渡状态。
+ * 目的：
+ *  - 提供独立 Hook 负责管理 requestAnimationFrame 生命周期，使 Loader 聚焦于布局与样式。
+ * 关键决策与取舍：
+ *  - 使用 requestAnimationFrame 而非 setTimeout，确保过渡在浏览器绘制时机触发，避免低端设备抖动。
+ * 影响范围：
+ *  - 任何使用该 Hook 的组件需在卸载时自动取消帧任务，防止内存泄漏。
+ * 演进与TODO：
+ *  - TODO：后续可支持自定义缓动或过渡时长，以适配品牌主题切换。
+ */
+import { useEffect, useRef, useState } from "react";
+
+export default function useFrameReveal(frameToken) {
+  const [isRevealed, setIsRevealed] = useState(false);
+  const animationFrameRef = useRef(null);
+
+  useEffect(() => {
+    setIsRevealed(false);
+    animationFrameRef.current = requestAnimationFrame(() => {
+      setIsRevealed(true);
+    });
+
+    return () => {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+    };
+  }, [frameToken]);
+
+  return isRevealed;
+}


### PR DESCRIPTION
## Summary
- center the loader symbol and constrain it to 33% viewport height while simplifying the icon rendering
- introduce a frame reveal hook and extend the waiting cycle hook to self-schedule frame changes instead of relying on CSS animations
- cover the new hooks with focused unit tests to verify scheduler behavior and the gray-to-black transition lifecycle

## Testing
- npm test -- useFrameReveal useWaitingFrameCycle

------
https://chatgpt.com/codex/tasks/task_e_68e2bc8dcf9c8332b48709ae7bdd6aab