### PR TITLE
feat: restyle dictionary report modal header

### DIFF
--- a/website/src/components/settings/SettingsSurface/SettingsSurface.jsx
+++ b/website/src/components/settings/SettingsSurface/SettingsSurface.jsx
@@ -20,6 +20,7 @@ const SettingsSurface = forwardRef(function SettingsSurface(
     descriptionId: providedDescriptionId,
     as,
     className = "",
+    renderHeader,
   },
   ref,
 ) {
@@ -41,6 +42,29 @@ const SettingsSurface = forwardRef(function SettingsSurface(
     .filter(Boolean)
     .join(" ");
 
+  /**
+   * 意图：
+   *  - 当上层需要自定义抬头布局（如插入关闭按钮或多列信息）时，允许通过 renderHeader 覆盖默认结构。
+   * 流程：
+   *  1) 优先调用 renderHeader，并注入 headingId/descriptionId/title/description 等上下文。
+   *  2) 未提供时回退到原有的语义化标题与描述栈，确保默认路径无感知。
+   */
+  const headerContent =
+    typeof renderHeader === "function"
+      ? renderHeader({ headingId, descriptionId, title, description })
+      : (
+          <header className={styles.header}>
+            <h2 id={headingId} className={styles.title}>
+              {title}
+            </h2>
+            {description ? (
+              <p id={descriptionId} className={styles.description}>
+                {description}
+              </p>
+            ) : null}
+          </header>
+        );
+
   return (
     <Component
       ref={ref}
@@ -49,16 +73,7 @@ const SettingsSurface = forwardRef(function SettingsSurface(
       aria-describedby={descriptionId}
       onSubmit={onSubmit}
     >
-      <header className={styles.header}>
-        <h2 id={headingId} className={styles.title}>
-          {title}
-        </h2>
-        {description ? (
-          <p id={descriptionId} className={styles.description}>
-            {description}
-          </p>
-        ) : null}
-      </header>
+      {headerContent}
       <div className={styles.content}>{children}</div>
       {actions ? <footer className={styles.actions}>{actions}</footer> : null}
     </Component>
@@ -76,6 +91,7 @@ SettingsSurface.propTypes = {
   descriptionId: PropTypes.string,
   as: PropTypes.elementType,
   className: PropTypes.string,
+  renderHeader: PropTypes.func,
 };
 
 export default SettingsSurface;

--- a/website/src/features/dictionary-experience/components/ReportIssueModal.jsx
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useId } from "react";
 import PropTypes from "prop-types";
 import BaseModal from "@/components/modals/BaseModal.jsx";
 import { SettingsSurface } from "@/components";
@@ -32,6 +32,7 @@ function ReportIssueModal({
   onSubmit,
 }) {
   const { t } = useLanguage();
+  const headingId = useId();
 
   const handleSubmit = useCallback(
     (event) => {
@@ -158,15 +159,47 @@ function ReportIssueModal({
     ],
   );
 
-  // 通过挂载局部样式类，重置 ModalContent 注入的背景色，避免举报弹窗出现额外底色。
+  // 通过挂载局部样式类，为举报弹窗注入专属的表面与阴影令牌，确保视觉与语义双重聚焦。
   const modalClassName = `modal-content ${styles["modal-shell"]}`;
 
+  const handleClose = useCallback(() => {
+    onClose?.();
+  }, [onClose]);
+
+  const renderHeader = useCallback(
+    ({ headingId: surfaceHeadingId, title }) => (
+      <header className={styles.header}>
+        <button
+          type="button"
+          className={styles["header-close"]}
+          aria-label={t.close ?? "Close"}
+          onClick={handleClose}
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h2 id={surfaceHeadingId} className={styles["header-title"]}>
+          {title}
+        </h2>
+        <span aria-hidden="true" className={styles["header-spacer"]} />
+      </header>
+    ),
+    [handleClose, t.close],
+  );
+
   return (
-    <BaseModal open={open} onClose={onClose} className={modalClassName}>
+    <BaseModal
+      open={open}
+      onClose={onClose}
+      className={modalClassName}
+      hideDefaultCloseButton
+      ariaLabelledBy={headingId}
+    >
       <SettingsSurface
         as="form"
         onSubmit={handleSubmit}
         title={t.reportTitle ?? "Report an issue"}
+        headingId={headingId}
+        renderHeader={renderHeader}
         actions={
           <div className={styles["action-bar"]}>
             {/*

--- a/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
@@ -1,31 +1,123 @@
 .modal-shell {
   /*
-   * 作为挂载在 Modal 容器上的局部类，便于在不影响其他对话框的前提下重置背景与阴影。
+   * 为举报弹窗提供独立的色彩令牌，既强化层级感，也避免影响共用的 modal-content 基线样式。
    */
+  --report-modal-surface: color-mix(
+    in srgb,
+    var(--app-bg) 90%,
+    var(--color-surface-alt)
+  );
+  --report-modal-border: color-mix(in srgb, var(--border-color) 38%, transparent);
+  --report-modal-shadow: 0 48px 120px
+    color-mix(in srgb, var(--shadow-color) 32%, transparent);
+  --report-modal-inner-surface: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, var(--app-bg)) 94%,
+    transparent
+  );
+  --report-modal-inner-border: color-mix(
+    in srgb,
+    var(--preferences-panel-border, var(--border-color)) 46%,
+    transparent
+  );
+  --report-modal-inner-shadow: 0 36px 96px
+    color-mix(in srgb, var(--shadow-color) 24%, transparent);
 }
 
 :global(.modal-content).modal-shell {
-  background: transparent;
+  background: var(--report-modal-surface);
   color: var(--preferences-panel-text, var(--color-text));
   padding: clamp(var(--space-6), 5vw, var(--space-7));
   border-radius: var(--radius-2xl);
-  box-shadow: none;
+  border: 1px solid var(--report-modal-border);
+  box-shadow: var(--report-modal-shadow);
 }
 
 .plain-surface {
-  background: transparent;
-  border: none;
-  box-shadow: none;
+  background: var(--report-modal-inner-surface);
+  border: 1px solid var(--report-modal-inner-border);
+  box-shadow: var(--report-modal-inner-shadow);
 }
 
 :global(.modal-content) :where(.plain-surface) {
   /*
-   * 通过在模态容器作用域内提高优先级，彻底移除 SettingsSurface 默认的渐变底色，
-   * 避免举报面板出现与外层背景冲突的叠色。
+   * 在模态容器作用域内确保内层面板继承我们定义的底色与阴影，
+   * 以呼应 SettingsSurface 的玻璃化质感并保持视觉统一。
    */
-  background: transparent;
-  border: none;
-  box-shadow: none;
+  background: var(--report-modal-inner-surface);
+  border: 1px solid var(--report-modal-inner-border);
+  box-shadow: var(--report-modal-inner-shadow);
+}
+
+.header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: clamp(var(--space-2), 2.4vw, var(--space-3));
+  padding-bottom: clamp(var(--space-3), 3vw, var(--space-4));
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--preferences-panel-border, var(--border-color)) 32%, transparent);
+}
+
+.header-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(36px, 6vw, 44px);
+  height: clamp(36px, 6vw, 44px);
+  border-radius: var(--radius-xl);
+  border: 1px solid transparent;
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-surface, var(--app-bg)) 80%,
+    transparent
+  );
+  color: var(--preferences-panel-text, var(--color-text));
+  font-size: clamp(20px, 3vw, 22px);
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.header-close:hover {
+  background: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, var(--highlight-color)) 18%,
+    var(--app-bg)
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, var(--highlight-color)) 45%,
+    transparent
+  );
+  transform: translateY(-1px);
+}
+
+.header-close:focus-visible {
+  outline: none;
+  border-color: var(--preferences-panel-ring, var(--highlight-color));
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--preferences-panel-ring, var(--highlight-color)) 28%, transparent);
+}
+
+.header-title {
+  margin: 0;
+  font-size: clamp(var(--text-xl), 3vw, var(--text-2xl));
+  font-weight: var(--font-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--preferences-panel-text, var(--color-text));
+}
+
+.header-spacer {
+  display: inline-flex;
+  width: clamp(36px, 6vw, 44px);
+  height: clamp(36px, 6vw, 44px);
 }
 
 .summary {


### PR DESCRIPTION
## Summary
- allow SettingsSurface consumers to provide a custom header renderer for advanced layouts
- redesign the dictionary report issue modal header with a horizontal close control and centered title
- refresh modal surface tokens to restore missing background layers and align accessibility metadata

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e4d037ab9c8332ae88739ab91164b2