### PR TITLE
fix: eliminate store barrel cycles in web app

### DIFF
--- a/website/src/api/__tests__/words.test.js
+++ b/website/src/api/__tests__/words.test.js
@@ -3,7 +3,8 @@ import { API_PATHS } from "../../config/api.js";
 import { DEFAULT_MODEL } from "../../config/index.js";
 import { WORD_FLAVOR_BILINGUAL } from "@/utils/language.js";
 import { useWordStore } from "@/store/wordStore.js";
-import { useDataGovernanceStore } from "@/store";
+// 直接引用数据治理 store，保持与生产依赖一致并防止 barrel 循环。
+import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
 import { jest } from "@jest/globals";
 
 /**

--- a/website/src/api/words.js
+++ b/website/src/api/words.js
@@ -4,7 +4,8 @@ import { useApi } from "@/hooks/useApi.js";
 import { createCachedFetcher, parseSse } from "@/utils";
 import { WORD_FLAVOR_BILINGUAL } from "@/utils/language.js";
 import { useWordStore } from "@/store/wordStore.js";
-import { useDataGovernanceStore } from "@/store";
+// 直接引用数据治理 store，避免 utils/store 桶状导出间的循环依赖在 SSR 或打包阶段触发。
+import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
 
 export const WORD_CACHE_VERSION = "md1";
 

--- a/website/src/components/Layout/index.jsx
+++ b/website/src/components/Layout/index.jsx
@@ -24,7 +24,8 @@ import {
 import PropTypes from "prop-types";
 import Sidebar from "@/components/Sidebar";
 import ThemeIcon from "@/components/ui/Icon";
-import { useIsMobile } from "@/utils";
+// 直接引用移动端判断 Hook，避免 utils 桶状导出的循环依赖在移动端首屏触发。
+import { useIsMobile } from "@/utils/device.js";
 import styles from "./Layout.module.css";
 
 function Layout({

--- a/website/src/components/Sidebar/hooks/useSidebarNavigation.js
+++ b/website/src/components/Sidebar/hooks/useSidebarNavigation.js
@@ -15,7 +15,8 @@
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLanguage } from "@/context";
-import { useIsMobile } from "@/utils";
+// 避免通过 utils/index 的桶状导出造成 rollup chunk 循环，直接引用具体实现。
+import { useIsMobile } from "@/utils/device.js";
 
 const NAVIGATION_KEYS = {
   DICTIONARY: "dictionary",

--- a/website/src/components/__tests__/Layout.test.jsx
+++ b/website/src/components/__tests__/Layout.test.jsx
@@ -53,7 +53,7 @@ jest.unstable_mockModule("@/components/ui/Icon", () => ({
   default: () => null,
 }));
 
-jest.unstable_mockModule("@/utils", () => ({
+jest.unstable_mockModule("@/utils/device.js", () => ({
   __esModule: true,
   useIsMobile: () => false,
 }));

--- a/website/src/context/AppContext.jsx
+++ b/website/src/context/AppContext.jsx
@@ -1,5 +1,10 @@
 import { createContext, useContext } from "react";
-import { useUserStore, useHistoryStore, useFavoritesStore } from "@/store";
+// 直接依赖具体 Store 模块，避免通过桶状导出引入的循环依赖在构建阶段打散到不同 chunk
+// 导致执行顺序错乱。此举保持上下文与状态容器之间的一对一关系，后续如需扩展可考虑
+// 通过依赖注入集中管理。
+import { useUserStore } from "@/store/userStore.ts";
+import { useHistoryStore } from "@/store/historyStore.ts";
+import { useFavoritesStore } from "@/store/favoritesStore.ts";
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const AppContext = createContext({

--- a/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
@@ -19,7 +19,9 @@ import {
   copyTextToClipboard,
 } from "@/utils";
 import { wordCacheKey } from "@/api/words.js";
-import { useWordStore, useDataGovernanceStore } from "@/store";
+// 直接依赖各 store，避免桶状导出拆分 chunk 时的循环依赖影响首屏渲染。
+import { useWordStore } from "@/store/wordStore.js";
+import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
 import { DEFAULT_MODEL, REPORT_FORM_URL, SUPPORT_EMAIL } from "@/config";
 import { useDictionaryLanguageConfig } from "./useDictionaryLanguageConfig.js";
 import { useDictionaryPopup } from "./useDictionaryPopup.js";

--- a/website/src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx
@@ -125,8 +125,17 @@ useDataGovernanceStore.setState = (updater) => {
 };
 
 jest.unstable_mockModule("@/store", () => ({
-  useWordStore,
+  // 仅暴露 settings store 以匹配 useDictionaryLanguageConfig 的依赖，其他 store 由具体模块 mock。
   useSettingsStore,
+}));
+
+jest.unstable_mockModule("@/store/wordStore.js", () => ({
+  __esModule: true,
+  useWordStore,
+}));
+
+jest.unstable_mockModule("@/store/dataGovernanceStore.ts", () => ({
+  __esModule: true,
   useDataGovernanceStore,
 }));
 

--- a/website/src/hooks/useStreamWord.js
+++ b/website/src/hooks/useStreamWord.js
@@ -6,7 +6,8 @@ import {
 } from "@/utils";
 import { wordCacheKey } from "@/api/words.js";
 import { useWordStore } from "@/store/wordStore.js";
-import { useDataGovernanceStore } from "@/store";
+// 直接引用治理 store，避免桶状导出拆分 chunk 后的执行先后错位。
+import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
 import { DEFAULT_MODEL } from "@/config";
 
 const safeParseJson = (input) => {

--- a/website/src/pages/preferences/sections/DataSection.jsx
+++ b/website/src/pages/preferences/sections/DataSection.jsx
@@ -19,7 +19,10 @@ import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { useLanguage, useUser } from "@/context";
 import LanguageMenu from "@/components/ui/LanguageMenu";
-import { useDataGovernanceStore, useHistoryStore } from "@/store";
+// 避免经由 store/index 桶状导出的路径，确保页面依赖在打包拆分时保持拓扑稳定
+// 并为后续按需加载各 store 留出空间。
+import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
+import { useHistoryStore } from "@/store/historyStore.ts";
 import {
   DATA_RETENTION_POLICIES,
   getRetentionPolicyById,

--- a/website/src/pages/preferences/sections/__tests__/DataSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/DataSection.test.jsx
@@ -3,7 +3,9 @@ import { jest } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { useDataGovernanceStore, useHistoryStore } from "@/store";
+// 测试同样直接引用具体 Store，保证与生产实现一致且规避 barrel 带来的循环依赖。
+import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
+import { useHistoryStore } from "@/store/historyStore.ts";
 
 const translations = {
   settingsDataDescription: "Data stewardship",

--- a/website/src/session/sessionLifecycle.js
+++ b/website/src/session/sessionLifecycle.js
@@ -1,9 +1,8 @@
-import {
-  useFavoritesStore,
-  useHistoryStore,
-  useVoiceStore,
-  useWordStore,
-} from "@/store";
+// 为避免桶状导出导致的循环依赖，在会话生命周期模块中直接依赖各 store。
+import { useFavoritesStore } from "@/store/favoritesStore.ts";
+import { useHistoryStore } from "@/store/historyStore.ts";
+import { useVoiceStore } from "@/store/voiceStore.ts";
+import { useWordStore } from "@/store/wordStore.js";
 
 function clearHistoryState() {
   const historyStore = useHistoryStore.getState();

--- a/website/src/store/__tests__/historyStore.test.js
+++ b/website/src/store/__tests__/historyStore.test.js
@@ -1,7 +1,10 @@
 import { jest } from "@jest/globals";
 import { act } from "@testing-library/react";
 import api from "@/api/index.js";
-import { useHistoryStore, useWordStore, useDataGovernanceStore } from "@/store";
+// 直接引用具体 store 以规避 barrel 引入的循环依赖并保持测试与生产实现等价。
+import { useHistoryStore } from "@/store/historyStore.ts";
+import { useWordStore } from "@/store/wordStore.js";
+import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
 import { WORD_FLAVOR_BILINGUAL } from "@/utils/language.js";
 
 const mockWordStore = useWordStore;


### PR DESCRIPTION
## Summary
- replace barrel-based imports of Zustand stores and device hooks with direct module references to break circular chunk dependencies
- refresh context, API, and feature modules plus their unit tests to document the rationale and reflect the new import graph
- ensure layout and sidebar components consume the dedicated mobile detector without going through the utils index barrel

## Testing
- npm run test -- --runTestsByPath src/store/__tests__/historyStore.test.js src/pages/preferences/sections/__tests__/DataSection.test.jsx src/components/__tests__/Layout.test.jsx src/hooks/__tests__/useStreamWord.test.js src/api/__tests__/words.test.js src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3c3618180833297bd382386ed8ae2