### PR TITLE
Add language scoped history description to settings

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -119,6 +119,8 @@ export default {
   settingsDataRetentionOption_365d: "365 days",
   settingsDataRetentionOption_forever: "Keep forever",
   settingsDataLanguageLabel: "Language history",
+  settingsDataLanguageDescription:
+    "Only clears saved lookups for the selected language.",
   settingsDataClearLanguagePlaceholder: "No language-specific history yet",
   settingsDataActionsLabel: "Data actions",
   settingsDataClearAll: "Erase all history",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -106,6 +106,8 @@ export default {
   settingsDataRetentionOption_365d: "365 天",
   settingsDataRetentionOption_forever: "永久保留",
   settingsDataLanguageLabel: "按语言清理",
+  settingsDataLanguageDescription:
+    "仅删除所选语言的查询历史，不影响其他语种的留存。",
   settingsDataClearLanguagePlaceholder: "暂无按语言分类的历史记录",
   settingsDataActionsLabel: "数据操作",
   settingsDataClearAll: "清空全部历史",

--- a/website/src/pages/preferences/sections/DataSection.jsx
+++ b/website/src/pages/preferences/sections/DataSection.jsx
@@ -206,6 +206,9 @@ function DataSection({ title, message, headingId, descriptionId }) {
     "Choose how long records stay before we prune them.";
 
   const languageLabel = t.settingsDataLanguageLabel || "Language history";
+  const languageDescription =
+    t.settingsDataLanguageDescription ||
+    "Only clears saved lookups for the selected language.";
   const languagePlaceholder =
     t.settingsDataClearLanguagePlaceholder || "No language history yet";
 
@@ -453,6 +456,7 @@ function DataSection({ title, message, headingId, descriptionId }) {
           <label htmlFor={languageFieldId} className={styles["control-label"]}>
             {languageLabel}
           </label>
+          <p className={styles.description}>{languageDescription}</p>
           {languageOptions.length > 0 ? (
             <div className={styles["language-shell"]}>
               <LanguageMenu

--- a/website/src/pages/preferences/sections/__tests__/DataSection.test.jsx
+++ b/website/src/pages/preferences/sections/__tests__/DataSection.test.jsx
@@ -20,6 +20,8 @@ const translations = {
   settingsDataRetentionOption_365d: "365 days",
   settingsDataRetentionOption_forever: "Keep forever",
   settingsDataLanguageLabel: "Language history",
+  settingsDataLanguageDescription:
+    "Only clears saved lookups for the selected language.",
   settingsDataClearLanguage: "Clear selected language",
   settingsDataClearLanguagePlaceholder: "No language history",
   settingsDataActionsLabel: "Data actions",
@@ -137,6 +139,39 @@ test("Given section message When rendering Then description linked for accessibi
 
   expect(description).toHaveAttribute("id", "data-description");
   expect(section).toHaveAttribute("aria-describedby", "data-description");
+});
+
+/**
+ * 测试目标：语言清理控制区域呈现说明文字，提示仅影响所选语言。
+ * 前置条件：默认翻译文案已注入。
+ * 步骤：
+ *  1) 渲染 DataSection；
+ *  2) 查询语言描述文本与容器。
+ * 断言：
+ *  - 描述文本等于预期翻译；
+ *  - 描述文本与语言标签处于同一控制容器内。
+ * 边界/异常：
+ *  - 若描述缺失，用户可能误认为会清空全部历史。
+ */
+test("Given language scoped controls When rendering Then language description clarifies scope", () => {
+  render(
+    <DataSection
+      title="Data"
+      message="Control your data"
+      headingId="data-heading"
+      descriptionId="data-description"
+    />,
+  );
+
+  const description = screen.getByText(
+    translations.settingsDataLanguageDescription,
+  );
+  expect(description).toBeInTheDocument();
+
+  const fieldContainer = description.closest("div");
+  expect(fieldContainer).toContainElement(
+    screen.getByText(translations.settingsDataLanguageLabel),
+  );
 });
 
 /**


### PR DESCRIPTION
## Summary
- surface explanatory copy under the language-specific history controls in the data section
- extend English and Chinese locale bundles with the language clearing description
- cover the new text with a regression test alongside existing DataSection cases

## Testing
- npm test -- DataSection.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e4fcf2d4688332a34c83b019efda65