### PR TITLE
Refine username action layout

### DIFF
--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -31,6 +31,7 @@ jest.unstable_mockModule("@/api/profiles.js", () => ({
 }));
 
 let usePreferenceSections;
+let ACCOUNT_USERNAME_FIELD_TYPE;
 let translations;
 let fetchProfileMock;
 let saveProfileMock;
@@ -39,6 +40,9 @@ let consoleErrorStub;
 beforeAll(async () => {
   ({ default: usePreferenceSections } = await import(
     "../usePreferenceSections.js"
+  ));
+  ({ ACCOUNT_USERNAME_FIELD_TYPE } = await import(
+    "../sections/AccountSection.jsx"
   ));
 });
 
@@ -325,9 +329,14 @@ test(
       "function",
     );
     expect(accountSection.componentProps.identity.isUploading).toBe(false);
+    expect(accountSection.componentProps.fields[0].type).toBe(
+      ACCOUNT_USERNAME_FIELD_TYPE,
+    );
     expect(
-      typeof accountSection.componentProps.fields[0].renderValue,
-    ).toBe("function");
+      accountSection.componentProps.fields[0].usernameEditorProps,
+    ).toMatchObject({
+      username: "amy",
+    });
     expect(accountSection.componentProps.bindings.title).toBe(
       translations.settingsAccountBindingTitle,
     );

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -11,7 +11,6 @@
  *  - TODO: 当新增分区或引入懒加载时，可在此处扩展蓝图数组或接入数据缓存策略。
  */
 import {
-  createElement,
   useCallback,
   useEffect,
   useMemo,
@@ -20,7 +19,9 @@ import {
   useState,
 } from "react";
 import { useLanguage, useUser } from "@/context";
-import AccountSection from "./sections/AccountSection.jsx";
+import AccountSection, {
+  ACCOUNT_USERNAME_FIELD_TYPE,
+} from "./sections/AccountSection.jsx";
 import DataSection from "./sections/DataSection.jsx";
 import GeneralSection from "./sections/GeneralSection.jsx";
 import KeyboardSection from "./sections/KeyboardSection.jsx";
@@ -28,7 +29,6 @@ import ResponseStyleSection from "./sections/ResponseStyleSection.jsx";
 import SubscriptionSection from "./sections/SubscriptionSection.jsx";
 import { buildSubscriptionSectionProps } from "./sections/subscriptionBlueprint.js";
 import useAvatarEditorWorkflow from "@/hooks/useAvatarEditorWorkflow.js";
-import UsernameEditor from "@/components/Profile/UsernameEditor/index.jsx";
 import { useUsersApi } from "@/api/users.js";
 import { useProfilesApi } from "@/api/profiles.js";
 import {
@@ -663,15 +663,14 @@ function usePreferenceSections({ initialSectionId }) {
         id: "username",
         label: t.settingsAccountUsername ?? "Username",
         value: usernameValue,
-        // 采用 createElement 保持 hook 文件不引入 JSX 语法，避免额外编译配置并便于在 Node 测试环境中复用。
-        renderValue: () =>
-          createElement(UsernameEditor, {
-            username: sanitizedUsername,
-            emptyDisplayValue: fallbackValue,
-            t: usernameEditorTranslations,
-            onSubmit: handleUsernameSubmit,
-            onFailure: handleUsernameFailure,
-          }),
+        type: ACCOUNT_USERNAME_FIELD_TYPE,
+        usernameEditorProps: {
+          username: sanitizedUsername,
+          emptyDisplayValue: fallbackValue,
+          t: usernameEditorTranslations,
+          onSubmit: handleUsernameSubmit,
+          onFailure: handleUsernameFailure,
+        },
       },
       {
         id: "email",


### PR DESCRIPTION
## Summary
- expose an external action slot for the username editor so the account section can drive the button from the dedicated action column
- specialize the account section to render username rows via a custom renderer while keeping existing field rendering unchanged
- update the preference hook and associated unit tests to exercise the new split layout

## Testing
- npm test -- --runTestsByPath src/components/Profile/__tests__/UsernameEditor.test.jsx
- npm test -- --runTestsByPath src/pages/preferences/sections/__tests__/AccountSection.test.jsx
- npm test -- --runTestsByPath src/pages/preferences/__tests__/usePreferenceSections.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e3d7a8eb1c83329b577a548ca71aa1