### PR TITLE
feat: sanitize server error responses

### DIFF
--- a/backend/src/main/java/com/glancy/backend/exception/HttpStatusAwareErrorMessageResolver.java
+++ b/backend/src/main/java/com/glancy/backend/exception/HttpStatusAwareErrorMessageResolver.java
@@ -1,0 +1,77 @@
+/**
+ * 背景：
+ *  - 现有异常处理直接将后端异常消息透传给客户端，遇到 5xx 等服务器异常时会暴露内部细节。
+ * 目的：
+ *  - 通过状态码驱动的策略模式，统一约束对外暴露的错误文案，在服务端异常时返回稳定、可本地化的信息。
+ * 关键决策与取舍：
+ *  - 采用策略模式（Strategy）管理不同状态码段的消息转换，便于未来针对 4xx/5xx 乃至特定业务码扩展文案处理。
+ *  - 放弃简单 if/else 实现，避免在全局异常处理器中堆叠条件分支，提升可维护性与测试友好度。
+ * 影响范围：
+ *  - 所有经由 GlobalExceptionHandler 输出的错误消息，将在响应前统一经过该解析器。
+ * 演进与TODO：
+ *  - 如需支持多语言或可配置文案，可在此处接入消息资源或特性开关以动态调整策略列表。
+ */
+package com.glancy.backend.exception;
+
+import java.util.List;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+
+public final class HttpStatusAwareErrorMessageResolver {
+
+    private final List<ErrorMessageStrategy> strategies;
+
+    public HttpStatusAwareErrorMessageResolver(List<ErrorMessageStrategy> strategies) {
+        this.strategies = List.copyOf(strategies);
+    }
+
+    public static HttpStatusAwareErrorMessageResolver defaultResolver() {
+        return new HttpStatusAwareErrorMessageResolver(
+            List.of(new ServerErrorMessageStrategy(), new PassthroughMessageStrategy())
+        );
+    }
+
+    public String resolve(HttpStatus status, String originalMessage) {
+        for (ErrorMessageStrategy strategy : strategies) {
+            if (strategy.supports(status)) {
+                return strategy.toPublicMessage(originalMessage);
+            }
+        }
+        return originalMessage;
+    }
+
+    interface ErrorMessageStrategy {
+        boolean supports(HttpStatus status);
+
+        String toPublicMessage(String originalMessage);
+    }
+
+    static final class ServerErrorMessageStrategy implements ErrorMessageStrategy {
+
+        private static final String GENERIC_MESSAGE = "服务暂不可用，请稍后重试";
+
+        @Override
+        public boolean supports(HttpStatus status) {
+            return status.series() == Series.SERVER_ERROR;
+        }
+
+        @Override
+        public String toPublicMessage(String originalMessage) {
+            return GENERIC_MESSAGE;
+        }
+    }
+
+    static final class PassthroughMessageStrategy implements ErrorMessageStrategy {
+
+        @Override
+        public boolean supports(HttpStatus status) {
+            return true;
+        }
+
+        @Override
+        public String toPublicMessage(String originalMessage) {
+            return Objects.requireNonNullElse(originalMessage, "");
+        }
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/exception/GlobalExceptionHandlerServerErrorMessageTest.java
+++ b/backend/src/test/java/com/glancy/backend/exception/GlobalExceptionHandlerServerErrorMessageTest.java
@@ -1,0 +1,74 @@
+/**
+ * 背景：
+ *  - 5xx 异常目前会透传后端异常详情，违反最小披露原则且影响用户体验。
+ * 目的：
+ *  - 通过集成测试验证全局异常处理器会在服务端异常时返回统一提示语，保障策略落地。
+ * 关键决策与取舍：
+ *  - 采用 MockMvcBuilders 构建轻量级独立容器，仅加载待测控制器与异常处理器，避免全应用上下文带来的安全拦截干扰。
+ * 影响范围：
+ *  - 该测试覆盖 503 服务降级场景，其验证逻辑适用于所有 5xx 策略。
+ * 演进与TODO：
+ *  - 后续可追加对 SSE、特定 5xx 状态的断言，以防策略回归。
+ */
+package com.glancy.backend.exception;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class GlobalExceptionHandlerServerErrorMessageTest {
+
+    private MockMvc mvc;
+
+    @RestController
+    @RequestMapping("/unstable")
+    public static class UnstableController {
+
+        @GetMapping("/503")
+        String boom() {
+            throw new ServiceDegradedException("upstream provider timeout");
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(
+            new ObjectMapper(),
+            HttpStatusAwareErrorMessageResolver.defaultResolver()
+        );
+        mvc = MockMvcBuilders.standaloneSetup(new UnstableController())
+            .setControllerAdvice(handler)
+            .defaultRequest(get("/").accept(MediaType.APPLICATION_JSON))
+            .build();
+    }
+
+    /**
+     * 测试目标：确认 5xx 响应的错误消息会被统一替换为泛化提示，避免暴露内部细节。
+     * 前置条件：Mock 控制器在访问 /unstable/503 时抛出 ServiceDegradedException，触发 503。
+     * 步骤：
+     *  1) 发送 GET /unstable/503 请求，接受 JSON。
+     *  2) 由全局异常处理器生成响应。
+     * 断言：
+     *  - HTTP 状态码为 503。
+     *  - 响应体 message 字段为统一提示语 "服务暂不可用，请稍后重试"。
+     * 边界/异常：
+     *  - 若策略未生效导致 message 泄露原始文案，断言失败并暴露问题。
+     */
+    @Test
+    void GivenServerError_WhenHandled_ThenReturnGenericMessage() throws Exception {
+        mvc
+            .perform(get("/unstable/503").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("服务暂不可用，请稍后重试"));
+    }
+}

--- a/backend/src/test/java/com/glancy/backend/exception/GlobalExceptionHandlerSseTest.java
+++ b/backend/src/test/java/com/glancy/backend/exception/GlobalExceptionHandlerSseTest.java
@@ -3,12 +3,12 @@ package com.glancy.backend.exception;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,16 +20,25 @@ import org.springframework.web.bind.annotation.RestController;
  * 2. 控制器抛出 ResourceNotFoundException。
  * 3. 验证响应为 SSE 格式错误事件。
  */
-@WebMvcTest(controllers = GlobalExceptionHandlerSseTest.DummyController.class)
-@Import(GlobalExceptionHandler.class)
 class GlobalExceptionHandlerSseTest {
 
-    @Autowired
     private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(
+            new ObjectMapper(),
+            HttpStatusAwareErrorMessageResolver.defaultResolver()
+        );
+        mvc = MockMvcBuilders.standaloneSetup(new DummyController())
+            .setControllerAdvice(handler)
+            .defaultRequest(get("/").accept(MediaType.APPLICATION_JSON))
+            .build();
+    }
 
     @RestController
     @RequestMapping("/dummy")
-    static class DummyController {
+    public static class DummyController {
 
         @GetMapping("/boom")
         String boom() {


### PR DESCRIPTION
## Summary
- add an HttpStatus-aware error message resolver to centralize server-error wording
- integrate the resolver into the global exception handler so 5xx responses return a neutral prompt
- exercise the new behaviour with standalone MockMvc tests for JSON and SSE flows

## Testing
- mvn -Dtest=GlobalExceptionHandlerServerErrorMessageTest,GlobalExceptionHandlerSseTest test

------
https://chatgpt.com/codex/tasks/task_e_68e4b3b973508332a64e31dce43bea5b