### PR TITLE
Adjust report issue modal gutter spacing

### DIFF
--- a/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
@@ -29,6 +29,13 @@
     color-mix(in srgb, var(--shadow-color) 24%, transparent);
 
   /*
+   * 通过单独的留白令牌统一内边距尺度，既方便未来接入响应式调整，也能在保证 SettingsSurface 宽度约束的同时，
+   * 为模态与内容体之间预留更充裕的呼吸空间。
+   * 备选方案：直接调整 SettingsSurface 的 width 或 margin，但那会破坏组件在其他上下文下的尺寸语义，故弃用。
+   */
+  --report-modal-gutter: clamp(var(--space-6), 7vw, var(--space-9));
+
+  /*
    * 依据订阅面板的新版视觉规范，压缩圆角以强调面板的建筑感，
    * 同时通过提升描边对比度（外层 64%、内层 58%）让层级关系更清晰。
    * 备选方案：保留旧描边（46%）但改圆角，测试后发现会让面板显得浮，故弃用。
@@ -39,7 +46,7 @@
 :global(.modal-content).modal-shell {
   background: var(--report-modal-surface);
   color: var(--preferences-panel-text, var(--color-text));
-  padding: clamp(var(--space-6), 5vw, var(--space-7));
+  padding: var(--report-modal-gutter);
   border-radius: var(--report-modal-radius);
   border: 1px solid var(--report-modal-border);
   box-shadow: var(--report-modal-shadow);
@@ -381,6 +388,13 @@
 }
 
 @media (width <= 599px) {
+  .modal-shell {
+    /*
+     * 在窄屏下收敛外层留白以避免可视区域被过度压缩，同时保留最小安全间距防止内容贴边。
+     */
+    --report-modal-gutter: clamp(var(--space-4), 8vw, var(--space-6));
+  }
+
   .summary {
     grid-template-columns: 1fr;
     padding: clamp(var(--space-3), 4vw, var(--space-4));


### PR DESCRIPTION
## Summary
- add a dedicated gutter token so the report issue modal keeps consistent breathing room around the SettingsSurface
- tune the gutter responsively on small screens to avoid edge-to-edge layouts

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e4e79f44208332baebe2b29cb2b89c