### PR TITLE
Add toast feedback for successful word issue reports

### DIFF
--- a/website/src/features/dictionary-experience/DictionaryExperience.jsx
+++ b/website/src/features/dictionary-experience/DictionaryExperience.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 import MessagePopup from "@/components/ui/MessagePopup";
+import Toast from "@/components/ui/Toast";
 import Layout from "@/components/Layout";
 import HistoryDisplay from "@/components/ui/HistoryDisplay";
 import { DictionaryEntryView } from "@/components/ui/DictionaryEntry";
@@ -51,6 +52,8 @@ export default function DictionaryExperience() {
     popupOpen,
     popupMsg,
     closePopup,
+    toast,
+    closeToast,
     dictionaryTargetLanguageLabel,
     dictionarySourceLanguageLabel,
     dictionarySwapLanguagesLabel,
@@ -246,6 +249,15 @@ export default function DictionaryExperience() {
         onSubmit={reportDialogHandlers.submit}
       />
       <MessagePopup open={popupOpen} message={popupMsg} onClose={closePopup} />
+      <Toast
+        open={toast?.open}
+        message={toast?.message}
+        duration={toast?.duration}
+        backgroundColor={toast?.backgroundColor}
+        textColor={toast?.textColor}
+        closeLabel={toast?.closeLabel}
+        onClose={closeToast}
+      />
     </>
   );
 }

--- a/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryExperience.js
@@ -23,6 +23,7 @@ import { useDataGovernanceStore } from "@/store/dataGovernanceStore.ts";
 import { DEFAULT_MODEL } from "@/config";
 import { useDictionaryLanguageConfig } from "./useDictionaryLanguageConfig.js";
 import { useDictionaryPopup } from "./useDictionaryPopup.js";
