### PR TITLE
Fix example segmentation handling for headings

### DIFF
--- a/website/src/utils/markdown.js
+++ b/website/src/utils/markdown.js
@@ -1199,6 +1199,111 @@ function normalizeExampleContent(value) {
 }
 
 /**
+ * 意图：在例句正文与下一行之间解析潜在的 `#token#` 分词标记。
+ * 输入：
+ *  - lines：Markdown 行数组。
+ *  - startIndex：疑似分词标记行的索引。
+ * 输出：若解析成功返回 `{ marker, trailingText, consumed }`，否则返回 null。
+ * 流程：
+ *  1) 读取首行并归一化 `#` 前后的空格。
+ *  2) 若首行已形成完整 `#token#`，直接返回；否则向后寻找补齐的闭合 `#`。
+ *  3) 当后续行以单个 `#` 开头时，将其视为闭合标记，并把剩余正文作为 `trailingText`。
+ * 错误处理：遇到多级标题（`##`）或非 `#` 开头的行即放弃解析，避免误吞标题。
+ * 复杂度：O(p)，p 为尝试拼接分词标记所需行数。
+ */
+function parseSegmentationMarker(lines, startIndex) {
+  if (startIndex >= lines.length) {
+    return null;
+  }
+  const firstLine = lines[startIndex];
+  const trimmed = firstLine.trimStart();
+  if (!trimmed.startsWith("#")) {
+    return null;
+  }
+  const normalized = trimmed.replace(/^#\s+/, "#").trimEnd();
+  if (!/^#[^#\s]+/.test(normalized)) {
+    return null;
+  }
+  let consumed = 1;
+  if (/^#[^#\s]+#$/.test(normalized)) {
+    return { marker: normalized, trailingText: "", consumed };
+  }
+  if (!/^#[^#\s]+$/.test(normalized)) {
+    return null;
+  }
+  let gapConsumed = 0;
+  for (let idx = startIndex + 1; idx < lines.length; idx += 1) {
+    const candidate = lines[idx];
+    const candidateTrimmed = candidate.trimStart();
+    if (candidateTrimmed === "") {
+      gapConsumed += 1;
+      continue;
+    }
+    if (!candidateTrimmed.startsWith("#")) {
+      return null;
+    }
+    if (/^##/.test(candidateTrimmed)) {
+      return null;
+    }
+    const trailingText = candidateTrimmed.replace(/^#\s*/, "");
+    return {
+      marker: `${normalized}#`,
+      trailingText,
+      consumed: consumed + gapConsumed + 1,
+    };
+  }
+  return null;
+}
+
+/**
+ * 意图：收集例句行后续的分词标记附件，并保留需要独立渲染的标题行。
+ * 输入：
+ *  - lines：Markdown 行数组。
+ *  - startIndex：例句下一行的索引。
+ * 输出：结构体 `{ markerAttachments, preservedHeadings, consumed }`。
+ * 流程：
+ *  1) 跳过空行，逐行检查是否为分词标记或标题。
+ *  2) 对 `#` 开头的行调用 `parseSegmentationMarker`，仅当解析成功时并入附件。
+ *  3) 遇到无法解析的 `#` 行则认定为标题，终止扫描并记录待保留的标题行。
+ * 错误处理：默认保守策略，未识别的行会被留给后续流程。
+ * 复杂度：O(q)，q 为附件区段的行数。
+ */
+function collectExampleSegmentationAttachments(lines, startIndex) {
+  const markerAttachments = [];
+  const preservedHeadings = [];
+  let consumed = 0;
+  let cursor = startIndex;
+  while (cursor < lines.length) {
+    const current = lines[cursor];
+    const trimmed = current.trimStart();
+    if (trimmed === "") {
+      consumed += 1;
+      cursor += 1;
+      continue;
+    }
+    if (!/^(#|\{\{|\[\[)/.test(trimmed)) {
+      break;
+    }
+    if (trimmed.startsWith("#")) {
+      const parsed = parseSegmentationMarker(lines, cursor);
+      if (!parsed) {
+        preservedHeadings.push(current);
+        consumed += 1;
+        break;
+      }
+      markerAttachments.push(parsed);
+      consumed += parsed.consumed;
+      cursor += parsed.consumed;
+      continue;
+    }
+    markerAttachments.push({ marker: trimmed, trailingText: "" });
+    consumed += 1;
+    cursor += 1;
+  }
+  return { markerAttachments, preservedHeadings, consumed };
+}
+
+/**
  * 意图：在字典 Markdown 中定位例句行并补齐分词空格。
  * 输入：格式化前的 Markdown 字符串。
  * 输出：例句段落完成分词空格后的 Markdown。
@@ -1228,35 +1333,20 @@ function applyExampleSegmentationSpacing(text) {
       normalized.push(line);
       continue;
     }
-    let combined = rest;
-    let consumed = 0;
-    const attachments = [];
-    for (let j = i + 1; j < lines.length; j += 1) {
-      const candidate = lines[j];
-      const trimmed = candidate.trimStart();
-      if (trimmed === "") {
-        consumed += 1;
-        continue;
-      }
-      if (!/^(#|\{\{|\[\[)/.test(trimmed)) {
-        break;
-      }
-      consumed += 1;
-      if (trimmed.startsWith("#")) {
-        attachments.push(trimmed.replace(/^#\s+/, "#"));
-      } else {
-        attachments.push(trimmed);
-      }
-    }
-    if (attachments.length > 0) {
-      combined = `${combined}${attachments.join("")}`;
-    }
+    const { markerAttachments, preservedHeadings, consumed } =
+      collectExampleSegmentationAttachments(lines, i + 1);
+    const combined = markerAttachments.reduce((acc, attachment) => {
+      return `${acc}${attachment.marker}${attachment.trailingText}`;
+    }, rest);
     const normalizedContent = normalizeExampleContent(combined);
     if (!normalizedContent) {
       normalized.push(prefix.trimEnd());
     } else {
       normalized.push(`${prefix}${normalizedContent}`);
     }
+    preservedHeadings.forEach((heading) => {
+      normalized.push(heading);
+    });
     i += consumed;
   }
   return normalized.join("\n");

--- a/website/src/utils/markdown.test.js
+++ b/website/src/utils/markdown.test.js
@@ -150,6 +150,43 @@ test("translation line keeps nested unordered list indentation", () => {
 });
 
 /**
+ * 测试目标：验证例句后紧跟的标题不会被误并入分词标记，仍保持独立换行。
+ * 前置条件：例句行之后立即出现 Markdown 标题行 `# 英文释义`。
+ * 步骤：
+ *  1) 构造包含例句与后续标题的 Markdown 字串。
+ *  2) 调用 polishDictionaryMarkdown 进行格式化处理。
+ * 断言：
+ *  - 标题仍为独立行；若断言失败，说明示例分词逻辑错误吞并了标题。
+ * 边界/异常：
+ *  - 覆盖例句旁的标题场景，防止未来回归再次破坏 heading 结构。
+ */
+test(
+  "polishDictionaryMarkdown preserves heading after example segmentation",
+  () => {
+    const source = ["- **例句**: Hello world", "# 英文释义"].join("\n");
+    const result = polishDictionaryMarkdown(source);
+    expect(result).toBe(["- **例句**: Hello world", "# 英文释义"].join("\n"));
+  },
+);
+
+/**
+ * 测试目标：确保 `#token#` 分词标记仍会并入例句正文，分词逻辑保持向后兼容。
+ * 前置条件：例句行之后紧跟分词标记行 `#token#`。
+ * 步骤：
+ *  1) 构造包含例句与分词标记的 Markdown 字串。
+ *  2) 调用 polishDictionaryMarkdown 获取格式化结果。
+ * 断言：
+ *  - 输出中的例句行末尾仍包含 `#token#`；若失败则表示新解析未保留分词标记。
+ * 边界/异常：
+ *  - 覆盖分词标记典型模式，防止正则调整造成回归。
+ */
+test("polishDictionaryMarkdown keeps hash segmentation markers", () => {
+  const source = ["- **例句**: 今天天气好", "#token#"].join("\n");
+  const result = polishDictionaryMarkdown(source);
+  expect(result).toBe("- **例句**: 今天天气好 #token#");
+});
+
+/**
  * 测试目标：验证串联的英译英标签会被拆行并恢复空格，提升词条可读性。
  * 前置条件：行内包含 `Examples:Example1:...`、`UsageInsight:...` 等紧贴字段。
  * 步骤：


### PR DESCRIPTION
## Summary
- parse example attachments to only merge valid segmentation markers and preserve nearby headings
- rebuild example lines from structured marker attachments before reintroducing retained headings
- add regression tests covering heading preservation and `#token#` marker joins

## Testing
- npm test -- --runTestsByPath src/utils/markdown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e574e67a2c83328d1dff60a227ba64