### PR TITLE
Hide subscription carousel nav buttons at scroll bounds

### DIFF
--- a/website/src/pages/preferences/sections/SubscriptionSection.jsx
+++ b/website/src/pages/preferences/sections/SubscriptionSection.jsx
@@ -143,6 +143,12 @@ function SubscriptionSection({
   }, []);
 
   const shouldRenderPlanRailNav = planCards.length > 1;
+  /**
+   * 以导航显隐取代禁用态，避免读屏软件聚焦到无效按钮，并减少视觉噪点。
+   * 如后续需要保留占位，可改为渲染按钮容器并在样式层做透明处理。
+   */
+  const shouldShowPlanRailPreviousNav = shouldRenderPlanRailNav && !isPlanRailAtStart;
+  const shouldShowPlanRailNextNav = shouldRenderPlanRailNav && !isPlanRailAtEnd;
 
   return (
     <section
@@ -158,12 +164,11 @@ function SubscriptionSection({
       </div>
       <div className={styles["subscription-matrix"]}>
         <div className={styles["subscription-plan-carousel"]}>
-          {shouldRenderPlanRailNav ? (
+          {shouldShowPlanRailPreviousNav ? (
             <button
               type="button"
               className={`${styles["subscription-plan-nav"]} ${styles["subscription-plan-nav-previous"]}`}
               onClick={() => handlePlanRailNav(-1)}
-              disabled={isPlanRailAtStart}
               aria-label="查看前一个订阅方案"
             >
               <span aria-hidden="true">‹</span>
@@ -226,12 +231,11 @@ function SubscriptionSection({
               })}
             </div>
           </div>
-          {shouldRenderPlanRailNav ? (
+          {shouldShowPlanRailNextNav ? (
             <button
               type="button"
               className={`${styles["subscription-plan-nav"]} ${styles["subscription-plan-nav-next"]}`}
               onClick={() => handlePlanRailNav(1)}
-              disabled={isPlanRailAtEnd}
               aria-label="查看后一个订阅方案"
             >
               <span aria-hidden="true">›</span>


### PR DESCRIPTION
## Summary
- hide the subscription carousel navigation buttons when the rail is already at the corresponding scroll boundary
- add inline documentation clarifying the accessibility rationale for removing disabled buttons

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e4d2777858833289d9667305c275f6