### PR TITLE
Refine report issue modal layout

### DIFF
--- a/website/src/features/dictionary-experience/components/ReportIssueModal.jsx
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.jsx
@@ -50,10 +50,7 @@ function ReportIssueModal({
         type="button"
         role="radio"
         aria-checked={active}
-        className={[
-          styles.segment,
-          active ? styles["segment-active"] : "",
-        ]
+        className={[styles.segment, active ? styles["segment-active"] : ""]
           .filter(Boolean)
           .join(" ")}
         onClick={() => onCategoryChange(option.value)}
@@ -168,12 +165,22 @@ function ReportIssueModal({
         onSubmit={handleSubmit}
         title={t.reportTitle ?? "Report an issue"}
         actions={
-          <div className={styles["action-row"]}>
-            {error ? (
-              <p className={styles.error} role="alert">
-                {t.reportErrorMessage ?? error}
-              </p>
-            ) : null}
+          <div className={styles["action-bar"]}>
+            {/*
+             * 通过占满 actions 区域来与 SettingsSurface 保持左右对齐的栅格节奏，
+             * 既方便在左侧展示错误消息，也能在右侧维持操作按钮的视觉稳定。
+             */}
+            <div
+              className={styles["action-status"]}
+              aria-live="assertive"
+              aria-atomic="true"
+            >
+              {error ? (
+                <p className={styles.error} role="alert">
+                  {t.reportErrorMessage ?? error}
+                </p>
+              ) : null}
+            </div>
             <div className={styles["action-buttons"]}>
               <button
                 type="button"

--- a/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
@@ -6,37 +6,47 @@
 }
 
 .summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2) clamp(var(--space-4), 6vw, var(--space-6));
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: clamp(var(--space-3), 3vw, var(--space-5));
   margin: 0;
-  padding: 0;
+  padding: clamp(var(--space-3), 3vw, var(--space-4));
+  border-radius: var(--radius-xl);
+  border: 1px solid
+    color-mix(in srgb, var(--preferences-panel-border, var(--border-color)) 55%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, var(--app-bg)) 92%,
+    transparent
+  );
 }
 
 .summary-item {
-  display: inline-flex;
-  align-items: baseline;
-  gap: var(--space-2);
-  white-space: nowrap;
+  display: grid;
+  gap: var(--space-1);
+  align-content: start;
+  min-width: 0;
 }
 
 .summary-label {
   margin: 0;
   font-size: var(--text-xs);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: color-mix(
     in srgb,
-    var(--preferences-panel-muted, var(--color-text)) 72%,
+    var(--preferences-panel-muted, var(--color-text)) 76%,
     transparent
   );
 }
 
 .summary-value {
   margin: 0;
-  font-size: clamp(var(--text-base), 2vw, var(--text-lg));
+  font-size: clamp(var(--text-lg), 2.4vw, var(--text-xl));
   font-weight: var(--font-semibold);
+  line-height: 1.5;
   color: var(--preferences-panel-text, var(--color-text));
+  overflow-wrap: anywhere;
 }
 
 .fieldset {
@@ -44,48 +54,56 @@
   padding: 0;
   border: none;
   display: grid;
-  gap: clamp(var(--space-2), 2vw, var(--space-3));
+  gap: clamp(var(--space-3), 3vw, var(--space-4));
 }
 
 .legend {
   margin: 0;
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: var(--preferences-panel-text, var(--color-text));
 }
 
 .segment-group {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: var(--space-1);
-  padding: clamp(var(--space-1), 1.8vw, var(--space-2));
+  gap: var(--space-2);
+  padding: clamp(var(--space-2), 2vw, var(--space-3));
   border-radius: var(--radius-xxl);
+  border: 1px solid
+    color-mix(in srgb, var(--preferences-panel-border, var(--border-color)) 48%, transparent);
   background: color-mix(
     in srgb,
-    var(--preferences-panel-surface, var(--app-bg)) 84%,
+    var(--preferences-panel-surface, var(--app-bg)) 88%,
     transparent
   );
 }
 
 .segment {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-width: 112px;
-  padding: 0.65rem 1.2rem;
+  padding: 0.75rem 1.4rem;
   border: none;
   border-radius: calc(var(--radius-xl) - var(--space-1));
   background: transparent;
   color: color-mix(
     in srgb,
-    var(--preferences-panel-muted, currentColor) 82%,
+    var(--preferences-panel-muted, currentColor) 78%,
     transparent
   );
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   cursor: pointer;
   transition:
     background 160ms ease,
     color 160ms ease,
-    box-shadow 160ms ease;
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .segment:focus-visible {
@@ -101,6 +119,7 @@
 
 .segment:hover:not(:disabled) {
   color: var(--preferences-panel-text, var(--color-text));
+  transform: translateY(-1px);
 }
 
 .segment-active {
@@ -108,19 +127,20 @@
   color: var(--preferences-panel-text, var(--color-text));
   box-shadow: 0 18px 42px
     color-mix(in srgb, var(--shadow-color) 22%, transparent);
+  transform: translateY(-1px);
 }
 
 .textarea {
   width: 100%;
   min-height: 140px;
-  padding: clamp(var(--space-2), 2vw, var(--space-3));
+  padding: clamp(var(--space-3), 3vw, var(--space-4));
   border-radius: var(--radius-xl);
   border: 1px solid
     color-mix(in srgb, var(--preferences-panel-ring, var(--border-color)) 55%, transparent);
   background: color-mix(in srgb, var(--preferences-panel-surface, var(--app-bg)) 94%, transparent);
   color: var(--preferences-panel-text, var(--color-text));
   font-size: var(--text-sm);
-  line-height: 1.6;
+  line-height: 1.7;
   resize: vertical;
 }
 
@@ -131,11 +151,16 @@
     color-mix(in srgb, var(--preferences-panel-ring, var(--highlight-color)) 35%, transparent);
 }
 
-.action-row {
+.action-bar {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
+  align-items: center;
+  gap: clamp(var(--space-3), 3vw, var(--space-4));
   width: 100%;
+}
+
+.action-status {
+  flex: 1;
+  min-height: 1.5rem;
 }
 
 .error {
@@ -145,7 +170,7 @@
 }
 
 .action-buttons {
-  display: flex;
+  display: inline-flex;
   gap: var(--space-3);
   justify-content: flex-end;
 }
@@ -207,8 +232,22 @@
 }
 
 @media (width <= 599px) {
+  .summary {
+    grid-template-columns: 1fr;
+    padding: clamp(var(--space-3), 4vw, var(--space-4));
+  }
+
   .segment {
     min-width: 100%;
+  }
+
+  .action-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .action-status {
+    min-height: auto;
   }
 
   .action-buttons {


### PR DESCRIPTION
## Summary
- restructure the report issue modal footer to mirror SettingsSurface alignment and keep errors visible beside the action buttons
- refresh the summary, segmented control, and textarea styling to match the system spacing and typography tokens

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e40bf085b883329152ac40f794799e