### PR TITLE
refactor: centralize word persistence workflow

### DIFF
--- a/backend/src/main/java/com/glancy/backend/service/support/ResponseMarkdownOrSerializedWordStrategy.java
+++ b/backend/src/main/java/com/glancy/backend/service/support/ResponseMarkdownOrSerializedWordStrategy.java
@@ -1,0 +1,45 @@
+package com.glancy.backend.service.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Word;
+import com.glancy.backend.util.SensitiveDataUtil;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 背景：
+ *  - 同步查询场景下模型通常直接返回 markdown，历史版本希望复用该内容以保持一致展示。\
+ * 目的：
+ *  - 首选响应中的 markdown，若缺失则序列化完整词条作为兜底。\
+ * 关键决策与取舍：
+ *  - 优先复用响应可避免重复序列化；\
+ *  - 回退到序列化而非放弃持久化，确保历史记录仍可查看，代价是遇到序列化异常时只能保存预览文本。\
+ * 影响范围：
+ *  - 默认同步查询路径选用该策略；\
+ *  - 通过上下文暴露的序列化函数可替换为不同格式（如 YAML）。
+ * 演进与TODO：
+ *  - 若未来需要多语言 markdown，可在此策略内注入转换组件。\
+ *  - 可扩展异常分类上报以监控序列化失败率。
+ */
+@Slf4j
+public class ResponseMarkdownOrSerializedWordStrategy implements WordVersionContentStrategy {
+
+    @Override
+    public String resolveContent(WordPersistenceCoordinator.PersistenceContext context, Word savedWord) {
+        WordResponse response = context.response();
+        if (response != null && response.getMarkdown() != null && !response.getMarkdown().isBlank()) {
+            return response.getMarkdown();
+        }
+        try {
+            return context.serializeWord(savedWord);
+        } catch (JsonProcessingException e) {
+            log.warn(
+                "Failed to serialize word '{}' for version content: {}",
+                savedWord.getTerm(),
+                e.getOriginalMessage(),
+                e
+            );
+            return SensitiveDataUtil.previewText(savedWord.getMarkdown());
+        }
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/support/SanitizedStreamingMarkdownStrategy.java
+++ b/backend/src/main/java/com/glancy/backend/service/support/SanitizedStreamingMarkdownStrategy.java
@@ -1,0 +1,36 @@
+package com.glancy.backend.service.support;
+
+import com.glancy.backend.entity.Word;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 背景：
+ *  - 流式响应在聚合后会产出净化 markdown，更贴近用户最终看到的内容。\
+ * 目的：
+ *  - 在流式场景下使用聚合后的净化 markdown 作为历史版本内容。\
+ * 关键决策与取舍：
+ *  - 直接依赖上下文提供的净化文本，避免重复解析；\
+ *  - 当净化文本缺失时回退到词条自带 markdown，取舍是日志中需提示潜在模型异常。\
+ * 影响范围：
+ *  - finalizeStreamingSession 调用该策略；\
+ *  - 若未来引入多段摘要，可在上下文扩展更多字段。
+ * 演进与TODO：
+ *  - 可在净化文本缺失时触发告警链路；\
+ *  - 支持根据用户偏好选择原始流或净化版本。
+ */
+@Slf4j
+public class SanitizedStreamingMarkdownStrategy implements WordVersionContentStrategy {
+
+    @Override
+    public String resolveContent(WordPersistenceCoordinator.PersistenceContext context, Word savedWord) {
+        String sanitized = context.sanitizedMarkdown();
+        if (sanitized == null || sanitized.isBlank()) {
+            log.warn(
+                "Sanitized markdown missing for term '{}', falling back to persisted markdown",
+                savedWord.getTerm()
+            );
+            return savedWord.getMarkdown();
+        }
+        return sanitized;
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/support/WordPersistenceCoordinator.java
+++ b/backend/src/main/java/com/glancy/backend/service/support/WordPersistenceCoordinator.java
@@ -1,0 +1,315 @@
+package com.glancy.backend.service.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.glancy.backend.dto.WordPersonalizationContext;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.DictionaryFlavor;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.SearchResultVersion;
+import com.glancy.backend.entity.Word;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 背景：
+ *  - WordService 在同步与流式路径中都需要执行保存词条、记录同步、版本化与个性化回写的相同步骤。
+ * 目的：
+ *  - 以模板方法封装持久化协作流程，消除 WordService 中分支复制的编排逻辑。
+ * 关键决策与取舍：
+ *  - 选用模板方法而非责任链：流程步骤顺序固定且存在状态依赖（需先保存词条再同步记录），模板方法可显式表达骨架；
+ *  - 通过函数式依赖注入各步骤实现，避免协调器直接依赖具体仓储，降低与 WordService 的耦合，取舍是上下文构造略显繁琐。
+ * 影响范围：
+ *  - WordService 将通过 PersistenceContext 提供具体操作；
+ *  - SearchResultService 与个性化逻辑通过回调方式被统一调度。
+ * 演进与TODO：
+ *  - 后续可引入指标埋点或重试策略，只需在对应 step 中扩展实现；
+ *  - 若持久化流程出现新的分支，可在策略接口中扩展版本内容生成逻辑。
+ */
+@Slf4j
+@Component
+public class WordPersistenceCoordinator {
+
+    /**
+     * 意图：统一执行“保存词条→同步搜索记录→持久化版本→写回个性化”的骨架流程。\
+     * 输入：
+     *  - context：封装流程依赖与外部状态；\
+     *  - strategy：决定版本内容生成方式。\
+     * 输出：持久化后的实体、响应与版本。
+     * 流程：
+     *  1) 使用上下文提供的保存实现写入词条；\
+     *  2) 在需要记录历史时同步搜索记录并生成版本内容；\
+     *  3) 调用版本持久化实现并回写 versionId；\
+     *  4) 执行个性化写回返回最终响应。
+     * 错误处理：步骤内部由上下文实现负责，协调器仅确保流程按序执行。\
+     * 复杂度：O(1)，每个步骤均为常量时间外部调用。
+     */
+    public PersistenceOutcome persist(PersistenceContext context, WordVersionContentStrategy strategy) {
+        Objects.requireNonNull(context, "persistence context must not be null");
+        Objects.requireNonNull(strategy, "version content strategy must not be null");
+
+        Word savedWord = context.saveWordStep.save(
+            context.requestedTerm,
+            context.response,
+            context.language,
+            context.flavor
+        );
+
+        SearchResultVersion version = null;
+        if (context.captureHistory) {
+            context.recordSynchronizationStep.synchronize(context.userId, context.recordId, savedWord.getTerm());
+            String content = strategy.resolveContent(context, savedWord);
+            if (content != null) {
+                version = context.versionPersistStep.persist(
+                    context.recordId,
+                    context.userId,
+                    context.model,
+                    content,
+                    savedWord,
+                    context.flavor
+                );
+                if (version != null && version.getId() != null) {
+                    context.response.setVersionId(version.getId());
+                }
+            }
+        }
+
+        WordResponse personalized = context.personalizationStep.apply(
+            context.userId,
+            context.response,
+            context.personalizationContext
+        );
+        return new PersistenceOutcome(savedWord, personalized, version);
+    }
+
+    public record PersistenceOutcome(Word word, WordResponse response, SearchResultVersion version) {}
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private Long userId;
+        private String requestedTerm;
+        private Language language;
+        private DictionaryFlavor flavor;
+        private String model;
+        private boolean captureHistory;
+        private Long recordId;
+        private WordResponse response;
+        private WordPersonalizationContext personalizationContext;
+        private SaveWordStep saveWordStep;
+        private RecordSynchronizationStep recordSynchronizationStep;
+        private VersionPersistStep versionPersistStep;
+        private PersonalizationStep personalizationStep;
+        private WordSerializationStep wordSerializationStep;
+        private String sanitizedMarkdown;
+
+        private Builder() {}
+
+        public Builder userId(Long userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder requestedTerm(String requestedTerm) {
+            this.requestedTerm = requestedTerm;
+            return this;
+        }
+
+        public Builder language(Language language) {
+            this.language = language;
+            return this;
+        }
+
+        public Builder flavor(DictionaryFlavor flavor) {
+            this.flavor = flavor;
+            return this;
+        }
+
+        public Builder model(String model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder captureHistory(boolean captureHistory) {
+            this.captureHistory = captureHistory;
+            return this;
+        }
+
+        public Builder recordId(Long recordId) {
+            this.recordId = recordId;
+            return this;
+        }
+
+        public Builder response(WordResponse response) {
+            this.response = response;
+            return this;
+        }
+
+        public Builder personalizationContext(WordPersonalizationContext personalizationContext) {
+            this.personalizationContext = personalizationContext;
+            return this;
+        }
+
+        public Builder saveWordStep(SaveWordStep saveWordStep) {
+            this.saveWordStep = saveWordStep;
+            return this;
+        }
+
+        public Builder recordSynchronizationStep(RecordSynchronizationStep recordSynchronizationStep) {
+            this.recordSynchronizationStep = recordSynchronizationStep;
+            return this;
+        }
+
+        public Builder versionPersistStep(VersionPersistStep versionPersistStep) {
+            this.versionPersistStep = versionPersistStep;
+            return this;
+        }
+
+        public Builder personalizationStep(PersonalizationStep personalizationStep) {
+            this.personalizationStep = personalizationStep;
+            return this;
+        }
+
+        public Builder wordSerializationStep(WordSerializationStep wordSerializationStep) {
+            this.wordSerializationStep = wordSerializationStep;
+            return this;
+        }
+
+        public Builder sanitizedMarkdown(String sanitizedMarkdown) {
+            this.sanitizedMarkdown = sanitizedMarkdown;
+            return this;
+        }
+
+        public PersistenceContext build() {
+            return new PersistenceContext(this);
+        }
+    }
+
+    public static final class PersistenceContext {
+
+        private final Long userId;
+        private final String requestedTerm;
+        private final Language language;
+        private final DictionaryFlavor flavor;
+        private final String model;
+        private final boolean captureHistory;
+        private final Long recordId;
+        private final WordResponse response;
+        private final WordPersonalizationContext personalizationContext;
+        private final SaveWordStep saveWordStep;
+        private final RecordSynchronizationStep recordSynchronizationStep;
+        private final VersionPersistStep versionPersistStep;
+        private final PersonalizationStep personalizationStep;
+        private final WordSerializationStep wordSerializationStep;
+        private final String sanitizedMarkdown;
+
+        private PersistenceContext(Builder builder) {
+            this.userId = Objects.requireNonNull(builder.userId, "userId must not be null");
+            this.requestedTerm = Objects.requireNonNull(builder.requestedTerm, "requestedTerm must not be null");
+            this.language = Objects.requireNonNull(builder.language, "language must not be null");
+            this.flavor = Objects.requireNonNull(builder.flavor, "flavor must not be null");
+            this.model = Objects.requireNonNull(builder.model, "model must not be null");
+            this.captureHistory = builder.captureHistory;
+            this.recordId = builder.recordId;
+            this.response = Objects.requireNonNull(builder.response, "response must not be null");
+            this.personalizationContext = builder.personalizationContext;
+            this.saveWordStep = Objects.requireNonNull(builder.saveWordStep, "saveWordStep must not be null");
+            this.recordSynchronizationStep = Objects.requireNonNull(
+                builder.recordSynchronizationStep,
+                "recordSynchronizationStep must not be null"
+            );
+            this.versionPersistStep = Objects.requireNonNull(
+                builder.versionPersistStep,
+                "versionPersistStep must not be null"
+            );
+            this.personalizationStep = Objects.requireNonNull(
+                builder.personalizationStep,
+                "personalizationStep must not be null"
+            );
+            this.wordSerializationStep = Objects.requireNonNull(
+                builder.wordSerializationStep,
+                "wordSerializationStep must not be null"
+            );
+            this.sanitizedMarkdown = builder.sanitizedMarkdown;
+        }
+
+        public Long userId() {
+            return userId;
+        }
+
+        public String requestedTerm() {
+            return requestedTerm;
+        }
+
+        public Language language() {
+            return language;
+        }
+
+        public DictionaryFlavor flavor() {
+            return flavor;
+        }
+
+        public String model() {
+            return model;
+        }
+
+        public boolean captureHistory() {
+            return captureHistory;
+        }
+
+        public Long recordId() {
+            return recordId;
+        }
+
+        public WordResponse response() {
+            return response;
+        }
+
+        public WordPersonalizationContext personalizationContext() {
+            return personalizationContext;
+        }
+
+        public String sanitizedMarkdown() {
+            return sanitizedMarkdown;
+        }
+
+        public String serializeWord(Word word) throws JsonProcessingException {
+            return wordSerializationStep.serialize(word);
+        }
+    }
+
+    @FunctionalInterface
+    public interface SaveWordStep {
+        Word save(String requestedTerm, WordResponse response, Language language, DictionaryFlavor flavor);
+    }
+
+    @FunctionalInterface
+    public interface RecordSynchronizationStep {
+        void synchronize(Long userId, Long recordId, String canonicalTerm);
+    }
+
+    @FunctionalInterface
+    public interface VersionPersistStep {
+        SearchResultVersion persist(
+            Long recordId,
+            Long userId,
+            String model,
+            String content,
+            Word word,
+            DictionaryFlavor flavor
+        );
+    }
+
+    @FunctionalInterface
+    public interface PersonalizationStep {
+        WordResponse apply(Long userId, WordResponse response, WordPersonalizationContext context);
+    }
+
+    @FunctionalInterface
+    public interface WordSerializationStep {
+        String serialize(Word word) throws JsonProcessingException;
+    }
+}

--- a/backend/src/main/java/com/glancy/backend/service/support/WordVersionContentStrategy.java
+++ b/backend/src/main/java/com/glancy/backend/service/support/WordVersionContentStrategy.java
@@ -1,0 +1,29 @@
+package com.glancy.backend.service.support;
+
+import com.glancy.backend.entity.Word;
+
+/**
+ * 背景：
+ *  - 历史版本内容的生成方式在同步与流式路径存在差异，直接内联在服务层导致可读性下降。\
+ * 目的：
+ *  - 通过策略模式封装版本内容生成逻辑，解耦流程骨架与内容来源。\
+ * 关键决策与取舍：
+ *  - 选用策略模式以便未来新增版本来源（如多模态摘要）时无需修改模板流程；\
+ *  - 放弃简单的条件判断，代价是上下文需要暴露额外状态（如流式净化文本）。\
+ * 影响范围：
+ *  - WordPersistenceCoordinator 根据实现选择不同内容策略；\
+ *  - 新增策略只需实现该接口并在调用端注入即可生效。
+ * 演进与TODO：
+ *  - 可进一步引入注册表以支持按语言或模型动态选择策略；\
+ *  - 若版本内容需要结构化存储，可调整返回类型为值对象。
+ */
+public interface WordVersionContentStrategy {
+    /**
+     * 根据持久化上下文与保存后的词条生成历史版本内容。
+     *
+     * @param context 当前持久化上下文
+     * @param savedWord 已落库的词条实体
+     * @return 版本内容字符串，返回 {@code null} 表示跳过版本持久化
+     */
+    String resolveContent(WordPersistenceCoordinator.PersistenceContext context, Word savedWord);
+}

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamPersistenceTest.java
@@ -22,6 +22,7 @@ import com.glancy.backend.repository.WordRepository;
 import com.glancy.backend.service.personalization.WordPersonalizationService;
 import com.glancy.backend.service.support.DictionaryTermNormalizer;
 import com.glancy.backend.service.support.SearchContentDictionaryTermNormalizer;
+import com.glancy.backend.service.support.WordPersistenceCoordinator;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -62,6 +63,7 @@ class WordServiceStreamPersistenceTest {
     private PersonalizedWordExplanation personalization;
     private ObjectMapper objectMapper;
     private DictionaryTermNormalizer termNormalizer;
+    private WordPersistenceCoordinator wordPersistenceCoordinator;
 
     @BeforeEach
     void setUp() {
@@ -82,6 +84,7 @@ class WordServiceStreamPersistenceTest {
         );
         objectMapper = Jackson2ObjectMapperBuilder.json().build();
         termNormalizer = new SearchContentDictionaryTermNormalizer(new SearchContentManagerImpl());
+        wordPersistenceCoordinator = new WordPersistenceCoordinator();
         when(searchRecordService.synchronizeRecordTerm(anyLong(), anyLong(), any())).thenReturn(null);
         wordService = new WordService(
             wordSearcher,
@@ -91,7 +94,8 @@ class WordServiceStreamPersistenceTest {
             parser,
             wordPersonalizationService,
             termNormalizer,
-            objectMapper
+            objectMapper,
+            wordPersistenceCoordinator
         );
     }
 

--- a/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/WordServiceStreamingErrorTest.java
@@ -18,6 +18,7 @@ import com.glancy.backend.repository.WordRepository;
 import com.glancy.backend.service.personalization.WordPersonalizationService;
 import com.glancy.backend.service.support.DictionaryTermNormalizer;
 import com.glancy.backend.service.support.SearchContentDictionaryTermNormalizer;
+import com.glancy.backend.service.support.WordPersistenceCoordinator;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,7 @@ class WordServiceStreamingErrorTest {
     private WordPersonalizationContext personalizationContext;
     private ObjectMapper objectMapper;
     private DictionaryTermNormalizer termNormalizer;
+    private WordPersistenceCoordinator wordPersistenceCoordinator;
 
     @BeforeEach
     void setUp() {
@@ -75,6 +77,7 @@ class WordServiceStreamingErrorTest {
         );
         objectMapper = Jackson2ObjectMapperBuilder.json().build();
         termNormalizer = new SearchContentDictionaryTermNormalizer(new SearchContentManagerImpl());
+        wordPersistenceCoordinator = new WordPersistenceCoordinator();
         wordService = new WordService(
             wordSearcher,
             wordRepository,
@@ -83,7 +86,8 @@ class WordServiceStreamingErrorTest {
             parser,
             wordPersonalizationService,
             termNormalizer,
-            objectMapper
+            objectMapper,
+            wordPersistenceCoordinator
         );
     }
 

--- a/backend/src/test/java/com/glancy/backend/service/support/WordPersistenceCoordinatorTest.java
+++ b/backend/src/test/java/com/glancy/backend/service/support/WordPersistenceCoordinatorTest.java
@@ -1,0 +1,212 @@
+package com.glancy.backend.service.support;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.glancy.backend.dto.PersonalizedWordExplanation;
+import com.glancy.backend.dto.WordPersonalizationContext;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.DictionaryFlavor;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.SearchResultVersion;
+import com.glancy.backend.entity.Word;
+import com.glancy.backend.util.SensitiveDataUtil;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 针对 WordPersistenceCoordinator 的流程编排验证。
+ */
+class WordPersistenceCoordinatorTest {
+
+    private final WordPersistenceCoordinator coordinator = new WordPersistenceCoordinator();
+
+    /**
+     * 测试目标：验证同步流程复用响应 markdown 并写回个性化。\
+     * 前置条件：\
+     *  - 上下文包含有效的搜索记录 ID 与 markdown；\
+     *  - 所有协作步骤均成功执行。\
+     * 步骤：\
+     *  1) 构建上下文并执行 persist；\
+     *  2) 记录同步与版本持久化返回模拟对象。\
+     * 断言：\
+     *  - 记录同步被触发；\
+     *  - 版本内容复用了响应 markdown；\
+     *  - versionId 被写回响应且个性化结果不为空。\
+     * 边界/异常：\
+     *  - 若任一步骤未执行，将导致断言失败。\
+     */
+    @Test
+    void persistSyncFlow_ReuseResponseMarkdownAndApplyPersonalization() {
+        WordResponse response = new WordResponse();
+        response.setMarkdown("### definition");
+        AtomicBoolean recordSynced = new AtomicBoolean(false);
+        AtomicReference<String> versionContent = new AtomicReference<>();
+
+        WordPersistenceCoordinator.PersistenceContext context = WordPersistenceCoordinator.builder()
+            .userId(1L)
+            .requestedTerm("raw")
+            .language(Language.ENGLISH)
+            .flavor(DictionaryFlavor.BILINGUAL)
+            .model("model")
+            .recordId(2L)
+            .captureHistory(true)
+            .response(response)
+            .personalizationContext(new WordPersonalizationContext(null, false, null, null, null, List.of(), List.of()))
+            .saveWordStep((requested, resp, language, flavor) -> {
+                Word word = new Word();
+                word.setTerm("canonical");
+                word.setLanguage(language);
+                word.setFlavor(flavor);
+                word.setMarkdown(resp.getMarkdown());
+                return word;
+            })
+            .recordSynchronizationStep((userId, recordId, canonicalTerm) -> {
+                assertEquals(1L, userId, "用户 ID 应按上下文透传");
+                assertEquals(2L, recordId, "记录 ID 应保持一致");
+                assertEquals("canonical", canonicalTerm, "规范词条需来自保存结果");
+                recordSynced.set(true);
+            })
+            .versionPersistStep((recordId, userId, model, content, word, flavor) -> {
+                versionContent.set(content);
+                SearchResultVersion version = new SearchResultVersion();
+                version.setId(99L);
+                return version;
+            })
+            .personalizationStep((userId, resp, context1) -> {
+                resp.setPersonalization(
+                    new PersonalizedWordExplanation("persona", "takeaway", "context", List.of(), List.of())
+                );
+                return resp;
+            })
+            .wordSerializationStep(word -> "serialized")
+            .sanitizedMarkdown(null)
+            .build();
+
+        WordVersionContentStrategy strategy = new ResponseMarkdownOrSerializedWordStrategy();
+        WordPersistenceCoordinator.PersistenceOutcome outcome = coordinator.persist(context, strategy);
+
+        assertTrue(recordSynced.get(), "应同步搜索记录");
+        assertEquals("### definition", versionContent.get(), "版本内容应复用响应 markdown");
+        assertEquals(99L, outcome.response().getVersionId(), "versionId 应写回响应");
+        assertNotNull(outcome.response().getPersonalization(), "应写入个性化结果");
+    }
+
+    /**
+     * 测试目标：验证流式策略使用净化 markdown。\
+     * 前置条件：\
+     *  - 上下文提供净化后的 markdown；\
+     *  - 保存后的词条 markdown 与净化文本不同以便区分。\
+     * 步骤：\
+     *  1) 执行 persist 并捕获版本内容；\
+     *  2) 通过策略选择流式净化文本。\
+     * 断言：\
+     *  - 版本内容等于净化 markdown；\
+     *  - 个性化步骤仍被执行。\
+     * 边界/异常：\
+     *  - 若净化文本缺失则会触发策略回退，此处不覆盖。\
+     */
+    @Test
+    void persistStreamingFlow_UsesSanitizedMarkdown() {
+        WordResponse response = new WordResponse();
+        AtomicReference<String> versionContent = new AtomicReference<>();
+        AtomicBoolean personalized = new AtomicBoolean(false);
+
+        WordPersistenceCoordinator.PersistenceContext context = WordPersistenceCoordinator.builder()
+            .userId(5L)
+            .requestedTerm("term")
+            .language(Language.ENGLISH)
+            .flavor(DictionaryFlavor.BILINGUAL)
+            .model("streaming-model")
+            .recordId(7L)
+            .captureHistory(true)
+            .response(response)
+            .personalizationContext(null)
+            .saveWordStep((requested, resp, language, flavor) -> {
+                Word word = new Word();
+                word.setTerm("term");
+                word.setMarkdown("persisted-markdown");
+                return word;
+            })
+            .recordSynchronizationStep((userId, recordId, canonicalTerm) -> {})
+            .versionPersistStep((recordId, userId, model, content, word, flavor) -> {
+                versionContent.set(content);
+                SearchResultVersion version = new SearchResultVersion();
+                version.setId(11L);
+                return version;
+            })
+            .personalizationStep((userId, resp, context1) -> {
+                personalized.set(true);
+                return resp;
+            })
+            .wordSerializationStep(word -> "unused")
+            .sanitizedMarkdown("## sanitized output")
+            .build();
+
+        WordVersionContentStrategy strategy = new SanitizedStreamingMarkdownStrategy();
+        WordPersistenceCoordinator.PersistenceOutcome outcome = coordinator.persist(context, strategy);
+
+        assertEquals("## sanitized output", versionContent.get(), "版本内容应取净化 markdown");
+        assertTrue(personalized.get(), "应执行个性化回写");
+        assertEquals(11L, outcome.response().getVersionId(), "应写入版本 ID");
+    }
+
+    /**
+     * 测试目标：验证序列化失败时回退为 markdown 预览。\
+     * 前置条件：\
+     *  - 响应未提供 markdown；\
+     *  - 序列化函数抛出异常。\
+     * 步骤：\
+     *  1) 构建上下文并触发持久化；\
+     *  2) 捕获版本内容。\
+     * 断言：\
+     *  - 版本内容等于词条 markdown 的预览值；\
+     *  - versionId 同样被写回响应。\
+     * 边界/异常：\
+     *  - 若预览值为空说明策略回退失败。\
+     */
+    @Test
+    void persistSyncFlow_FallbacksToPreviewWhenSerializationFails() {
+        WordResponse response = new WordResponse();
+        AtomicReference<String> versionContent = new AtomicReference<>();
+
+        WordPersistenceCoordinator.PersistenceContext context = WordPersistenceCoordinator.builder()
+            .userId(3L)
+            .requestedTerm("input")
+            .language(Language.ENGLISH)
+            .flavor(DictionaryFlavor.BILINGUAL)
+            .model("model")
+            .recordId(4L)
+            .captureHistory(true)
+            .response(response)
+            .personalizationContext(null)
+            .saveWordStep((requested, resp, language, flavor) -> {
+                Word word = new Word();
+                word.setTerm("fallback");
+                word.setMarkdown("markdown-content-with-length");
+                return word;
+            })
+            .recordSynchronizationStep((userId, recordId, canonicalTerm) -> {})
+            .versionPersistStep((recordId, userId, model, content, word, flavor) -> {
+                versionContent.set(content);
+                SearchResultVersion version = new SearchResultVersion();
+                version.setId(21L);
+                return version;
+            })
+            .personalizationStep((userId, resp, context1) -> resp)
+            .wordSerializationStep(word -> {
+                throw new JsonProcessingException("boom") {};
+            })
+            .sanitizedMarkdown(null)
+            .build();
+
+        WordVersionContentStrategy strategy = new ResponseMarkdownOrSerializedWordStrategy();
+        WordPersistenceCoordinator.PersistenceOutcome outcome = coordinator.persist(context, strategy);
+
+        String expectedPreview = SensitiveDataUtil.previewText("markdown-content-with-length");
+        assertEquals(expectedPreview, versionContent.get(), "序列化失败时应回退到 markdown 预览");
+        assertEquals(21L, outcome.response().getVersionId(), "versionId 仍需写回响应");
+    }
+}


### PR DESCRIPTION
## Summary
- add a WordPersistenceCoordinator template flow with markdown strategies to unify synchronous and streaming word persistence
- refactor WordService to delegate persistence and personalization to the coordinator and remove duplicate branches
- add unit coverage for coordinator plus adjust existing stream tests to use the new dependency

## Testing
- mvn test -Dtest=WordPersistenceCoordinatorTest
- mvn spotless:apply

------
https://chatgpt.com/codex/tasks/task_e_68e55ef358548332a3a86a301f2a4087