### PR TITLE
Fix lint issues in preferences data export

### DIFF
--- a/website/src/pages/preferences/sections/DataSection.jsx
+++ b/website/src/pages/preferences/sections/DataSection.jsx
@@ -171,11 +171,6 @@ function DataSection({ title, message, headingId, descriptionId }) {
     [t],
   );
 
-  const selectedPolicy = useMemo(
-    () => getRetentionPolicyById(retentionPolicyId) ?? null,
-    [retentionPolicyId],
-  );
-
   const languageOptions = useMemo(
     () => toLanguageOptions(history, t),
     [history, t],

--- a/website/src/pages/preferences/sections/historyExportSerializer.js
+++ b/website/src/pages/preferences/sections/historyExportSerializer.js
@@ -319,14 +319,17 @@ class HistoryCsvSerializerTemplate {
     return rows.map((row) => toCsvRow(row)).join("\r\n");
   }
 
-  // eslint-disable-next-line class-methods-use-this
   buildHeader() {
-    return [];
+    // 采用模板方法模式，通过显式抛错约束子类覆写，避免静默回退默认空结构。 
+    throw new Error(
+      `${this.constructor.name} must implement buildHeader(context)`,
+    );
   }
 
-  // eslint-disable-next-line class-methods-use-this
   buildRows() {
-    return [];
+    throw new Error(
+      `${this.constructor.name} must implement buildRows(historyItems, context)`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the unused retention policy memoization from the preferences data section to satisfy eslint
- enforce the template-method override contract in the history CSV serializer instead of suppressing lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e501e976148332a2b6b25d8abcb70d