### PR TITLE
Refine report issue modal layout and metadata

### DIFF
--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -233,6 +233,8 @@ export default function DictionaryExperience() {
         term={reportDialog.term}
         language={reportDialog.language}
         flavor={reportDialog.flavor}
+        sourceLanguage={reportDialog.sourceLanguage}
+        targetLanguage={reportDialog.targetLanguage}
         category={reportDialog.category}
         categories={reportDialog.categories ?? []}
         description={reportDialog.description}

--- a/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
@@ -1,13 +1,23 @@
+
+.plain-surface {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
 .summary {
-  display: grid;
-  gap: clamp(var(--space-3), 3vw, var(--space-4));
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) clamp(var(--space-4), 6vw, var(--space-6));
   margin: 0;
   padding: 0;
 }
 
 .summary-item {
-  display: grid;
-  gap: var(--space-1);
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  white-space: nowrap;
 }
 
 .summary-label {
@@ -15,7 +25,11 @@
   font-size: var(--text-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--preferences-panel-muted, var(--color-text)) 78%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--preferences-panel-muted, var(--color-text)) 72%,
+    transparent
+  );
 }
 
 .summary-value {
@@ -40,27 +54,30 @@
   color: var(--preferences-panel-text, var(--color-text));
 }
 
-.field-hint {
-  font-size: var(--text-xs);
-  color: color-mix(in srgb, var(--preferences-panel-muted, var(--color-text)) 72%, transparent);
-}
-
 .segment-group {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: var(--space-2);
-  padding: clamp(6px, 2vw, 10px);
-  border-radius: var(--radius-xl);
-  background: color-mix(in srgb, var(--preferences-panel-surface, var(--app-bg)) 88%, transparent);
+  gap: var(--space-1);
+  padding: clamp(var(--space-1), 1.8vw, var(--space-2));
+  border-radius: var(--radius-xxl);
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, var(--app-bg)) 84%,
+    transparent
+  );
 }
 
 .segment {
-  min-width: 120px;
-  padding: 10px 18px;
+  min-width: 112px;
+  padding: 0.65rem 1.2rem;
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: calc(var(--radius-xl) - var(--space-1));
   background: transparent;
-  color: color-mix(in srgb, var(--preferences-panel-muted, currentColor) 88%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--preferences-panel-muted, currentColor) 82%,
+    transparent
+  );
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   letter-spacing: 0.02em;
@@ -68,13 +85,13 @@
   transition:
     background 160ms ease,
     color 160ms ease,
-    transform 160ms ease;
+    box-shadow 160ms ease;
 }
 
 .segment:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px
-    color-mix(in srgb, var(--preferences-panel-ring, var(--highlight-color)) 45%, transparent);
+    color-mix(in srgb, var(--preferences-panel-ring, var(--highlight-color)) 38%, transparent);
 }
 
 .segment:disabled {
@@ -83,13 +100,14 @@
 }
 
 .segment:hover:not(:disabled) {
-  transform: translateY(-1px);
+  color: var(--preferences-panel-text, var(--color-text));
 }
 
 .segment-active {
-  background: color-mix(in srgb, var(--preferences-panel-surface, var(--app-bg)) 96%, transparent);
+  background: var(--preferences-panel-surface, var(--app-bg));
   color: var(--preferences-panel-text, var(--color-text));
-  transform: translateY(-1px);
+  box-shadow: 0 18px 42px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
 }
 
 .textarea {

--- a/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
@@ -181,6 +181,8 @@ export function useDictionaryExperience() {
       term: context.term ?? "",
       language: context.language ?? null,
       flavor: context.flavor ?? null,
+      sourceLanguage: context.sourceLanguage ?? null,
+      targetLanguage: context.targetLanguage ?? null,
       sourceUrl: context.sourceUrl ?? "",
       category: reportDialogState.form.category,
       description: reportDialogState.form.description,
@@ -682,6 +684,8 @@ export function useDictionaryExperience() {
       term: activeTerm,
       language: contextLanguage,
       flavor: contextFlavor,
+      sourceLanguage: dictionarySourceLanguage,
+      targetLanguage: dictionaryTargetLanguage,
       sourceUrl,
     });
   }, [


### PR DESCRIPTION
## Summary
- update the report issue modal to use an inline summary row, remove redundant descriptions, and restyle the issue type segmented control
- surface dictionary source/target languages so the modal shows an explicit language pair instead of a generic bilingual label
- clear the form container background to match the settings UI treatment

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e40342fd0883329eb44a91f03f1d6e