### PR TITLE
feat: soften loader waiting animation reveal

### DIFF
--- a/website/src/components/ui/Loader/Loader.module.css
+++ b/website/src/components/ui/Loader/Loader.module.css
@@ -2,10 +2,10 @@
  * 背景：
  *  - Loader 动画自 2025-03 起强调“中心显现、向外扩展，再向内收束”的节奏，需更精细的遮罩控制。
  * 目的：
- *  - 通过 CSS 模块统一管理透明度与 clip-path 过渡，让 Hook 输出布尔态即可驱动方向性渐隐渐显。
+ *  - 通过 CSS 模块统一管理透明度与遮罩扩散过渡，让 Hook 输出布尔态即可驱动方向性渐隐渐显。
  *  - 引入 mask + currentColor 的组合，将素材颜色响应式映射到当前主题文本色。
  * 关键决策与取舍：
- *  - 继续使用过渡属性组合（opacity + clip-path），避免额外 keyframes 造成维护负担；
+ *  - 使用径向遮罩与 `mask-size` 过渡替代 clip-path，便于在淡入淡出过程中引入羽化模糊；
  *  - 所有时长仍交由 CSS 变量控制，方便主题或无障碍场景动态调整。
  */
 .loader {
@@ -43,15 +43,38 @@
   block-size: 100%;
   overflow: hidden;
   opacity: 0;
-  clip-path: inset(0 50% 0 50%);
   transition:
     opacity var(--waiting-fade-duration, 1000ms) ease-in-out,
-    clip-path var(--waiting-fade-duration, 1000ms) ease-in-out;
+    mask-size var(--waiting-fade-duration, 1000ms) ease-in-out,
+    -webkit-mask-size var(--waiting-fade-duration, 1000ms) ease-in-out;
+  mask-image: radial-gradient(
+    circle at center,
+    rgb(0 0 0 / 100%) calc(100% - var(--waiting-reveal-softness, 12%)),
+    rgb(0 0 0 / 0%) 100%
+  );
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: 0% 0%;
+  /* stylelint-disable property-no-vendor-prefix */
+  -webkit-mask-image: radial-gradient(
+    circle at center,
+    rgb(0 0 0 / 100%) calc(100% - var(--waiting-reveal-softness, 12%)),
+    rgb(0 0 0 / 0%) 100%
+  );
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: 0% 0%;
+  /* stylelint-enable property-no-vendor-prefix */
 }
 
 .frame-visible {
   opacity: 1;
-  clip-path: inset(0 0 0 0);
+  mask-size: var(--waiting-reveal-mask-visible-size, 140%)
+    var(--waiting-reveal-mask-visible-size, 140%);
+  /* stylelint-disable property-no-vendor-prefix */
+  -webkit-mask-size: var(--waiting-reveal-mask-visible-size, 140%)
+    var(--waiting-reveal-mask-visible-size, 140%);
+  /* stylelint-enable property-no-vendor-prefix */
 }
 
 .frame-asset {

--- a/website/src/components/ui/Loader/__tests__/waitingSymbolStyle.test.js
+++ b/website/src/components/ui/Loader/__tests__/waitingSymbolStyle.test.js
@@ -20,24 +20,27 @@ import { buildWaitingSymbolStyle } from "../waitingSymbolStyle";
  * 断言：
  *  - 高度变量采用 33vh 与像素值的 min 表达式。
  *  - 纵横比变量保留 6 位小数精度。
+ *  - 羽化与遮罩尺寸变量根据素材尺寸推导后写入。
  *  - 渐隐时长与素材地址均写入对应变量。
  * 边界/异常：
  *  - 若后续新增参数，此测试需同步更新以维持语义准确。
  */
- it("GivenDimensions_WhenBuildingStyle_ThenReturnsCssVariables", () => {
-   const style = buildWaitingSymbolStyle(
-     { width: 640, height: 360 },
-     780,
-     'url("asset.svg")',
-   );
+it("GivenDimensions_WhenBuildingStyle_ThenReturnsCssVariables", () => {
+  const style = buildWaitingSymbolStyle(
+    { width: 640, height: 360 },
+    780,
+    'url("asset.svg")',
+  );
 
-   expect(style).toEqual({
-     "--waiting-frame-height": "min(33vh, 360px)",
-     "--waiting-frame-aspect-ratio": Number((640 / 360).toFixed(6)),
-     "--waiting-fade-duration": "780ms",
-     "--waiting-frame-image": 'url("asset.svg")',
-   });
- });
+  expect(style).toEqual({
+    "--waiting-frame-height": "min(33vh, 360px)",
+    "--waiting-frame-aspect-ratio": Number((640 / 360).toFixed(6)),
+    "--waiting-reveal-softness": "13.33%",
+    "--waiting-reveal-mask-visible-size": "130%",
+    "--waiting-fade-duration": "780ms",
+    "--waiting-frame-image": 'url("asset.svg")',
+  });
+});
 
 /**
  * 测试目标：当尺寸入参非法时，函数应抛出语义化错误阻止渲染。
@@ -49,12 +52,8 @@ import { buildWaitingSymbolStyle } from "../waitingSymbolStyle";
  * 边界/异常：
  *  - 同时覆盖 width 非数值等情况，确保防御性逻辑完整。
  */
- it("GivenInvalidDimensions_WhenBuildingStyle_ThenThrows", () => {
-   expect(() =>
-     buildWaitingSymbolStyle(
-       { width: 320, height: 0 },
-       500,
-       "url('asset.svg')",
-     ),
-   ).toThrow(/dimensions/);
- });
+it("GivenInvalidDimensions_WhenBuildingStyle_ThenThrows", () => {
+  expect(() =>
+    buildWaitingSymbolStyle({ width: 320, height: 0 }, 500, "url('asset.svg')"),
+  ).toThrow(/dimensions/);
+});

--- a/website/src/components/ui/Loader/waitingSymbolStyle.js
+++ b/website/src/components/ui/Loader/waitingSymbolStyle.js
@@ -14,6 +14,10 @@
  */
 const WAITING_FRAME_HEIGHT_VH = "33vh";
 const WAITING_FRAME_PRECISION = 6;
+// 设计权衡：24px 羽化宽度可兼顾桌面与移动端，必要时可提炼为主题配置。
+const WAITING_REVEAL_FEATHER_PX = 24;
+// 确保遮罩在放大后完全覆盖素材，避免因 rounding 截断边缘。
+const WAITING_REVEAL_VISIBLE_SCALE_FLOOR = 130;
 
 function assertValidDimensions(dimensions) {
   if (!dimensions || typeof dimensions !== "object") {
@@ -30,15 +34,63 @@ function formatHeightLimit(heightPx) {
 }
 
 function computeAspectRatio(dimensions) {
-  return Number((dimensions.width / dimensions.height).toFixed(WAITING_FRAME_PRECISION));
+  return Number(
+    (dimensions.width / dimensions.height).toFixed(WAITING_FRAME_PRECISION),
+  );
 }
 
-export function buildWaitingSymbolStyle(dimensions, fadeDurationMs, frameImageValue) {
+/**
+ * 意图：依据素材尺寸推导淡入淡出边界的羽化宽度与遮罩放大倍数。
+ * 输入：Loader 素材的像素宽高，需为有限正数。
+ * 输出：用于 CSS 变量的百分比字符串，分别代表羽化比例与遮罩放大倍率。
+ * 流程：
+ *  1) 以较短边作为基准，得到半径后计算羽化像素所占的比例；
+ *  2) 对比例设置上限与下限，保证大屏不至于过度锐利，小屏也不会糊成一团；
+ *  3) 根据比例推导遮罩放大倍数，确保动画结束时不会截断素材边缘。
+ * 错误处理：若尺寸非法，回退到保守的默认值，避免运行时抛错影响加载体验。
+ * 复杂度：常量时间与空间。
+ */
+function computeRevealSoftness(dimensions) {
+  const minSide = Math.min(dimensions.width, dimensions.height);
+  if (!Number.isFinite(minSide) || minSide <= 0) {
+    return {
+      softnessPercent: "12%",
+      visibleScalePercent: "140%",
+    };
+  }
+
+  const radius = minSide / 2;
+  const normalizedFeather = Math.min(WAITING_REVEAL_FEATHER_PX / radius, 0.45);
+  const softnessPercentValue = Math.max(normalizedFeather * 100, 8);
+  const visibleScalePercentValue = Math.max(
+    WAITING_REVEAL_VISIBLE_SCALE_FLOOR,
+    Math.round(100 + normalizedFeather * 100),
+  );
+
+  return {
+    softnessPercent: `${softnessPercentValue.toFixed(2)}%`,
+    visibleScalePercent: `${visibleScalePercentValue}%`,
+  };
+}
+
+export function buildWaitingSymbolStyle(
+  dimensions,
+  fadeDurationMs,
+  frameImageValue,
+) {
   assertValidDimensions(dimensions);
   const style = {
     "--waiting-frame-height": formatHeightLimit(dimensions.height),
     "--waiting-frame-aspect-ratio": computeAspectRatio(dimensions),
   };
+
+  const {
+    softnessPercent: revealSoftness,
+    visibleScalePercent: revealVisibleScale,
+  } = computeRevealSoftness(dimensions);
+
+  style["--waiting-reveal-softness"] = revealSoftness;
+  style["--waiting-reveal-mask-visible-size"] = revealVisibleScale;
 
   if (Number.isFinite(fadeDurationMs)) {
     style["--waiting-fade-duration"] = `${fadeDurationMs}ms`;


### PR DESCRIPTION
## Summary
- replace the loader clip-path reveal with a radial mask transition to soften fade boundaries
- derive reveal softness and mask scaling variables in `buildWaitingSymbolStyle`
- update unit coverage to assert the new CSS variables

## Testing
- npm run test -- waitingSymbolStyle
- npx eslint --fix src/components/ui/Loader/Loader.jsx src/components/ui/Loader/waitingSymbolStyle.js src/components/ui/Loader/__tests__/waitingSymbolStyle.test.js
- npx stylelint --fix src/components/ui/Loader/Loader.module.css
- npx prettier -w src/components/ui/Loader/waitingSymbolStyle.js src/components/ui/Loader/__tests__/waitingSymbolStyle.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e4e3581940833292ed3f9787a218cd