### PR TITLE
feat: surface verification code success via toast

### DIFF
--- a/website/src/components/__tests__/AuthForm.test.jsx
+++ b/website/src/components/__tests__/AuthForm.test.jsx
@@ -9,6 +9,9 @@ jest.unstable_mockModule("@/context", () => ({
   useTheme: () => ({ resolvedTheme: "light" }),
   useLocale: () => ({ locale: "en-US" }),
   useApiContext: () => ({ request: async () => {} }),
+  useUser: () => ({ setUser: jest.fn() }),
+  useHistory: () => ({ entries: [] }),
+  useFavorites: () => ({ items: [] }),
   useLanguage: () => ({
     lang: "en",
     t: {
@@ -26,8 +29,11 @@ jest.unstable_mockModule("@/context", () => ({
       codeRequestSuccess: "Verification code sent. Please check your inbox.",
       codeRequestFailed: "Failed to send verification code",
       codeRequestInvalidMethod: "Unavailable",
+      toastDismissLabel: "Dismiss notification",
     },
   }),
+  useKeyboardShortcutContext: () => ({ shortcuts: [] }),
+  KEYBOARD_SHORTCUT_RESET_ACTION: "reset",
 }));
 
 const iconRegistry = {
@@ -233,11 +239,11 @@ describe("AuthForm", () => {
       }),
     );
 
-    expect(
-      await screen.findByText(
-        "Verification code sent. Please check your inbox.",
-      ),
-    ).toBeInTheDocument();
+    const toast = await screen.findByRole("status");
+    expect(toast).toHaveTextContent(
+      "Verification code sent. Please check your inbox.",
+    );
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 
   /**


### PR DESCRIPTION
## Summary
- route AuthForm feedback through popup/toast strategies so verification code success uses the dropdown toast component
- extend AuthForm unit test context mocks and expectations to cover the toast channel

## Testing
- npm run test -- AuthForm

------
https://chatgpt.com/codex/tasks/task_e_68e50d5760c48332a1d5993bd3140b08