### PR TITLE
Adapt streaming chat formatting for word spacing

### DIFF
--- a/website/src/features/chat/__tests__/assistantMessageFormatter.test.js
+++ b/website/src/features/chat/__tests__/assistantMessageFormatter.test.js
@@ -24,6 +24,42 @@ test("passthrough formatting for generic chat text", () => {
 });
 
 /**
+ * 测试目标：验证分词级流式输出会在缺少前导空格时自动补齐。
+ * 前置条件：连续两次 append 的输入分别为 "Quick" 与 "Brown"，第二段不含空格。
+ * 步骤：
+ *  1) 调用 append("Quick")；
+ *  2) 调用 append("Brown")；
+ * 断言：
+ *  - 第二次 append 返回值包含单个空格分隔两个单词；
+ * 边界/异常：
+ *  - 保证英文单词不会粘连，兼容词粒度分片。
+ */
+test("inserts spacing for word-level streaming chunks", () => {
+  const formatter = createAssistantMessageFormatter();
+  formatter.append("Quick");
+  const second = formatter.append("Brown");
+  expect(second).toBe("Quick Brown");
+});
+
+/**
+ * 测试目标：验证回车符分片会被规范化为换行符后继续格式化。
+ * 前置条件：第二个 append 输入为 "\r"，第三个 append 输入为 "Line"。
+ * 步骤：
+ *  1) 依次调用 append("Alpha"), append("\r"), append("Line");
+ * 断言：
+ *  - 最终返回值为 "Alpha\nLine"；
+ * 边界/异常：
+ *  - 覆盖 Windows 回车分片，防止出现残余回车字符。
+ */
+test("normalizes carriage return segments during streaming", () => {
+  const formatter = createAssistantMessageFormatter();
+  formatter.append("Alpha");
+  formatter.append("\r");
+  const result = formatter.append("Line");
+  expect(result).toBe("Alpha\nLine");
+});
+
+/**
  * 测试目标：确认检测到抖宝词典信号后会回溯格式化已有文本。
  * 前置条件：默认策略集合，输入包含 Example/UsageInsight 等特征字段。
  * 步骤：

--- a/website/src/features/chat/createAssistantMessageFormatter.js
+++ b/website/src/features/chat/createAssistantMessageFormatter.js
@@ -12,7 +12,7 @@
  * 演进与TODO：
  *  - 后续可引入配置驱动策略选择或接入 A/B 开关，支持灰度验证不同格式化方案。
  */
