### PR TITLE
fix: keep collapsible summaries with custom components

### DIFF
--- a/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
+++ b/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
@@ -36,15 +36,23 @@ function MarkdownRenderer({
   children,
   remarkPlugins: additionalRemarkPlugins,
   rehypePlugins: additionalRehypePlugins,
+  components: additionalComponents,
   ...props
 }) {
   const injectBreaks = useBreakableContent();
-  const components = useMemo(
+  const baseComponents = useMemo(
     () =>
       buildMarkdownComponents({
         injectBreaks,
       }),
     [injectBreaks],
+  );
+  const components = useMemo(
+    () => ({
+      ...baseComponents,
+      ...(additionalComponents ?? {}),
+    }),
+    [additionalComponents, baseComponents],
   );
 
   const remarkPlugins = useMemo(
@@ -301,6 +309,9 @@ MarkdownRenderer.propTypes = {
   remarkPlugins: PropTypes.arrayOf(PropTypes.func),
   rehypePlugins: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
+  ),
+  components: PropTypes.objectOf(
+    PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   ),
 };
 

--- a/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
+++ b/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
@@ -58,12 +58,14 @@
   /*
    * 背景：折叠标题在包含长文本时会收缩宽度，导致内容溢出。
    * 目的：让标题文本填满剩余空间，同时保持视觉对齐的稳定性。
-   * 取舍：放弃两端对齐，改为统一左对齐，以匹配 collapsible-summary 的排版需求。
+   * 取舍：放弃两端对齐，改为统一左对齐，以匹配 collapsible-summary 的排版需求；
+   *       同时保持加粗以突出层级标题的视觉锚点。
    */
   display: inline-flex;
   flex-direction: column;
   gap: 4px;
   font-size: 1rem;
+  font-weight: var(--font-bold);
   letter-spacing: 0.02em;
   flex: 1 1 auto;
   min-width: 0;
@@ -146,4 +148,5 @@
   text-align: left;
   text-align-last: left;
   text-justify: auto;
+  font-weight: var(--font-bold);
 }

--- a/website/src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx
+++ b/website/src/components/ui/MarkdownRenderer/__tests__/MarkdownRenderer.test.jsx
@@ -138,3 +138,39 @@ test("skips break injection inside code blocks", () => {
   const code = screen.getByText("const sightseeing = true;");
   expect(code.textContent).not.toContain("\u200B");
 });
+
+/**
+ * 测试目标：传入自定义组件时仍保留折叠摘要渲染器。
+ * 前置条件：覆盖段落标签并渲染包含二级标题的 Markdown。
+ * 步骤：
+ *  1) 渲染 MarkdownRenderer 并通过 components 覆写段落。
+ *  2) 捕获折叠按钮与自定义段落节点。
+ * 断言：
+ *  - DOM 中不存在原生 <collapsible-summary> 标签。
+ *  - 折叠按钮可用且 aria-expanded 属性默认为 true。
+ * 边界/异常：
+ *  - 若折叠结构失效，应能立即定位此测试失败。
+ */
+test("merges custom components with collapsible summaries", () => {
+  const markdown = "## Custom Heading\n\nParagraph";
+  const CustomParagraph = ({ children, ...paragraphProps }) => (
+    <p data-testid="custom-paragraph" {...paragraphProps}>
+      {children}
+    </p>
+  );
+
+  render(
+    <MarkdownRenderer
+      components={{
+        p: CustomParagraph,
+      }}
+    >
+      {markdown}
+    </MarkdownRenderer>,
+  );
+
+  const toggle = getButtonByLabel("Custom Heading");
+  expect(toggle).toHaveAttribute("aria-expanded", "true");
+  expect(document.querySelector("collapsible-summary")).toBeNull();
+  expect(screen.getByTestId("custom-paragraph")).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- merge MarkdownRenderer defaults with incoming component overrides so collapsible summaries stay left-aligned
- add prop validation and a regression test ensuring custom components coexist with the collapsible renderer

## Testing
- npm run test -- MarkdownRenderer

------
https://chatgpt.com/codex/tasks/task_e_68e5622aa1b88332ade256cd34546962