### PR TITLE
Align search history with corrected terms

### DIFF
--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
@@ -82,6 +82,7 @@ class WordServiceStreamPersistenceTest {
         );
         objectMapper = Jackson2ObjectMapperBuilder.json().build();
         termNormalizer = new SearchContentDictionaryTermNormalizer(new SearchContentManagerImpl());
+        when(searchRecordService.synchronizeRecordTerm(anyLong(), anyLong(), any())).thenReturn(null);
         wordService = new WordService(
             wordSearcher,
             wordRepository,
@@ -256,6 +257,7 @@ class WordServiceStreamPersistenceTest {
             any(Word.class),
             any(DictionaryFlavor.class)
         );
+        verify(searchRecordService).synchronizeRecordTerm(eq(1L), eq(10L), eq("hi"));
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a synchronization hook so saved search records store the LLM-corrected term instead of the raw typo
- call the synchronization logic for both synchronous and streaming dictionary lookups to keep history consistent
- cover the new workflow with unit tests for the service layer and adjust streaming persistence tests to verify the update

## Testing
- mvn spotless:apply
- mvn -Dtest=SearchRecordServiceTest,WordServiceStreamPersistenceTest test

------
https://chatgpt.com/codex/tasks/task_e_68e2beb1ecbc8332ae2f06fa196ec00b