### PR TITLE
Align collapsible headers to the left

### DIFF
--- a/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
+++ b/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.jsx
@@ -140,18 +140,18 @@ function CollapsibleSummary({
       aria-controls={contentId}
       onClick={onToggle}
     >
+      <span className={styles.chevron} aria-hidden="true">
+        <span
+          className={styles["chevron-icon"]}
+          data-open={isOpen ? "true" : "false"}
+        />
+      </span>
       <span
         className={styles["summary-title"]}
         role="heading"
         aria-level={depth}
       >
         {renderedChildren}
-      </span>
-      <span className={styles.chevron} aria-hidden="true">
-        <span
-          className={styles["chevron-icon"]}
-          data-open={isOpen ? "true" : "false"}
-        />
       </span>
     </button>
   );

--- a/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
+++ b/website/src/components/ui/MarkdownRenderer/MarkdownRenderer.module.css
@@ -21,7 +21,12 @@
 .summary {
   width: 100%;
   display: flex;
-  justify-content: space-between;
+  /*
+   * 背景：按钮与标题左右分散排列，导致用户目光在阅读开头时需要额外扫到最右侧确认折叠状态。
+   * 目的：将指示图标与文字统一左对齐，让展开控制顺着阅读方向出现，降低眼动负担。
+   * 取舍：舍弃 space-between 布局，改由 gap 控制间距，保证整行仍为单一点击热区且视觉节奏一致。
+   */
+  justify-content: flex-start;
   align-items: center;
   gap: 12px;
   border: none;


### PR DESCRIPTION
## Summary
- move the collapsible section chevron before the heading text so the control follows the reading order
- left-align the summary layout to keep the button and label aligned per the latest design guidance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e68f7a3b748332b52d0490a0be3e76