### PR TITLE
Fix stylelint spacing violation in modal content module

### DIFF
--- a/website/src/components/modals/ModalContent.module.css
+++ b/website/src/components/modals/ModalContent.module.css
@@ -2,8 +2,9 @@
   /*
    * 为举报弹窗等需要展示完整操作区的场景提升可用高度，
    * 同时通过变量受控，避免影响其他对话框的宽高策略。
-   */
+  */
   --modal-max-height: min(92vh, 920px);
+
   background: var(--app-bg);
   color: var(--app-color);
   padding: 32px 32px 28px;


### PR DESCRIPTION
## Summary
- add a blank line between the modal custom property and subsequent declarations to satisfy stylelint spacing rules

## Testing
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e4c21b7f6883329d2261dd714869eb