-import { polishDictionaryMarkdown } from "@/utils";
+import { createStreamingTextBuffer, polishDictionaryMarkdown } from "@/utils";
 
 const FALLBACK_STRATEGY = {
   matches() {
@@ -57,7 +57,7 @@ function createDoubaoDictionaryStrategy() {
  */
 export function createAssistantMessageFormatter({ strategies } = {}) {
   const availableStrategies = strategies ?? [createDoubaoDictionaryStrategy(), FALLBACK_STRATEGY];
-  let buffer = "";
+  const streamBuffer = createStreamingTextBuffer();
 
   function applyStrategies(text) {
     for (const strategy of availableStrategies) {
@@ -74,13 +74,11 @@ export function createAssistantMessageFormatter({ strategies } = {}) {
 
   return {
     append(chunk) {
-      if (chunk) {
-        buffer += chunk;
-      }
-      return applyStrategies(buffer);
+      const aggregated = streamBuffer.append(chunk);
+      return applyStrategies(aggregated);
     },
     reset() {
-      buffer = "";
+      streamBuffer.reset();
     },
   };
 }

--- a/website/src/utils/__tests__/streamingTextBuffer.test.js
+++ b/website/src/utils/__tests__/streamingTextBuffer.test.js
@@ -1,0 +1,75 @@
+import { createStreamingTextBuffer } from "../streamingTextBuffer.js";
+
+/**
+ * 测试目标：验证英文单词分片之间会自动补充空格。
+ * 前置条件：首个分片与第二个分片均为英文单词且缺少前导空格。
+ * 步骤：
+ *  1) 调用 append 追加 "Hello"；
+ *  2) 再追加 "World"；
+ * 断言：
+ *  - 聚合结果等于 "Hello World"；
+ * 边界/异常：
+ *  - 覆盖无空格单词场景，确保默认策略生效。
+ */
+test("inserts space between english word chunks", () => {
+  const buffer = createStreamingTextBuffer();
+  buffer.append("Hello");
+  const result = buffer.append("World");
+  expect(result).toBe("Hello World");
+});
+
+/**
+ * 测试目标：验证回车符会被统一转换为换行符。
+ * 前置条件：第二个分片包含 "\r\n"；
+ * 步骤：
+ *  1) 追加 "Line"；
+ *  2) 追加 "\r\n"；
+ *  3) 追加 "Next"；
+ * 断言：
+ *  - 聚合结果为 "Line\nNext"；
+ * 边界/异常：
+ *  - 覆盖 Windows 风格换行符，防止渲染异常。
+ */
+test("normalizes carriage returns into line feeds", () => {
+  const buffer = createStreamingTextBuffer();
+  buffer.append("Line");
+  buffer.append("\r\n");
+  const result = buffer.append("Next");
+  expect(result).toBe("Line\nNext");
+});
+
+/**
+ * 测试目标：验证中文字符不会被误插入空格。
+ * 前置条件：连续追加两个中文字符串且均无前导空格；
+ * 步骤：
+ *  1) 追加 "你好"；
+ *  2) 追加 "世界"；
+ * 断言：
+ *  - 聚合结果为 "你好世界"；
+ * 边界/异常：
+ *  - 避免对 CJK 场景添加多余空格。
+ */
+test("keeps cjk characters adjacent", () => {
+  const buffer = createStreamingTextBuffer();
+  buffer.append("你好");
+  const result = buffer.append("世界");
+  expect(result).toBe("你好世界");
+});
+
+/**
+ * 测试目标：验证在标点符号后缺少空格时也会插入空格。
+ * 前置条件：第一个分片以逗号结尾且第二个分片为英文单词；
+ * 步骤：
+ *  1) 追加 "Hi,"；
+ *  2) 追加 "there"；
+ * 断言：
+ *  - 聚合结果为 "Hi, there"；
+ * 边界/异常：
+ *  - 避免标点后紧贴单词的显示问题。
+ */
+test("inserts spacing after punctuation when needed", () => {
+  const buffer = createStreamingTextBuffer();
+  buffer.append("Hi,");
+  const result = buffer.append("there");
+  expect(result).toBe("Hi, there");
+});

--- a/website/src/utils/index.js
+++ b/website/src/utils/index.js
@@ -33,5 +33,6 @@ export {
   extractMarkdownPreview,
   polishDictionaryMarkdown,
 } from "./markdown.js";
+export { createStreamingTextBuffer } from "./streamingTextBuffer.js";
 export { resolveShareTarget, attemptShareLink } from "./share.js";
 export { copyTextToClipboard } from "./clipboard.js";

--- a/website/src/utils/streamingTextBuffer.js
+++ b/website/src/utils/streamingTextBuffer.js
@@ -1,0 +1,124 @@
+/**
+ * 背景：
+ *  - Doubao 等流式模型在增量输出时按“词”粒度拆片，默认不携带空格与回车信号，导致前端渲染阶段出现单词粘连。
+ * 目的：
+ *  - 采用“适配器模式”为流式片段提供统一的空白符补齐策略，屏蔽上层对分词格式的差异感知。
+ * 关键决策与取舍：
+ *  - 通过状态化缓冲区记录历史尾字符，仅在确认为独立英文词或需要标点后空格时插入空格，避免误伤中文等无需空格的场景；
+ *  - 对回车符统一归一化为换行符，同时支持扩展自定义换行标记，兼顾不同上游协议。
+ * 影响范围：
+ *  - 被 ChatView 等流式渲染调用后，能够保障英文内容在流式过程中保持可读性；
+ *  - 新增空白符逻辑仅作用于展示层，不影响底层 JSON 累积或缓存命中。
+ * 演进与TODO：
+ *  - 如后续需要识别更细粒度的语种，可在 `isWordLikeChar` 中扩展脚本判定；
+ *  - 支持配置化的标点空格策略，兼容不同语系的排版规范。
+ */
+const DEFAULT_NEWLINE_TOKENS = new Set();
+
+const WORD_LIKE_CHAR = /[A-Za-z\d]/;
+const HAN_SCRIPT = /\p{Script=Han}/u;
+const TRAILING_SPACE_PUNCTUATION = /[,:;!?]/;
+const WHITESPACE_RE = /\s/u;
+
+function normalizeNewlines(text, newlineTokens) {
+  let result = text.replace(/\r\n?|\u2028|\u2029/g, "\n");
+  if (newlineTokens.size === 0) {
+    return result;
+  }
+  for (const token of newlineTokens) {
+    if (!token) continue;
+    result = result.split(token).join("\n");
+  }
+  return result;
+}
+
+function getLastVisibleChar(text) {
+  for (let index = text.length - 1; index >= 0; index -= 1) {
+    const char = text[index];
+    if (!WHITESPACE_RE.test(char)) {
+      return char;
+    }
+  }
+  return "";
+}
+
+function getFirstVisibleChar(text) {
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (!WHITESPACE_RE.test(char)) {
+      return char;
+    }
+  }
+  return "";
+}
+
+function isWordLikeChar(char) {
+  if (!char) return false;
+  if (HAN_SCRIPT.test(char)) {
+    return false;
+  }
+  return WORD_LIKE_CHAR.test(char);
+}
+
+function shouldInsertSpace(previousTail, addition) {
+  if (!addition) {
+    return false;
+  }
+  if (addition[0] === "\n" || addition.startsWith(" ")) {
+    return false;
+  }
+  if (previousTail.endsWith("\n")) {
+    return false;
+  }
+  const last = getLastVisibleChar(previousTail);
+  if (!last) {
+    return false;
+  }
+  const next = getFirstVisibleChar(addition);
+  if (!next) {
+    return false;
+  }
+  if (isWordLikeChar(last) && isWordLikeChar(next)) {
+    return true;
+  }
+  if (TRAILING_SPACE_PUNCTUATION.test(last) && isWordLikeChar(next)) {
+    return true;
+  }
+  return false;
+}
+
+export function createStreamingTextBuffer(options = {}) {
+  const newlineTokens = new Set(options.newlineTokens || DEFAULT_NEWLINE_TOKENS);
+  let buffer = "";
+
+  return {
+    append(chunk) {
+      if (chunk == null) {
+        return buffer;
+      }
+      const normalized = normalizeNewlines(String(chunk), newlineTokens);
+      if (!normalized) {
+        return buffer;
+      }
+      const addition = shouldInsertSpace(buffer, normalized)
+        ? ` ${normalized}`
+        : normalized;
+      buffer += addition;
+      return buffer;
+    },
+    reset() {
+      buffer = "";
+    },
+    value() {
+      return buffer;
+    },
+  };
+}
+
+export const __internal__testables = {
+  normalizeNewlines,
+  shouldInsertSpace,
+  getLastVisibleChar,
+  getFirstVisibleChar,
+  isWordLikeChar,
+};


### PR DESCRIPTION
## Summary
- add a streaming text buffer adapter that normalizes carriage returns and injects safe word spacing for live output
- wire the adapter into the assistant message formatter and cover new spacing behaviours with focused unit tests

## Testing
- npm test -- streamingTextBuffer
- npm test -- assistantMessageFormatter

------
https://chatgpt.com/codex/tasks/task_e_68e3f7d063d08332a5912bf3b8237fb7