### PR TITLE
Enable share options for unauthenticated users

### DIFF
--- a/website/src/components/OutputToolbar/index.jsx
+++ b/website/src/components/OutputToolbar/index.jsx
@@ -259,10 +259,10 @@ function OutputToolbar({
   );
   const shareButtonDisabled =
     disabled ||
-    !user ||
     !canShare ||
     !shareMenuAvailable ||
     shareCapabilities?.canShare === false;
+  // 设计取舍：分享需向未注册访客开放，因而不再依赖 user；仍保留其他禁用条件避免误触。
 
   useEffect(() => {
     if (!shareMenuAvailable || shareButtonDisabled) {


### PR DESCRIPTION
## Summary
- allow the dictionary toolbar share button to remain available without requiring a signed-in user while preserving other disable conditions
- extend the OutputToolbar test suite to cover guest access to the share menu and both copy-link and export-image flows

## Testing
- npm run test -- OutputToolbar
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4e38fa6a48332be2cfbd6de6d795e