### PR TITLE
Refine account section column proportions

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -1030,9 +1030,9 @@
    * 让动作按钮能与数值列拉开距离并自然贴齐右缘，
    * 也为后续响应式/密集布局提供统一调整入口。
    */
-  --preferences-detail-label-column: minmax(140px, 0.28fr);
+  --preferences-detail-label-column: minmax(120px, max-content);
   --preferences-detail-value-column: minmax(0, 1fr);
-  --preferences-detail-action-column: minmax(0, 0.3fr);
+  --preferences-detail-action-column: max-content;
 }
 
 .detail-row {
@@ -1159,6 +1159,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  justify-self: center;
+  inline-size: 100%;
   overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
## Summary
- tighten the account detail grid label/action column sizing so value fields gain breathing room without overlapping action buttons
- ensure the identity avatar cell stretches and centers the picture across the account section for consistent alignment

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e3e2e3c3748332b3e7d8d0e11e6479