### PR TITLE
feat: refresh report modal visual language

### DIFF
--- a/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
+++ b/website/src/features/dictionary-experience/components/ReportIssueModal.module.css
@@ -87,28 +87,18 @@
   height: clamp(36px, 6vw, 44px);
   border-radius: var(--radius-xl);
   border: 1px solid transparent;
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-surface, var(--app-bg)) 80%,
-    transparent
-  );
+  background: transparent;
   color: var(--preferences-panel-text, var(--color-text));
   font-size: clamp(20px, 3vw, 22px);
   line-height: 1;
   cursor: pointer;
   transition:
-    background 160ms ease,
     border-color 160ms ease,
     transform 160ms ease,
     box-shadow 160ms ease;
 }
 
 .header-close:hover {
-  background: color-mix(
-    in srgb,
-    var(--preferences-panel-ring, var(--highlight-color)) 18%,
-    var(--app-bg)
-  );
   border-color: color-mix(
     in srgb,
     var(--preferences-panel-ring, var(--highlight-color)) 45%,
@@ -192,6 +182,10 @@
   gap: clamp(var(--space-3), 3vw, var(--space-4));
 }
 
+.fieldset legend + * {
+  margin-top: clamp(var(--space-3), 3vw, var(--space-4));
+}
+
 .legend {
   margin: 0;
   font-size: var(--text-sm);
@@ -208,9 +202,11 @@
    */
   display: inline-flex;
   flex-wrap: wrap;
-  gap: clamp(var(--space-1), 1.6vw, var(--space-2));
-  padding: clamp(var(--space-1), 1.6vw, var(--space-2));
-  border-radius: var(--radius-2xl);
+  gap: var(--space-2);
+  padding: var(--space-1);
+  border-radius: 16px;
+  border: 1px solid
+    color-mix(in srgb, var(--preferences-panel-border, var(--border-color)) 45%, transparent);
   background: color-mix(
     in srgb,
     var(--preferences-panel-surface, var(--app-bg)) 82%,
@@ -223,15 +219,13 @@
   align-items: center;
   justify-content: center;
   min-width: 96px;
-  padding:
-    clamp(var(--space-2), 2.6vw, var(--space-3))
-    clamp(var(--space-4), 4vw, var(--space-5));
-  border: none;
-  border-radius: var(--radius-xl);
+  padding: 10px 18px;
+  border: 1px solid transparent;
+  border-radius: 12px;
   background: transparent;
   color: color-mix(
     in srgb,
-    var(--preferences-panel-muted, currentColor) 90%,
+    var(--preferences-panel-muted, var(--color-text)) 88%,
     transparent
   );
   font-size: var(--text-sm);
@@ -239,13 +233,19 @@
   letter-spacing: 0.04em;
   cursor: pointer;
   transition:
-    background 160ms ease,
-    color 160ms ease,
-    transform 160ms ease;
+    background 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .segment:focus-visible {
   outline: none;
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, var(--highlight-color)) 45%,
+    transparent
+  );
   box-shadow: 0 0 0 3px
     color-mix(in srgb, var(--preferences-panel-ring, var(--highlight-color)) 32%, transparent);
   transform: translateY(-1px);
@@ -265,6 +265,11 @@
   background: color-mix(
     in srgb,
     var(--preferences-panel-surface, var(--app-bg)) 96%,
+    transparent
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--preferences-panel-ring, var(--highlight-color)) 28%,
     transparent
   );
   color: var(--preferences-panel-text, var(--color-text));
@@ -340,11 +345,7 @@
   padding: 0.85rem 1.6rem;
   border-radius: var(--radius-lg);
   border: none;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--primary-bg) 94%, transparent) 0%,
-    color-mix(in srgb, var(--primary-bg) 72%, transparent) 100%
-  );
+  background: var(--primary-bg);
   color: var(--primary-color);
   font-weight: var(--font-semibold);
   letter-spacing: 0.08em;
@@ -354,7 +355,8 @@
     color-mix(in srgb, var(--shadow-color) 28%, transparent);
   transition:
     transform 160ms ease,
-    box-shadow 160ms ease;
+    box-shadow 160ms ease,
+    background 160ms ease;
 }
 
 .primary-button:focus-visible {
@@ -373,6 +375,7 @@
 
 .primary-button:hover:not(:disabled) {
   transform: translateY(-2px);
+  background: color-mix(in srgb, var(--primary-bg) 94%, transparent);
   box-shadow: 0 28px 64px
     color-mix(in srgb, var(--shadow-color) 34%, transparent);
 }

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -349,7 +349,7 @@ export default {
   reportCategoryHint: "请选择最贴近问题的选项。",
   reportDescriptionLabel: "详细描述（选填）",
   reportDescriptionPlaceholder: "补充说明、样例或上下文信息。",
-  reportSubmit: "提交举报",
+  reportSubmit: "提交",
   reportSubmitting: "提交中...",
   reportCancel: "取消",
   reportErrorMessage: "暂时无法提交举报，请稍后重试。",


### PR DESCRIPTION
## Summary
- remove the report modal close button fill and restyle the issue type segments to mirror the preferences design system
- switch the submit action to a solid primary button and harmonize spacings between category controls and the description field
- rename the Chinese submit copy to “提交” to match the updated call-to-action

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e50582e5748332a291752b8341ae30