### PR TITLE
Ensure dictionary entry text wraps and stays justified

### DIFF
--- a/website/src/components/ui/DictionaryEntry/DictionaryEntry.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryEntry.module.css
@@ -9,7 +9,13 @@
    */
   margin: 0;
   text-align: justify;
-  text-align-last: left;
+  text-align-last: justify;
+
+  /*
+   * 字典释义往往包含长段中文文本；通过 overflow-wrap 强制在容器内断行，
+   * 以满足“display 区域不出现横向滚动或截断”的产品要求，同时兼顾未来多语言场景。
+   */
+  overflow-wrap: anywhere;
   font-size: 1rem;
   font-weight: normal;
 }

--- a/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.module.css
+++ b/website/src/components/ui/DictionaryEntry/DictionaryMarkdown.module.css
@@ -1,17 +1,25 @@
 .wrapper {
   display: grid;
   gap: var(--space-3, 16px);
-  text-align: left;
   color: var(--app-color);
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
+
+  /*
+   * Markdown 片段也需要继承 display 宽度约束并保证中英文文本对齐；
+   * overflow-wrap 覆盖所有块级元素，避免长串字符导致溢出。
+   */
+  text-align: justify;
+  text-align-last: justify;
+  overflow-wrap: anywhere;
 }
 
 .heading {
   font-weight: 600;
   letter-spacing: 0.02em;
   line-height: var(--line-height-snug);
+  text-align: left;
 }
 
 .heading-primary {
@@ -35,6 +43,8 @@
   line-height: var(--line-height-relaxed);
   font-size: 1rem;
   color: inherit;
+  text-align: justify;
+  text-align-last: justify;
 }
 
 .ordered-list,
@@ -43,11 +53,15 @@
   padding-left: var(--space-5, 32px);
   display: grid;
   gap: var(--space-2, 8px);
+  text-align: justify;
+  text-align-last: justify;
 }
 
 .list-item {
   line-height: var(--line-height-comfortable);
   font-size: 1rem;
+  text-align: justify;
+  text-align-last: justify;
 }
 
 .blockquote {
@@ -58,6 +72,8 @@
   font-style: italic;
   background: color-mix(in srgb, var(--color-surface) 80%, transparent);
   border-radius: var(--radius-md, 8px);
+  text-align: justify;
+  text-align-last: justify;
 }
 
 .strong {


### PR DESCRIPTION
## Summary
- ensure dictionary entry containers justify text and wrap long content to avoid overflowing the display region
- update markdown-rendered blocks to inherit justified alignment and width-safe wrapping while keeping heading alignment intact

## Testing
- npm run lint
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68e55c968cac8332ba85bb115356b090