### PR TITLE
Fix streaming markdown spacing after periods

### DIFF
--- a/website/src/utils/__tests__/streamingTextBuffer.test.js
+++ b/website/src/utils/__tests__/streamingTextBuffer.test.js
@@ -73,3 +73,21 @@ test("inserts spacing after punctuation when needed", () => {
   const result = buffer.append("there");
   expect(result).toBe("Hi, there");
 });
+
+/**
+ * 测试目标：验证句号结尾的分片在下一个英文单词到来时同样会补空格。
+ * 前置条件：首个分片以句号收尾，第二个分片以英文单词开头且缺少前导空格。
+ * 步骤：
+ *  1) 追加 "Done."；
+ *  2) 追加 "Next"；
+ * 断言：
+ *  - 聚合结果为 "Done. Next"，若失败说明句号未被识别为需要补空格的标点。
+ * 边界/异常：
+ *  - 覆盖英语释义常见的句号断句场景，防止词典动态渲染出现单词粘连。
+ */
+test("inserts spacing after periods between english sentences", () => {
+  const buffer = createStreamingTextBuffer();
+  buffer.append("Done.");
+  const result = buffer.append("Next");
+  expect(result).toBe("Done. Next");
+});

--- a/website/src/utils/streamingTextBuffer.js
+++ b/website/src/utils/streamingTextBuffer.js
@@ -17,7 +17,9 @@ const DEFAULT_NEWLINE_TOKENS = new Set();
 
 const WORD_LIKE_CHAR = /[A-Za-z\d]/;
 const HAN_SCRIPT = /\p{Script=Han}/u;
-const TRAILING_SPACE_PUNCTUATION = /[,:;!?]/;
+// 说明：追加句号以覆盖「英文释义以句号结束后紧跟新句」的流式场景，
+//       避免 Doubao 词典输出在 `.` 与下一个单词之间缺失空格。
+const TRAILING_SPACE_PUNCTUATION = /[.,:;!?]/;
 const WHITESPACE_RE = /\s/u;
 
 function normalizeNewlines(text, newlineTokens) {


### PR DESCRIPTION
## Summary
- ensure the streaming text buffer treats periods as trailing punctuation so streamed english sentences keep their spacing
- add a regression test that covers period-separated markdown chunks

## Testing
- npm test -- streamingTextBuffer.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3fcf4b26c833289d90b3429121c5a