### PR TITLE
Align dictionary entry layout with section width

### DIFF
--- a/website/src/components/ui/DictionaryEntry/DictionaryEntry.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntry.module.css
@@ -1,12 +1,13 @@
 .dictionary-entry {
-  width: auto;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 
   /*
-   * 保持词条内容在中心对齐，去除固定 2cm 外边距以适配 Markdown 折叠块；
-   * 通过水平内边距吸收横向留白，避免超出内容区域。
+   * 让词条内容与承载 section 宽度保持一致，避免 Markdown 折叠块产生横向溢出；
+   * 如后续需要限制最大内容宽度，请通过上层容器设置限制而非组件内部写死。
    */
-  margin: 0 auto;
-  max-width: var(--layout-content-max, 100%);
+  margin: 0;
   text-align: justify;
   text-align-last: left;
   font-size: 1rem;

--- a/website/src/components/ui/DictionaryEntry/DictionaryEntryView.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntryView.module.css
@@ -4,6 +4,15 @@
   box-sizing: border-box;
 }
 
+.entry > * {
+  /*
+   * 将 section 内的直接子元素限制为与容器同宽，避免 Markdown 自定义元素撑破布局。
+   */
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
 .definition {
   display: block;
 }

--- a/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.module.css
@@ -3,6 +3,9 @@
   gap: var(--space-3, 16px);
   text-align: left;
   color: var(--app-color);
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .heading {


### PR DESCRIPTION
## Summary
- ensure the dictionary entry article and markdown wrapper always match the surrounding section width to avoid overflow
- enforce section children to inherit the container width so markdown blocks never exceed it

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e5554e3eb8833296b80e3ca3fcd044