+import { useDictionaryToast } from "./useDictionaryToast.js";
 import { useDictionaryLookupController } from "./useDictionaryLookupController.ts";
 import {
   DICTIONARY_EXPERIENCE_VIEWS,
@@ -143,6 +144,7 @@ export function useDictionaryExperience() {
     handleSwapLanguages,
   } = useDictionaryLanguageConfig({ t });
   const { popupOpen, popupMsg, showPopup, closePopup } = useDictionaryPopup();
+  const { state: toastState, showToast, closeToast } = useDictionaryToast();
   const {
     state: reportDialogState,
     categories: reportDialogCategories,
@@ -154,7 +156,7 @@ export function useDictionaryExperience() {
   } = useWordIssueReportDialog({
     onSuccess: () => {
       const message = t.reportSuccess ?? t.report ?? "Report";
-      showPopup(message);
+      showToast(message);
     },
     onError: () => {
       const message = t.reportFailed ?? t.report ?? "Report";
@@ -379,11 +381,13 @@ export function useDictionaryExperience() {
     setCurrentTerm("");
     setActiveView(DICTIONARY_EXPERIENCE_VIEWS.DICTIONARY);
     focusInput();
+    closeToast();
   }, [
     cancelActiveLookup,
     clearCopyFeedbackResetTimer,
     focusInput,
     setActiveView,
+    closeToast,
   ]);
 
   const { toggleFavoriteEntry } = useAppShortcuts({
@@ -1079,6 +1083,8 @@ export function useDictionaryExperience() {
     popupOpen,
     popupMsg,
     closePopup,
+    toast: toastState,
+    closeToast,
     handleCopy,
     reportDialog,
     reportDialogHandlers,

--- a/website/src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx
@@ -323,6 +323,85 @@ describe("useDictionaryExperience", () => {
   });
 
   /**
+   * 测试目标：举报成功后应通过 toast 提示成功信息。
+   * 前置条件：mock 举报接口返回成功，完成一次查询以激活举报按钮。
+   * 步骤：
+   *  1) 输入并提交查询文本；
+   *  2) 触发举报弹窗并执行提交；
+   *  3) 等待提交 Promise 完成。
+   * 断言：
+   *  - toast.open 为 true 且 message 为 reportSuccess；
+   *  - popup 渠道保持关闭以避免重复提示。
+   * 边界/异常：
+   *  - 错误路径在后续用例覆盖。
+   */
+  it("shows toast when word issue report submission succeeds", async () => {
+    submitWordReportMock.mockResolvedValue({ id: 1 });
+    const { result } = renderHook(() => useDictionaryExperience());
+
+    await act(async () => {
+      result.current.setText("alpha");
+    });
+
+    await act(async () => {
+      await result.current.handleSend({ preventDefault: jest.fn() });
+    });
+
+    act(() => {
+      result.current.dictionaryActionBarProps.onReport();
+    });
+
+    await act(async () => {
+      await result.current.reportDialogHandlers.submit();
+    });
+
+    expect(submitWordReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ term: "alpha" }),
+    );
+    expect(result.current.toast).toMatchObject({
+      open: true,
+      message: "报告成功",
+    });
+    expect(result.current.popupOpen).toBe(false);
+  });
+
+  /**
+   * 测试目标：举报失败时沿用弹窗渠道提示错误并保持 toast 关闭。
+   * 前置条件：mock 举报接口抛出异常。
+   * 步骤：
+   *  1) 激活举报弹窗；
+   *  2) 执行提交触发异常。
+   * 断言：
+   *  - popupMsg 为 reportFailed；
+   *  - toast.open 为 false。
+   * 边界/异常：
+   *  - 错误消息为空的场景需后续补充。
+   */
+  it("uses popup channel when word issue report submission fails", async () => {
+    submitWordReportMock.mockRejectedValue(new Error("unavailable"));
+    const { result } = renderHook(() => useDictionaryExperience());
+
+    await act(async () => {
+      result.current.setText("beta");
+    });
+
+    await act(async () => {
+      await result.current.handleSend({ preventDefault: jest.fn() });
+    });
+
+    act(() => {
+      result.current.dictionaryActionBarProps.onReport();
+    });
+
+    await act(async () => {
+      await result.current.reportDialogHandlers.submit();
+    });
+
+    expect(result.current.popupMsg).toBe("报告失败");
+    expect(result.current.toast.open).toBe(false);
+  });
+
+  /**
    * 测试路径：无用户登录时提交查询，需立即引导至登录页。
    * 步骤：构造空用户上下文，调用 handleSend。
    * 断言：应触发导航到 /login，且不会调用历史写入。

--- a/website/src/features/dictionary-experience/hooks/useDictionaryToast.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryToast.js
@@ -1,0 +1,71 @@
+/**
+ * 背景：
+ *  - 字典体验页的即时反馈目前依赖遮罩弹窗，缺乏轻量的顶部提示来承载成功类消息。
+ * 目的：
+ *  - 提供一个集中管理 Toast 状态的 Hook，支持按需展示消息并复用既有 Toast 组件。
+ * 关键决策与取舍：
+ *  - 采用不可变 state 对象并暴露 show/close 操作，避免外部直接修改内部结构；
+ *  - 仅存储最小必要字段，其他视觉属性由调用方按需传入，保持扩展弹性。
+ * 影响范围：
+ *  - 字典体验页及未来复用该 Hook 的功能模块。
+ * 演进与TODO：
+ *  - 后续可扩展队列或并发策略，支持多个 Toast 排队展示。
+ */
+import { useCallback, useMemo, useState } from "react";
+
+const DEFAULT_DURATION = 3000;
+
+const INITIAL_STATE = Object.freeze({
+  open: false,
+  message: "",
+  duration: DEFAULT_DURATION,
+  backgroundColor: undefined,
+  textColor: undefined,
+  closeLabel: undefined,
+});
+
+const resolveDuration = (candidate, fallback) => {
+  if (typeof candidate !== "number") return fallback;
+  if (!Number.isFinite(candidate)) return fallback;
+  if (candidate <= 0) return fallback;
+  return candidate;
+};
+
+export function useDictionaryToast({ defaultDuration = DEFAULT_DURATION } = {}) {
+  const [state, setState] = useState(INITIAL_STATE);
+
+  const showToast = useCallback(
+    (message, options = {}) => {
+      if (!message) {
+        return;
+      }
+      setState({
+        open: true,
+        message,
+        duration: resolveDuration(options.duration, defaultDuration),
+        backgroundColor: options.backgroundColor,
+        textColor: options.textColor,
+        closeLabel: options.closeLabel,
+      });
+    },
+    [defaultDuration],
+  );
+
+  const closeToast = useCallback(() => {
+    setState((current) => ({ ...current, open: false }));
+  }, []);
+
+  const toastState = useMemo(
+    () => ({
+      open: state.open,
+      message: state.message,
+      duration: state.duration,
+      backgroundColor: state.backgroundColor,
+      textColor: state.textColor,
+      closeLabel: state.closeLabel,
+    }),
+    [state],
+  );
+
+  return { state: toastState, showToast, closeToast };
+}

--- a/website/src/features/dictionary-experience/hooks/useDictionaryToast.test.js
+++ b/website/src/features/dictionary-experience/hooks/useDictionaryToast.test.js
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { useDictionaryToast } from "./useDictionaryToast.js";
+
+describe("useDictionaryToast", () => {
+  /**
+   * 测试目标：调用 showToast 应打开提示并应用自定义配置。
+   * 前置条件：使用默认配置初始化 Hook。
+   * 步骤：
+   *  1) 执行 showToast 传入消息与覆写参数；
+   *  2) 读取当前 state。
+   * 断言：
+   *  - open 为 true；
+   *  - 消息与自定义属性被写入。
+   * 边界/异常：
+   *  - duration 需回退到默认值时由其他用例覆盖。
+   */
+  it("opens toast with provided overrides", () => {
+    const { result } = renderHook(() =>
+      useDictionaryToast({ defaultDuration: 5000 }),
+    );
+
+    act(() => {
+      result.current.showToast("已完成", {
+        duration: 1200,
+        backgroundColor: "#111111",
+        textColor: "#fefefe",
+        closeLabel: "关闭提示",
+      });
+    });
+
+    expect(result.current.state).toMatchObject({
+      open: true,
+      message: "已完成",
+      duration: 1200,
+      backgroundColor: "#111111",
+      textColor: "#fefefe",
+      closeLabel: "关闭提示",
+    });
+  });
+
+  /**
+   * 测试目标：调用 closeToast 应仅关闭提示不清空配置。
+   * 前置条件：先打开一次 Toast。
+   * 步骤：
+   *  1) showToast 写入消息；
+   *  2) closeToast 关闭提示。
+   * 断言：
+   *  - open 变为 false；
+   *  - 其他字段保持最近一次的值。
+   * 边界/异常：
+   *  - 若后续需要重置字段，可在 Hook 内新增重置逻辑。
+   */
+  it("closes toast while retaining last payload", () => {
+    const { result } = renderHook(() => useDictionaryToast());
+
+    act(() => {
+      result.current.showToast("Saved");
+    });
+
+    act(() => {
+      result.current.closeToast();
+    });
+
+    expect(result.current.state).toMatchObject({
+      open: false,
+      message: "Saved",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated dictionary toast hook so the experience layer can emit top-level success messages
- trigger the toast after successful word issue reports and surface the toast in the dictionary experience UI while keeping existing popup flows for errors
- add focused unit tests covering the toast hook and the updated report submission feedback paths

## Testing
- npm test -- --runTestsByPath src/features/dictionary-experience/hooks/useDictionaryToast.test.js src/features/dictionary-experience/hooks/useDictionaryExperience.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e50cfdde608332a7fa34b4ad68c52d