### PR TITLE
feat: add fading cycle to loader asset

### DIFF
--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -1,10 +1,10 @@
 /**
  * 背景：
- *  - Loader 视觉升级为呼吸式淡入淡出，需让灰底与黑色覆盖在透明度层面往复切换。
+ *  - Loader 动画从“双层遮罩”升级为“整幅素材淡入淡出”，强调完整素材的呼吸节奏。
  * 目的：
- *  - 通过 CSS 模块配置透明度动画，保持尺寸 token 与动画节奏可配置，确保与策略层解耦。
+ *  - 通过 CSS 模块统一管理透明度过渡与尺寸 token，使 Hook 输出布尔态即可驱动渐隐渐显。
  * 关键决策与取舍：
- *  - 使用 opacity + transition，而非额外 keyframes，以便随 Hook 切换布尔态即可驱动动画；
+ *  - 继续使用 opacity + transition，避免引入额外 keyframes，保持渲染栈纯粹；
  *  - 所有时长仍交由 CSS 变量控制，方便主题或无障碍场景动态调整。
  */
 .loader {
@@ -39,31 +39,19 @@
   inline-size: 100%;
   block-size: 100%;
   overflow: hidden;
-}
-
-.frame-base,
-.frame-overlay {
-  inline-size: 100%;
-  block-size: 100%;
-  display: block;
-  object-fit: contain;
-}
-
-.frame-base {
-  filter: grayscale(1) brightness(1.2);
-}
-
-.frame-overlay {
-  position: absolute;
-  inset: 0;
-  filter: none;
-  pointer-events: none;
   opacity: 0;
   transition: opacity var(--waiting-fade-duration, 750ms) ease-in-out;
 }
 
-.frame-overlay-visible {
+.frame-visible {
   opacity: 1;
+}
+
+.frame-asset {
+  inline-size: 100%;
+  block-size: 100%;
+  display: block;
+  object-fit: contain;
 }
 
 .label {

--- a/website/src/components/ui/Loader/__tests__/frameVisibilityClassName.test.js
+++ b/website/src/components/ui/Loader/__tests__/frameVisibilityClassName.test.js
@@ -1,0 +1,33 @@
+import frameVisibilityClassName from "../frameVisibilityClassName";
+
+/**
+ * 测试目标：验证透明度类名组合函数能在不同可见态下输出预期字符串。
+ * 前置条件：输入的基础类名为 "frame"，可见态类名为 "frame-visible"。
+ * 步骤：
+ *  1) 调用函数并传入 isRevealed=false；
+ *  2) 再次调用函数并传入 isRevealed=true；
+ *  3) 传入空的可见态类名验证降级行为；
+ * 断言：
+ *  - 初始态仅返回基础类名；
+ *  - 可见态返回基础类 + 可见态类；
+ *  - 可见态类名缺失时仅返回基础类名。
+ * 边界/异常：
+ *  - 未覆盖多状态串联，后续如引入更多层级需在此补测。
+ */
+describe("frameVisibilityClassName", () => {
+  it("GivenBooleanFlag_WhenFalse_ThenReturnBaseClass", () => {
+    expect(frameVisibilityClassName("frame", "frame-visible", false)).toBe(
+      "frame",
+    );
+  });
+
+  it("GivenBooleanFlag_WhenTrue_ThenAppendVisibleClass", () => {
+    expect(frameVisibilityClassName("frame", "frame-visible", true)).toBe(
+      "frame frame-visible",
+    );
+  });
+
+  it("GivenMissingVisibleClass_WhenToggle_ThenReturnBaseOnly", () => {
+    expect(frameVisibilityClassName("frame", "", true)).toBe("frame");
+  });
+});

--- a/website/src/components/ui/Loader/frameVisibilityClassName.js
+++ b/website/src/components/ui/Loader/frameVisibilityClassName.js
@@ -1,0 +1,23 @@
+/**
+ * 背景：
+ *  - Loader 动画需根据 Hook 输出的布尔态切换透明度类名，直接在组件中拼接字符串可读性差且难于测试。
+ * 目的：
+ *  - 提供纯函数封装类名组合逻辑，便于复用与单元测试，同时与样式模块保持松耦合。
+ * 关键决策与取舍：
+ *  - 函数接受基础类名与可见态类名作为参数，确保未来若有更多状态（例如半透明）时可扩展；
+ *  - 默认返回基础类名，只有在显式要求展示时才追加可见态类，保持输出稳定。
+ * 影响范围：
+ *  - Loader 组件调用该函数组合类名；其他需要类似“可见/隐藏”拼接的组件亦可复用。
+ * 演进与TODO：
+ *  - TODO：若后续引入 `prefers-reduced-motion` 特性开关，可在此函数加入根据配置切换的额外类名。
+ */
+export default function frameVisibilityClassName(
+  baseClassName,
+  visibleClassName,
+  isRevealed,
+) {
+  if (!visibleClassName) {
+    return baseClassName;
+  }
+  return isRevealed ? `${baseClassName} ${visibleClassName}` : baseClassName;
+}


### PR DESCRIPTION
## Summary
- render the loader asset with a single layer that fades in and out based on the reveal hook
- extract a reusable frame visibility class helper and cover it with focused unit tests

## Testing
- npm test -- frameVisibilityClassName

------
https://chatgpt.com/codex/tasks/task_e_68e3d74576d083328d4535409bbd3078