### PR TITLE
Remove response style description from preferences

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -52,8 +52,6 @@ export default {
     "Add a few notes about yourself to tailor every response.",
   settingsPersonalizationLoadError:
     "We couldn't load your personalization details. Please try again shortly.",
-  settingsResponseStyleDescription:
-    "Choose the tone for explanations and share the context behind it.",
   settingsResponseStyleError:
     "We couldn't save your response style. Please try again in a moment.",
   settingsResponseStyleSaved: "Saved",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -46,7 +46,6 @@ export default {
   loading: "加载中...",
   settingsPersonalizationEmpty: "完善画像信息以便回答更贴近你。",
   settingsPersonalizationLoadError: "个性化详情暂时无法加载，请稍后再试。",
-  settingsResponseStyleDescription: "选择释义的语气，并补充你的背景信息。",
   settingsResponseStyleError: "响应风格配置暂时无法保存，请稍后重试。",
   settingsResponseStyleSaved: "已保存",
   responseStyleSelectLabel: "响应风格",

--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -77,7 +77,6 @@ const createTranslations = (overrides = {}) => ({
   loading: "Loading...",
   settingsPersonalizationEmpty: "No personalization yet",
   settingsPersonalizationLoadError: "Unable to load personalization",
-  settingsResponseStyleDescription: "Response style summary",
   settingsResponseStyleError: "Unable to save response style",
   settingsResponseStyleSaved: "Saved",
   responseStyleSelectLabel: "Response tone",
@@ -310,6 +309,7 @@ afterEach(() => {
  *  - sections 顺序符合蓝图。
  *  - activeSectionId 为 general。
  *  - focusHeadingId 与 headingId 指向 general 分区。
+ *  - responseStyle 分区未暴露描述信息，message 应为 undefined。
  *  - modalHeadingText 等于 General 文案。
  * 边界/异常：
  *  - 若 general 被禁用，应回退到下一个可用分区（由 sanitizeActiveSectionId 覆盖）。
@@ -330,6 +330,7 @@ test("Given default sections When reading blueprint Then general leads navigatio
       (section) => section.id === "responseStyle",
     );
     expect(responseStyleSection.componentProps.state.status).toBe("ready");
+    expect(responseStyleSection.componentProps.message).toBeUndefined();
   });
 
   expect(result.current.sections.map((section) => section.id)).toEqual([

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -771,14 +771,6 @@ function usePreferenceSections({ initialSectionId }) {
     const generalLabel = t.settingsTabGeneral ?? "General";
 
     const responseStyleLabel = t.settingsTabPersonalization ?? "Response style";
-    const responseStyleSummary =
-      t.settingsResponseStyleDescription ??
-      t.prefPersonalizationTitle ??
-      "Choose how explanations should sound.";
-    const responseStyleMessage = pickFirstMeaningfulString(
-      [t.settingsResponseStyleDescription, t.prefPersonalizationTitle],
-      responseStyleSummary,
-    );
 
     const dataLabel = t.settingsTabData ?? "Data controls";
     const dataSummary =
@@ -894,7 +886,7 @@ function usePreferenceSections({ initialSectionId }) {
         Component: ResponseStyleSection,
         componentProps: {
           title: responseStyleLabel,
-          message: responseStyleMessage,
+          // 根据最新信息架构，响应风格分区不再提供额外描述，避免重复呈现。
           state: responseStyleState,
           copy: responseStyleCopy,
           onRetry: handleResponseStyleRetry,
@@ -962,7 +954,6 @@ function usePreferenceSections({ initialSectionId }) {
     usernameEditorTranslations,
     changeAvatarLabel,
     t.prefAccountTitle,
-    t.prefPersonalizationTitle,
     t.settingsAccountBindingApple,
     t.settingsAccountBindingGoogle,
     t.settingsAccountBindingWeChat,
@@ -976,7 +967,6 @@ function usePreferenceSections({ initialSectionId }) {
     t.settingsTabGeneral,
     t.settingsTabKeyboard,
     t.settingsTabPersonalization,
-    t.settingsResponseStyleDescription,
     responseStyleCopy,
     responseStyleState,
     handleResponseStyleRetry,


### PR DESCRIPTION
## Summary
- stop passing a description message to the response style preference section so the redundant paragraph is no longer rendered
- drop the unused response-style description copy from the locale bundles and expand the preferences hook test to enforce the absence of the message

## Testing
- npm test -- src/pages/preferences/__tests__/usePreferenceSections.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4a53c5e288332b79dd7964d9fcb42