### PR TITLE
Align streaming markdown formatting with dictionary renderer

### DIFF
--- a/website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntry.jsx
@@ -2,7 +2,9 @@ import { useLanguage } from "@/context";
 import { TtsButton, PronounceableWord } from "@/components";
 import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
 import DictionaryMarkdown from "./DictionaryMarkdown.jsx";
-import { polishDictionaryMarkdown } from "@/utils";
+import {
+  normalizeDictionaryMarkdown,
+} from "@/features/dictionary-experience/markdown/dictionaryMarkdownNormalizer.js";
 import styles from "./DictionaryEntry.module.css";
 
 function tryParseJson(text) {
@@ -27,7 +29,7 @@ function DictionaryEntry({ entry, className }) {
     if (parsed) {
       return <DictionaryEntry entry={parsed} className={className} />;
     }
-    const polished = polishDictionaryMarkdown(entry.markdown);
+    const polished = normalizeDictionaryMarkdown(entry.markdown);
     return (
       <article className={entryClassName}>
         <DictionaryMarkdown>{polished}</DictionaryMarkdown>

--- a/website/src/features/dictionary-experience/markdown/__tests__/dictionaryMarkdownNormalizer.test.js
+++ b/website/src/features/dictionary-experience/markdown/__tests__/dictionaryMarkdownNormalizer.test.js
@@ -1,0 +1,65 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("@/utils", () => ({
+  polishDictionaryMarkdown: jest.fn((value) => `polished:${value}`),
+}));
+
+const normalizerModule = await import("../dictionaryMarkdownNormalizer.js");
+const utilsModule = await import("@/utils");
+
+const {
+  createDictionaryMarkdownNormalizer,
+  normalizeDictionaryMarkdown,
+  normalizeMarkdownEntity,
+} = normalizerModule;
+const { polishDictionaryMarkdown } = utilsModule;
+
+/**
+ * 测试目标：非字符串输入需安全回退为空串，避免渲染阶段出现 [object Object]。
+ * 前置条件：调用 normalizeDictionaryMarkdown 传入 undefined/null/对象。
+ * 步骤：分别执行并收集返回值。
+ * 断言：
+ *  - 每次调用均返回空字符串；
+ * 边界/异常：覆盖 undefined 与对象两类非法输入。
+ */
+test("GivenNonStringInput_WhenNormalizeInvoked_ShouldReturnEmptyString", () => {
+  expect(normalizeDictionaryMarkdown(undefined)).toBe("");
+  expect(normalizeDictionaryMarkdown(null)).toBe("");
+  expect(normalizeDictionaryMarkdown({ markdown: "value" })).toBe("");
+});
+
+/**
+ * 测试目标：自定义 pipeline 应按顺序执行，产出最终归一化结果。
+ * 前置条件：构造包含两个步骤的 pipeline，第一个追加标记，第二个转大写。
+ * 步骤：使用 createDictionaryMarkdownNormalizer 创建实例后执行 normalize。
+ * 断言：
+ *  - 返回值匹配预期的串联效果。
+ * 边界/异常：验证 pipeline 中含非函数时会被过滤。
+ */
+test("GivenCustomPipeline_WhenNormalizeInvoked_ShouldApplySequentially", () => {
+  const pipeline = [
+    (value) => `${value}-step1`,
+    null,
+    (value) => value.toUpperCase(),
+  ];
+  const normalizer = createDictionaryMarkdownNormalizer({ pipeline });
+  expect(normalizer.normalize("seed")).toBe("SEED-STEP1");
+});
+
+/**
+ * 测试目标：normalizeMarkdownEntity 在 markdown 发生变化时应返回浅拷贝。
+ * 前置条件：传入包含 markdown 的对象，并让底层 polish mock 返回不同值。
+ * 步骤：执行 normalizeMarkdownEntity 并检查引用与字段。
+ * 断言：
+ *  - 返回对象不与原引用相同；
+ *  - markdown 字段被替换为 mock 结果。
+ * 边界/异常：确保缺失 markdown 时返回原对象。
+ */
+test("GivenEntityWithMarkdown_WhenNormalized_ShouldReturnClonedResult", () => {
+  polishDictionaryMarkdown.mockImplementationOnce((value) => `norm:${value}`);
+  const original = { id: "v1", markdown: "**raw**" };
+  const normalized = normalizeMarkdownEntity(original);
+  expect(normalized).not.toBe(original);
+  expect(normalized.markdown).toBe("norm:**raw**");
+  expect(normalizeMarkdownEntity({ id: "v2" })).toEqual({ id: "v2" });
+});

--- a/website/src/features/dictionary-experience/markdown/dictionaryMarkdownNormalizer.js
+++ b/website/src/features/dictionary-experience/markdown/dictionaryMarkdownNormalizer.js
@@ -1,0 +1,84 @@
+/**
+ * 背景：
+ *  - 词典体验在流式与静态阶段分别维护 Markdown 字符串，历史上两处各自调用 polishDictionaryMarkdown，存在漂移风险。
+ * 目的：
+ *  - 以可扩展的归一化服务统一 Markdown 预处理，确保 streaming 预览与最终渲染沿用同一逻辑，从而保持视觉与语义一致。
+ * 关键决策与取舍：
+ *  - 采用“责任链/策略”混合模式，通过可配置的管线依次执行清洗步骤，当前仅内置 polishDictionaryMarkdown，未来可按需扩展。
+ *  - 保持函数式接口（normalize）以便 Hook 与组件调用，无需知晓内部策略细节，降低耦合度。
+ * 影响范围：
+ *  - useDictionaryExperience 在流式阶段更新 preview/finalText；DictionaryEntry 渲染 Markdown 文本。
+ * 演进与TODO：
+ *  - 后续若需按语言切换策略，可在 createDictionaryMarkdownNormalizer 的入参中注入多策略选择器。
+ */
+import { polishDictionaryMarkdown } from "@/utils";
+
+const DEFAULT_PIPELINE = Object.freeze([polishDictionaryMarkdown]);
+
+/**
+ * 意图：构建可扩展的 Markdown 归一化器，保证输入经过同一序列的清洗步骤。
+ * 输入：可选自定义 pipeline（函数数组），按顺序处理字符串；
+ * 输出：暴露 normalize 方法，返回归一化后的字符串。
+ * 流程：
+ *  1) 过滤非法步骤并固定为不可变数组；
+ *  2) 校验输入，仅处理字符串，其他类型返回空串；
+ *  3) 依次执行 pipeline，若某一步返回非字符串或抛错，则保留上一步结果。
+ * 错误处理：单步失败时吞掉异常并记录控制台错误，避免阻断主流程。
+ * 复杂度：O(n)（n 为步骤数），默认单步。
+ */
+export function createDictionaryMarkdownNormalizer({ pipeline } = {}) {
+  const steps = Array.isArray(pipeline) && pipeline.length > 0
+    ? pipeline.filter((step) => typeof step === "function")
+    : DEFAULT_PIPELINE;
+
+  return {
+    normalize(source) {
+      if (typeof source !== "string") {
+        return "";
+      }
+
+      return steps.reduce((acc, step) => {
+        if (typeof acc !== "string") {
+          return "";
+        }
+        try {
+          const next = step(acc);
+          return typeof next === "string" ? next : acc;
+        } catch (error) {
+          console.error("[dictionaryMarkdownNormalizer] step failed", error);
+          return acc;
+        }
+      }, source);
+    },
+  };
+}
+
+const defaultNormalizer = createDictionaryMarkdownNormalizer();
+
+export function normalizeDictionaryMarkdown(source) {
+  return defaultNormalizer.normalize(source);
+}
+
+/**
+ * 意图：在不破坏引用的前提下，统一处理对象上的 markdown 字段。
+ * 输入：包含 markdown 属性的对象；
+ * 输出：若 markdown 为字符串则返回归一化后的浅拷贝，否则返回原对象。
+ */
+export function normalizeMarkdownEntity(candidate) {
+  if (!candidate || typeof candidate !== "object") {
+    return candidate;
+  }
+  const { markdown } = candidate;
+  if (typeof markdown !== "string") {
+    return candidate;
+  }
+  const normalized = normalizeDictionaryMarkdown(markdown);
+  if (normalized === markdown) {
+    return candidate;
+  }
+  return { ...candidate, markdown: normalized };
+}
+
+export const __INTERNAL__ = Object.freeze({
+  DEFAULT_PIPELINE,
+});


### PR DESCRIPTION
## Summary
- add a reusable dictionary markdown normalizer to ensure streaming and persisted entries share the same sanitation pipeline
- update dictionary experience and word streaming hooks to reuse the shared normalizer and keep preview/final text consistent
- cover the new normalizer plus the streaming normalization flow with targeted unit tests

## Testing
- npm test -- --runTestsByPath src/features/dictionary-experience/markdown/__tests__/dictionaryMarkdownNormalizer.test.js src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx src/hooks/__tests__/useStreamWord.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4b3ff28f48332910ce71f80c2f668