### PR TITLE
Fix subscription preferences lint issues

### DIFF
--- a/website/src/pages/preferences/sections/subscriptionBlueprint.js
+++ b/website/src/pages/preferences/sections/subscriptionBlueprint.js
@@ -139,7 +139,7 @@ const formatRenewalDate = (value) => {
         month: "short",
         day: "numeric",
       }).format(value);
-    } catch (error) {
+    } catch {
       return value.toISOString().slice(0, 10);
     }
   }
@@ -186,7 +186,7 @@ const formatRenewalDate = (value) => {
     }).format(safeDate);
     const normalized = normalizeDisplayValue(formatted, normalizedIso);
     return normalized;
-  } catch (error) {
+  } catch {
     return normalizedIso;
   }
 };

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -310,7 +310,7 @@ function usePreferenceSections({ initialSectionId }) {
         safeDispatch({ type: "failure", error });
       }
     },
-    [dispatchPersonalization, fetchProfile, user?.id, user?.token],
+    [dispatchPersonalization, fetchProfile, user?.token],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove unused catch bindings in the subscription blueprint utilities to satisfy eslint
- narrow the personalization request callback dependencies to avoid redundant reruns

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2bf5f3fc8833299b1dd34c819dd91