### PR TITLE
feat: segment dictionary streaming markdown words

### DIFF
--- a/website/src/components/ui/DictionaryEntry/DictionaryEntryPlaceholder.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntryPlaceholder.jsx
@@ -1,18 +1,21 @@
 import { useMemo } from "react";
-import DictionaryEntry from "./DictionaryEntry.jsx";
 import DictionaryEntrySkeleton from "./DictionaryEntrySkeleton.jsx";
+import { DictionaryMarkdownStream } from "./DictionaryMarkdown.jsx";
+import {
+  normalizeDictionaryMarkdown,
+} from "@/features/dictionary-experience/markdown/dictionaryMarkdownNormalizer.js";
 import styles from "./DictionaryEntryPlaceholder.module.css";
 
 function DictionaryEntryPlaceholder({ preview, isLoading }) {
-  const previewEntry = useMemo(() => {
-    if (!preview) return null;
-    return { markdown: preview };
+  const previewMarkdown = useMemo(() => {
+    if (!preview) return "";
+    return normalizeDictionaryMarkdown(preview);
   }, [preview]);
 
-  if (previewEntry) {
+  if (previewMarkdown) {
     return (
       <div className={styles["preview-wrapper"]}>
-        <DictionaryEntry entry={previewEntry} />
+        <DictionaryMarkdownStream text={previewMarkdown} />
       </div>
     );
   }

--- a/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.jsx
+++ b/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.jsx
@@ -1,4 +1,8 @@
+import { useMemo } from "react";
 import MarkdownRenderer from "@/components/ui/MarkdownRenderer";
+import MarkdownStream, {
+  STREAM_SEGMENTATION_PROP,
+} from "@/components/ui/MarkdownStream";
 import styles from "./DictionaryMarkdown.module.css";
 
 function joinClassNames(...tokens) {
@@ -25,7 +29,7 @@ const headingFactory = (level) => {
   };
 };
 
-const components = {
+export const dictionaryMarkdownComponents = {
   h1: headingFactory(1),
   h2: headingFactory(2),
   h3: headingFactory(3),
@@ -104,11 +108,51 @@ const components = {
   },
 };
 
-export default function DictionaryMarkdown({ children }) {
+export default function DictionaryMarkdown({ children, className }) {
   if (!children) return null;
+  const wrapperClassName = joinClassNames(styles.wrapper, className);
   return (
-    <div className={styles.wrapper}>
-      <MarkdownRenderer components={components}>{children}</MarkdownRenderer>
+    <div className={wrapperClassName}>
+      <MarkdownRenderer components={dictionaryMarkdownComponents}>
+        {children}
+      </MarkdownRenderer>
     </div>
   );
+}
+
+function createDictionaryMarkdownStreamRenderer(additionalClassName) {
+  return function DictionaryMarkdownStreamRenderer({
+    className,
+    children,
+    ...rendererProps
+  }) {
+    const wrapperClassName = joinClassNames(
+      styles.wrapper,
+      additionalClassName,
+      className,
+    );
+    const streamRenderer = (
+      <div className={wrapperClassName}>
+        <MarkdownRenderer
+          {...rendererProps}
+          components={dictionaryMarkdownComponents}
+        >
+          {children}
+        </MarkdownRenderer>
+      </div>
+    );
+    return streamRenderer;
+  };
+}
+
+export function DictionaryMarkdownStream({ text, className }) {
+  const Renderer = useMemo(() => {
+    const renderer = createDictionaryMarkdownStreamRenderer(className);
+    renderer[STREAM_SEGMENTATION_PROP] = true;
+    return renderer;
+  }, [className]);
+
+  if (!text) return null;
+
+  return <MarkdownStream text={text} renderer={Renderer} />;
 }

--- a/website/src/components/ui/DictionaryEntry/__tests__/DictionaryEntryPlaceholder.streaming.test.jsx
+++ b/website/src/components/ui/DictionaryEntry/__tests__/DictionaryEntryPlaceholder.streaming.test.jsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import DictionaryEntryPlaceholder from "@/components/ui/DictionaryEntry/DictionaryEntryPlaceholder.jsx";
+
+const stripZeroWidth = (value) => value.replace(/\u200B/g, "");
+
+/**
+ * 测试目标：词典占位在流式预览阶段应执行词级拆分，保留空格。
+ * 前置条件：传入包含两个英文单词且以空格分隔的 preview 文本。
+ * 步骤：
+ *  1) 渲染 DictionaryEntryPlaceholder 并提供预览字符串；
+ *  2) 选择渲染结果中的 stream-word span；
+ * 断言：
+ *  - span 数量等于单词数量；
+ *  - 容器整体文本仍包含原始空格；
+ * 边界/异常：
+ *  - 断言失败信息需指明词语拆分不符合预期。
+ */
+test("GivenPreview_WhenStreaming_ShouldSplitWordsWithoutLosingSpaces", () => {
+  const { container } = render(
+    <DictionaryEntryPlaceholder preview="Hello world" isLoading={false} />,
+  );
+
+  const wrapper = container.querySelector(".stream-text");
+  expect(wrapper).not.toBeNull();
+  const spans = wrapper.querySelectorAll("span.stream-word");
+  expect(spans.length).toBe(2);
+  expect(stripZeroWidth(spans[0].textContent)).toBe("Hello");
+  expect(stripZeroWidth(spans[1].textContent)).toBe("world");
+  expect(stripZeroWidth(wrapper.textContent)).toBe("Hello world");
+});

--- a/website/src/components/ui/MarkdownStream/index.jsx
+++ b/website/src/components/ui/MarkdownStream/index.jsx
@@ -3,15 +3,23 @@ import PropTypes from "prop-types";
 import MarkdownRenderer from "../MarkdownRenderer";
 import rehypeStreamWordSegments from "./rehypeStreamWordSegments.js";
 
+const STREAM_SEGMENTATION_PROP = "enableStreamWordSegmentation";
+
 /**
  * 渲染 Markdown 流内容的通用组件，默认使用 MarkdownRenderer。
  * 可通过 renderer 属性注入自定义渲染器以便测试或扩展。
  */
-function MarkdownStream({ text, renderer }) {
+function MarkdownStream({ text, renderer, className = "stream-text" }) {
   const Renderer = renderer || MarkdownRenderer;
-  const additionalRehypePlugins = useMemo(
-    () => (Renderer === MarkdownRenderer ? [rehypeStreamWordSegments] : null),
+  const supportsSegmentation = useMemo(
+    () =>
+      Renderer === MarkdownRenderer ||
+      Renderer?.[STREAM_SEGMENTATION_PROP] === true,
     [Renderer],
+  );
+  const additionalRehypePlugins = useMemo(
+    () => (supportsSegmentation ? [rehypeStreamWordSegments] : null),
+    [supportsSegmentation],
   );
 
   const rendererProps = additionalRehypePlugins
@@ -19,7 +27,7 @@ function MarkdownStream({ text, renderer }) {
     : {};
 
   return (
-    <Renderer className="stream-text" {...rendererProps}>
+    <Renderer className={className} {...rendererProps}>
       {text}
     </Renderer>
   );
@@ -28,6 +36,8 @@ function MarkdownStream({ text, renderer }) {
 MarkdownStream.propTypes = {
   text: PropTypes.string,
   renderer: PropTypes.elementType,
+  className: PropTypes.string,
 };
 
 export default MarkdownStream;
+export { STREAM_SEGMENTATION_PROP };


### PR DESCRIPTION
## Summary
- render dictionary streaming previews through DictionaryMarkdownStream to inject word-level spans while preserving normalization
- extend MarkdownStream so custom renderers can opt-in to the segmentation rehype plugin and expose the functionality via DictionaryMarkdown
- add unit coverage for the placeholder to ensure streaming text keeps original spacing after segmentation

## Testing
- npm test -- --runTestsByPath src/components/ui/DictionaryEntry/__tests__/DictionaryEntryPlaceholder.streaming.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e4d07af8d88332a204d320a2509dcc