### PR TITLE
feat: center account identifiers in preferences panel

### DIFF
--- a/website/src/pages/preferences/Preferences.module.css
+++ b/website/src/pages/preferences/Preferences.module.css
@@ -1061,6 +1061,18 @@
   overflow-wrap: break-word;
 }
 
+/*
+ * 背景：
+ *  - 账户分区的邮箱/手机号需与用户名输入保持统一样式，避免信息密度不一致。
+ * 设计取舍：
+ *  - 复用 UsernameEditor 的输入基样式并叠加 center 对齐，确保跨组件视觉一致且文本聚焦。
+ */
+.detail-input {
+  display: block;
+  width: 100%;
+  text-align: center;
+}
+
 .identity-row {
   align-items: center;
   grid-template-columns:

--- a/website/src/pages/preferences/sections/accountSection.constants.js
+++ b/website/src/pages/preferences/sections/accountSection.constants.js
@@ -11,3 +11,4 @@
  *  - 后续若字段类型扩展，可在此模块集中维护并暴露枚举式接口。
  */
 export const ACCOUNT_USERNAME_FIELD_TYPE = "username-editor";
+export const ACCOUNT_STATIC_FIELD_TYPE = "static-readonly";

--- a/website/src/pages/preferences/usePreferenceSections.js
+++ b/website/src/pages/preferences/usePreferenceSections.js
@@ -20,7 +20,10 @@ import {
 } from "react";
 import { useLanguage, useUser } from "@/context";
 import AccountSection from "./sections/AccountSection.jsx";
-import { ACCOUNT_USERNAME_FIELD_TYPE } from "./sections/accountSection.constants.js";
+import {
+  ACCOUNT_STATIC_FIELD_TYPE,
+  ACCOUNT_USERNAME_FIELD_TYPE,
+} from "./sections/accountSection.constants.js";
 import DataSection from "./sections/DataSection.jsx";
 import GeneralSection from "./sections/GeneralSection.jsx";
 import KeyboardSection from "./sections/KeyboardSection.jsx";
@@ -823,12 +826,24 @@ function usePreferenceSections({ initialSectionId }) {
         id: "email",
         label: t.settingsAccountEmail ?? "Email",
         value: emailValue,
+        type: ACCOUNT_STATIC_FIELD_TYPE,
+        readOnlyInputProps: {
+          type: "email",
+          inputMode: "email",
+          autoComplete: "email",
+        },
         action: emailUnbindAction,
       },
       {
         id: "phone",
         label: t.settingsAccountPhone ?? "Phone",
         value: phoneValue,
+        type: ACCOUNT_STATIC_FIELD_TYPE,
+        readOnlyInputProps: {
+          type: "tel",
+          inputMode: "tel",
+          autoComplete: "tel", // 复用浏览器电话联想能力，尽管字段不可编辑。
+        },
         action: phoneRebindAction,
       },
     ];


### PR DESCRIPTION
## Summary
- render email and phone account fields as disabled inputs so they mirror the username editor styling and alignment
- add a static field renderer plus shared detail-input style to keep all account text centered
- extend AccountSection tests to cover the new static renderer and username input class expectations

## Testing
- npm test -- AccountSection

------
https://chatgpt.com/codex/tasks/task_e_68e4d56b0bcc83328c21b62e4152b0c6