### PR TITLE
Refine report issue modal layout

### DIFF
--- a/website/src/components/modals/Modal.module.css
+++ b/website/src/components/modals/Modal.module.css
@@ -30,6 +30,7 @@
   position: absolute;
   top: 16px;
   left: 16px;
+  z-index: 2;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -52,6 +53,7 @@
   position: absolute;
   top: 16px;
   left: 16px;
+  z-index: 2;
   display: flex;
   gap: 12px;
 }

--- a/website/src/features/dictionary-experience/components/ReportIssueModal.jsx
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.jsx
@@ -158,8 +158,11 @@ function ReportIssueModal({
     ],
   );
 
+  // 通过挂载局部样式类，重置 ModalContent 注入的背景色，避免举报弹窗出现额外底色。
+  const modalClassName = `modal-content ${styles["modal-shell"]}`;
+
   return (
-    <BaseModal open={open} onClose={onClose} className="modal-content">
+    <BaseModal open={open} onClose={onClose} className={modalClassName}>
       <SettingsSurface
         as="form"
         onSubmit={handleSubmit}

--- a/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
@@ -1,3 +1,16 @@
+.modal-shell {
+  /*
+   * 作为挂载在 Modal 容器上的局部类，便于在不影响其他对话框的前提下重置背景与阴影。
+   */
+}
+
+:global(.modal-content).modal-shell {
+  background: transparent;
+  color: var(--preferences-panel-text, var(--color-text));
+  padding: clamp(var(--space-6), 5vw, var(--space-7));
+  border-radius: var(--radius-2xl);
+  box-shadow: none;
+}
 
 .plain-surface {
   background: transparent;
@@ -79,12 +92,18 @@
 .segment-group {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: var(--space-2);
-  padding: var(--space-2);
+  gap: var(--space-1);
+  padding: clamp(var(--space-1), 1.6vw, var(--space-2));
   border-radius: var(--radius-2xl);
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--preferences-panel-border, var(--border-color)) 55%,
+      transparent
+    );
   background: color-mix(
     in srgb,
-    var(--preferences-panel-surface, var(--app-bg)) 82%,
+    var(--preferences-panel-surface, var(--app-bg)) 70%,
     transparent
   );
 }
@@ -95,7 +114,7 @@
   justify-content: center;
   min-width: 108px;
   padding: 0.65rem 1.25rem;
-  border: none;
+  border: 1px solid transparent;
   border-radius: var(--radius-xl);
   background: transparent;
   color: color-mix(
@@ -110,13 +129,16 @@
   transition:
     background 160ms ease,
     color 160ms ease,
-    transform 160ms ease;
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease;
 }
 
 .segment:focus-visible {
   outline: none;
+  border-color: var(--preferences-panel-ring, var(--highlight-color));
   box-shadow: 0 0 0 3px
-    color-mix(in srgb, var(--preferences-panel-ring, var(--highlight-color)) 38%, transparent);
+    color-mix(in srgb, var(--preferences-panel-ring, var(--highlight-color)) 32%, transparent);
 }
 
 .segment:disabled {
@@ -126,17 +148,29 @@
 
 .segment:hover:not(:disabled) {
   color: var(--preferences-panel-text, var(--color-text));
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, var(--highlight-color)) 42%,
+    transparent
+  );
   transform: translateY(-1px);
 }
 
 .segment-active {
   background: color-mix(
     in srgb,
-    var(--preferences-panel-surface, var(--app-bg)) 96%,
-    transparent
+    var(--preferences-panel-ring, var(--highlight-color)) 24%,
+    var(--app-bg)
   );
   color: var(--preferences-panel-text, var(--color-text));
-  transform: translateY(-1px);
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, var(--highlight-color)) 55%,
+    transparent
+  );
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px
+    color-mix(in srgb, var(--shadow-color) 22%, transparent);
 }
 
 .textarea {


### PR DESCRIPTION
## Summary
- raise the modal close control layering so it sits above the report surface
- clear the report modal container background by scoping overrides to the dictionary dialog
- refresh the report category segmented control styling to highlight the active selection

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e4ca22dcd08332ab4c6c70ab5e069c