### PR TITLE
Enhance subscription redemption feedback

### DIFF
--- a/website/src/i18n/common/en.js
+++ b/website/src/i18n/common/en.js
@@ -324,7 +324,10 @@ export default {
   subscriptionRedeemTitle: "Redeem exclusive benefits",
   subscriptionRedeemPlaceholder: "Enter 16-character code",
   subscriptionRedeemButton: "Redeem now",
-  subscriptionRedeemSuccessToast: "Redeemed successfully. Your benefits are active.",
+  subscriptionRedeemSuccessToast:
+    "Redeemed successfully. Your benefits are active.",
+  subscriptionRedeemFailureToast:
+    "Unable to redeem at the moment. Please try again.",
   subscriptionFeatureColumnLabel: "Feature",
   toastDismissLabel: "Dismiss notification",
   pricingFixedNote: "Pricing is pegged per region and not tied to FX rates.",

--- a/website/src/i18n/common/zh.js
+++ b/website/src/i18n/common/zh.js
@@ -307,6 +307,7 @@ export default {
   subscriptionRedeemPlaceholder: "请输入兑换码（16 位）",
   subscriptionRedeemButton: "立即兑换",
   subscriptionRedeemSuccessToast: "兑换成功，专享权益已立即生效。",
+  subscriptionRedeemFailureToast: "兑换失败，请稍后重试。",
   subscriptionFeatureColumnLabel: "能力项",
   toastDismissLabel: "关闭提示",
   pricingFixedNote: "本地区价格为固定面额，不随汇率波动调整。",

--- a/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
+++ b/website/src/pages/preferences/__tests__/usePreferenceSections.test.js
@@ -196,6 +196,7 @@ const createTranslations = (overrides = {}) => ({
   subscriptionRedeemPlaceholder: "Code",
   subscriptionRedeemButton: "Redeem now",
   subscriptionRedeemSuccessToast: "Redeemed successfully",
+  subscriptionRedeemFailureToast: "Redeem failed. Try again.",
   subscriptionFeatureColumnLabel: "Feature",
   pricingFixedNote: "Fixed",
   pricingTaxIncluded: "Tax included",
@@ -548,16 +549,24 @@ test("Given redeem failure When onRedeem invoked Then error bubbles without user
     (section) => section.id === "subscription",
   );
 
-  await expect(
-    subscriptionSection.componentProps.onRedeem("bad-code"),
-  ).rejects.toThrow("invalid-code");
+  await act(async () => {
+    await expect(
+      subscriptionSection.componentProps.onRedeem("bad-code"),
+    ).rejects.toThrow("invalid-code");
+  });
 
   expect(consoleErrorStub).toHaveBeenCalledWith(
     "Failed to redeem subscription code",
     failure,
   );
   expect(setUserMock).not.toHaveBeenCalled();
-  expect(result.current.feedback.redeemToast.open).toBe(false);
+  await waitFor(() => {
+    expect(result.current.feedback.redeemToast).toMatchObject({
+      open: true,
+      message: `${translations.subscriptionRedeemFailureToast} (invalid-code)`,
+      closeLabel: translations.toastDismissLabel,
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary
- add toast variants so subscription redemption can show success and failure notifications with appropriate styling
- surface API error reasons in the failure toast with localized fallbacks for en/zh
- extend preference section tests to cover failure feedback handling

## Testing
- npm run lint
- npm run test -- --runTestsByPath src/pages/preferences/__tests__/usePreferenceSections.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5077bd7348332a46d5b366d10b60b