### PR TITLE
feat: split streaming markdown into word spans

### DIFF
--- a/website/src/components/__tests__/MarkdownStream.test.jsx
+++ b/website/src/components/__tests__/MarkdownStream.test.jsx
@@ -13,3 +13,25 @@ test("renders markdown with default renderer", () => {
   );
   expect(strong.tagName).toBe("STRONG");
 });
+
+/**
+ * 测试目标：验证流式 Markdown 在渲染时按空格拆分词语。
+ * 前置条件：输入文本包含以空格分隔的英文单词。
+ * 步骤：
+ *  1) 渲染 MarkdownStream 并传入 "Hello world"；
+ *  2) 查询生成的词级 span 元素；
+ * 断言：
+ *  - span 数量等于单词数量且文本保持原始值；
+ * 边界/异常：
+ *  - 确保未破坏空格本身（通过比较父节点文本）。
+ */
+test("splits words with dedicated spans during streaming", () => {
+  const { container } = render(<MarkdownStream text="Hello world" />);
+  const paragraph = container.querySelector(".stream-text p");
+  expect(paragraph).not.toBeNull();
+  const spans = paragraph.querySelectorAll("span.stream-word");
+  expect(spans).toHaveLength(2);
+  expect(stripZeroWidth(spans[0].textContent)).toBe("Hello");
+  expect(stripZeroWidth(spans[1].textContent)).toBe("world");
+  expect(stripZeroWidth(paragraph.textContent)).toBe("Hello world");
+});

--- a/website/src/components/ui/MarkdownStream/index.jsx
+++ b/website/src/components/ui/MarkdownStream/index.jsx
@@ -1,4 +1,7 @@
+import { useMemo } from "react";
+import PropTypes from "prop-types";
 import MarkdownRenderer from "../MarkdownRenderer";
+import rehypeStreamWordSegments from "./rehypeStreamWordSegments.js";
 
 /**
  * 渲染 Markdown 流内容的通用组件，默认使用 MarkdownRenderer。
@@ -6,7 +9,25 @@ import MarkdownRenderer from "../MarkdownRenderer";
  */
 function MarkdownStream({ text, renderer }) {
   const Renderer = renderer || MarkdownRenderer;
-  return <Renderer className="stream-text">{text}</Renderer>;
+  const additionalRehypePlugins = useMemo(
+    () => (Renderer === MarkdownRenderer ? [rehypeStreamWordSegments] : null),
+    [Renderer],
+  );
+
+  const rendererProps = additionalRehypePlugins
+    ? { rehypePlugins: additionalRehypePlugins }
+    : {};
+
+  return (
+    <Renderer className="stream-text" {...rendererProps}>
+      {text}
+    </Renderer>
+  );
 }
+
+MarkdownStream.propTypes = {
+  text: PropTypes.string,
+  renderer: PropTypes.elementType,
+};
 
 export default MarkdownStream;

--- a/website/src/components/ui/MarkdownStream/rehypeStreamWordSegments.js
+++ b/website/src/components/ui/MarkdownStream/rehypeStreamWordSegments.js
@@ -1,0 +1,71 @@
+/**
+ * 背景：
+ *  - 流式 Markdown 需要在视觉层面区分逐词输出，以便后续实现词级高亮或动画效果。
+ * 目的：
+ *  - 提供一个 Rehype 插件，将文本节点按空白符拆分为词级片段，并以 span 包裹词语。
+ * 关键决策与取舍：
+ *  - 采用“访问者模式”遍历 HAST，避免在 React 渲染阶段重复处理；
+ *  - 跳过 code/pre 等语义节点，防止破坏代码块原始格式；
+ * 影响范围：
+ *  - 仅影响经 MarkdownStream 渲染的流式内容，其它 MarkdownRenderer 调用保持原状；
+ * 演进与TODO：
+ *  - 后续可扩展为可配置的粒度策略（按语种或词性分组）。
+ */
+import { visit } from "unist-util-visit";
+
+const STREAM_WORD_CLASS = "stream-word";
+const WHITESPACE_RE = /^\s+$/u;
+const WHITESPACE_SPLITTER = /(\s+)/u;
+const SKIP_TAGS = new Set(["code", "pre", "kbd", "samp"]);
+
+function createWordNode(value) {
+  return {
+    type: "element",
+    tagName: "span",
+    properties: { className: [STREAM_WORD_CLASS] },
+    children: [{ type: "text", value }],
+  };
+}
+
+function segmentValue(value) {
+  if (!value) return null;
+  const parts = value.split(WHITESPACE_SPLITTER).filter(Boolean);
+  if (parts.length <= 1) {
+    return null;
+  }
+
+  const nodes = parts.map((segment) =>
+    WHITESPACE_RE.test(segment)
+      ? { type: "text", value: segment }
+      : createWordNode(segment),
+  );
+
+  return nodes;
+}
+
+export default function rehypeStreamWordSegments() {
+  return (tree) => {
+    visit(tree, "text", (node, index, parent) => {
+      if (!parent || typeof node.value !== "string" || !node.value) {
+        return;
+      }
+
+      if (parent.type === "element" && SKIP_TAGS.has(parent.tagName)) {
+        return;
+      }
+
+      const replacements = segmentValue(node.value);
+      if (!replacements) {
+        return;
+      }
+
+      parent.children.splice(index, 1, ...replacements);
+      return index + replacements.length;
+    });
+  };
+}
+
+export const __internal__testables = {
+  segmentValue,
+  createWordNode,
+};


### PR DESCRIPTION
## Summary
- add a rehype plugin to MarkdownStream that wraps streamed words and preserves whitespace separation
- extend MarkdownRenderer to accept extra plugin hooks so streaming can inject word segmentation
- cover the new segmentation with a focused MarkdownStream test

## Testing
- npm test -- MarkdownStream

------
https://chatgpt.com/codex/tasks/task_e_68e4c96eb6dc8332b6a0a6eab4a1e7c4